### PR TITLE
Restore AC3 RF support in tbc_source

### DIFF
--- a/orc-tests/core/unit/stages/tbc_source/tbc_source_stage_test.cpp
+++ b/orc-tests/core/unit/stages/tbc_source/tbc_source_stage_test.cpp
@@ -89,15 +89,12 @@ class MockTBCSourceStageDeps : public orc::ITBCSourceStageDeps {
                size_t efm_byte_count),
               (const, override));
 
-  MOCK_METHOD(bool, has_ac3_files,
-              (const std::string& ac3_bin_path,
-               const std::string& ac3_meta_path),
+  MOCK_METHOD(bool, has_ac3_file, (const std::string& ac3_bin_path),
               (const, override));
 
-  MOCK_METHOD(std::optional<std::vector<uint8_t>>, read_ac3_for_frame,
-              (const std::string& ac3_bin_path,
-               const std::string& ac3_meta_path, int32_t field_seq_no_a,
-               int32_t field_seq_no_b),
+  MOCK_METHOD(std::vector<uint8_t>, read_ac3_bytes_at,
+              (const std::string& ac3_bin_path, size_t ac3_byte_offset,
+               size_t ac3_byte_count),
               (const, override));
 };
 
@@ -310,7 +307,7 @@ TEST(TBCSourceStageTest, Execute_ThrowsUserDataErrorWhenMetadataFails) {
       });
   EXPECT_CALL(*deps, has_audio_file(_)).WillRepeatedly(Return(false));
   EXPECT_CALL(*deps, has_efm_file(_)).WillRepeatedly(Return(false));
-  EXPECT_CALL(*deps, has_ac3_files(_, _)).WillRepeatedly(Return(false));
+  EXPECT_CALL(*deps, has_ac3_file(_)).WillRepeatedly(Return(false));
 
   EXPECT_THROW(
       stage.execute({}, {{"input_path", std::string("/tmp/test.tbc")}}, ctx),
@@ -337,7 +334,7 @@ TEST(TBCSourceStageTest,
       });
   ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   const auto outputs =
       stage.execute({}, {{"input_path", std::string("/tmp/test.tbc")}}, ctx);
@@ -362,7 +359,7 @@ TEST(TBCSourceStageTest, Execute_DisplayNameSetToPALTBCCompositeAfterLoad) {
       });
   ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   stage.execute({}, {{"input_path", std::string("/tmp/test.tbc")}}, ctx);
 
@@ -392,7 +389,7 @@ TEST(TBCSourceStageTest, OutputIsVFR_FrameCountIsFieldCountDividedByTwo) {
       });
   ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   const auto outputs =
       stage.execute({}, {{"input_path", std::string("/tmp/test.tbc")}}, ctx);
@@ -427,7 +424,7 @@ TEST(TBCSourceStageTest, OutputVFR_GetFrameLazilyAssemblesFromMockedDeps) {
       });
   ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   // Expect read_field_samples for TBC fields 0 and 1 (frame 0).
   EXPECT_CALL(*deps, read_field_samples("/tmp/test.tbc", 0, _, kF1Samples, _))
@@ -550,7 +547,7 @@ TEST(TBCSourceStageTest, OutputVFR_ExposesEFM_WhenEfmFileAndMetadataCountsSet) {
       });
   ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(true));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   // Return a synthetic payload that encodes the requested (offset, count) so
   // the test can assert both the byte range and the concatenation.
@@ -611,7 +608,7 @@ TEST(TBCSourceStageTest, OutputVFR_NoEFM_WhenEfmFileButMetadataCountsAbsent) {
       });
   ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(true));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   const auto outputs =
       stage.execute({},
@@ -624,6 +621,111 @@ TEST(TBCSourceStageTest, OutputVFR_NoEFM_WhenEfmFileButMetadataCountsAbsent) {
       dynamic_cast<orc::VideoFrameRepresentation*>(outputs.front().get());
   ASSERT_NE(vfr, nullptr);
   EXPECT_FALSE(vfr->has_efm());
+}
+
+// A TBC source with a raw .ac3sym sidecar (no .meta index — that is CVBS-only)
+// must expose AC3 RF symbols.  Per-field symbol counts come from the TBC
+// metadata (ac3_symbols); the .ac3sym file stores one byte per symbol in field
+// order.  Mirrors the EFM tests above.
+TEST(TBCSourceStageTest, OutputVFR_ExposesAC3_WhenAc3FileAndMetadataCountsSet) {
+  auto deps = std::make_shared<NiceMock<MockTBCSourceStageDeps>>();
+  orc::TBCSourceStage stage(deps);
+  orc::ObservationContext ctx;
+
+  constexpr int32_t kNumFields = 4;  // two frames
+  // Per-field symbol counts: frame 0 = fields 0+1 = 10+5 = 15 bytes @ off 0;
+  //                          frame 1 = fields 2+3 = 8+3 = 11 bytes @ off 15.
+  const std::array<int32_t, 4> kCounts = {10, 5, 8, 3};
+
+  ON_CALL(*deps, validate_input_file(_, _)).WillByDefault(Return(true));
+  ON_CALL(*deps, load_video_params(_, _))
+      .WillByDefault([](const std::string&, std::string&) {
+        return std::optional<orc::TBCVideoParams>{
+            make_pal_video_params(kNumFields)};
+      });
+  ON_CALL(*deps, load_all_field_meta(_, _))
+      .WillByDefault([kCounts](const std::string&, std::string&) {
+        auto meta = make_pal_field_meta(kNumFields);
+        for (size_t i = 0; i < meta.size(); ++i) {
+          meta[i].ac3rf_symbol_count = kCounts[i];
+        }
+        return meta;
+      });
+  ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(true));
+
+  // Return a synthetic payload that encodes the requested (offset, count) so
+  // the test can assert both the byte range and the concatenation.
+  ON_CALL(*deps, read_ac3_bytes_at(_, _, _))
+      .WillByDefault([](const std::string&, size_t offset, size_t count) {
+        std::vector<uint8_t> bytes(count);
+        for (size_t i = 0; i < count; ++i) {
+          bytes[i] = static_cast<uint8_t>((offset + i) & 0xFF);
+        }
+        return bytes;
+      });
+
+  const auto outputs =
+      stage.execute({},
+                    {{"input_path", std::string("/tmp/test.tbc")},
+                     {"ac3rf_path", std::string("/tmp/test.ac3sym")}},
+                    ctx);
+
+  ASSERT_EQ(outputs.size(), 1u);
+  const auto* vfr =
+      dynamic_cast<orc::VideoFrameRepresentation*>(outputs.front().get());
+  ASSERT_NE(vfr, nullptr);
+  EXPECT_TRUE(vfr->has_ac3_rf());
+
+  // Per-frame symbol counts must be reported.
+  EXPECT_EQ(vfr->get_ac3_symbol_count(0), 15u);
+  EXPECT_EQ(vfr->get_ac3_symbol_count(1), 11u);
+
+  // Frame 0: 15 bytes starting at offset 0.
+  const auto frame0 = vfr->get_ac3_symbols(0);
+  ASSERT_EQ(frame0.size(), 15u);
+  EXPECT_EQ(frame0.front(), 0u);
+  EXPECT_EQ(frame0.back(), 14u);
+
+  // Frame 1: 11 bytes starting at offset 15 (sum of frame 0's field counts).
+  const auto frame1 = vfr->get_ac3_symbols(1);
+  ASSERT_EQ(frame1.size(), 11u);
+  EXPECT_EQ(frame1.front(), 15u);
+  EXPECT_EQ(frame1.back(), 25u);
+}
+
+// When the .ac3sym file exists but the metadata carries no symbol counts, AC3
+// is unavailable — there is no way to index the raw stream without counts.
+TEST(TBCSourceStageTest, OutputVFR_NoAC3_WhenAc3FileButMetadataCountsAbsent) {
+  auto deps = std::make_shared<NiceMock<MockTBCSourceStageDeps>>();
+  orc::TBCSourceStage stage(deps);
+  orc::ObservationContext ctx;
+
+  ON_CALL(*deps, validate_input_file(_, _)).WillByDefault(Return(true));
+  ON_CALL(*deps, load_video_params(_, _))
+      .WillByDefault([](const std::string&, std::string&) {
+        return std::optional<orc::TBCVideoParams>{make_pal_video_params(2)};
+      });
+  ON_CALL(*deps, load_all_field_meta(_, _))
+      .WillByDefault([](const std::string&, std::string&) {
+        return make_pal_field_meta(2);  // no ac3rf_symbol_count set
+      });
+  ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(true));
+
+  const auto outputs =
+      stage.execute({},
+                    {{"input_path", std::string("/tmp/test.tbc")},
+                     {"ac3rf_path", std::string("/tmp/test.ac3sym")}},
+                    ctx);
+
+  ASSERT_EQ(outputs.size(), 1u);
+  const auto* vfr =
+      dynamic_cast<orc::VideoFrameRepresentation*>(outputs.front().get());
+  ASSERT_NE(vfr, nullptr);
+  EXPECT_FALSE(vfr->has_ac3_rf());
 }
 
 // ===========================================================================
@@ -662,7 +764,7 @@ orc::VideoFrameRepresentation* execute_audio_source(
   ON_CALL(*deps, get_audio_pair_count(_))
       .WillByDefault(Return(std::optional<uint64_t>{raw_pairs}));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   outputs_keepalive =
       stage.execute({},
@@ -725,7 +827,7 @@ TEST(TBCSourceAudioTest, NoPcmSidecar_ReportsZeroChannelPairs) {
       });
   ON_CALL(*deps, has_audio_file(_)).WillByDefault(Return(false));
   ON_CALL(*deps, has_efm_file(_)).WillByDefault(Return(false));
-  ON_CALL(*deps, has_ac3_files(_, _)).WillByDefault(Return(false));
+  ON_CALL(*deps, has_ac3_file(_)).WillByDefault(Return(false));
 
   const auto outputs =
       stage.execute({}, {{"input_path", std::string("/tmp/test.tbc")}}, ctx);

--- a/orc/plugins/stages/tbc_source/tbc_source_stage.cpp
+++ b/orc/plugins/stages/tbc_source/tbc_source_stage.cpp
@@ -152,9 +152,9 @@ class TBCDecodedFrameRepresentation final : public VideoFrameRepresentation,
       std::string tbc_path,  // composite .tbc (or Y .tbc for YC)
       std::string c_path,    // chroma .tbc for YC mode; empty for composite
       std::string pcm_path, std::string efm_bin_path, std::string ac3_bin_path,
-      std::string ac3_meta_path, bool has_audio, double pcm_sample_rate_hz,
-      bool has_efm, bool has_ac3, std::string audio_pair_name,
-      ArtifactID artifact_id, Provenance provenance)
+      bool has_audio, double pcm_sample_rate_hz, bool has_efm, bool has_ac3,
+      std::string audio_pair_name, ArtifactID artifact_id,
+      Provenance provenance)
       : Artifact(std::move(artifact_id), std::move(provenance)),
         video_params_(std::move(video_params)),
         source_params_(std::move(source_params)),
@@ -165,7 +165,6 @@ class TBCDecodedFrameRepresentation final : public VideoFrameRepresentation,
         pcm_path_(std::move(pcm_path)),
         efm_bin_path_(std::move(efm_bin_path)),
         ac3_bin_path_(std::move(ac3_bin_path)),
-        ac3_meta_path_(std::move(ac3_meta_path)),
         has_audio_(has_audio),
         pcm_sample_rate_hz_(pcm_sample_rate_hz),
         has_efm_(has_efm),
@@ -181,6 +180,7 @@ class TBCDecodedFrameRepresentation final : public VideoFrameRepresentation,
     // preview never needs audio (issue #209).
     compute_audio_total_raw_pairs();
     compute_efm_offsets();
+    compute_ac3_offsets();
   }
 
   // --------------------------------------------------------------------------
@@ -392,13 +392,21 @@ class TBCDecodedFrameRepresentation final : public VideoFrameRepresentation,
   // --------------------------------------------------------------------------
   bool has_ac3_rf() const override { return has_ac3_; }
 
+  uint32_t get_ac3_symbol_count(FrameID id) const override {
+    if (!has_ac3_) return 0;
+    const size_t idx = static_cast<size_t>(id);
+    if (idx >= ac3_frame_byte_counts_.size()) return 0;
+    return static_cast<uint32_t>(ac3_frame_byte_counts_[idx]);
+  }
+
   std::vector<uint8_t> get_ac3_symbols(FrameID id) const override {
     if (!has_ac3_ || !has_frame(id)) return {};
-    const int32_t fld1 = static_cast<int32_t>(id) * 2;
-    const int32_t fld2 = fld1 + 1;
-    auto result =
-        deps_->read_ac3_for_frame(ac3_bin_path_, ac3_meta_path_, fld1, fld2);
-    return result.value_or(std::vector<uint8_t>{});
+    const size_t idx = static_cast<size_t>(id);
+    if (idx >= ac3_frame_offsets_.size()) return {};
+    const size_t byte_offset = ac3_frame_offsets_[idx];
+    const size_t byte_count = ac3_frame_byte_counts_[idx];
+    if (byte_count == 0) return {};
+    return deps_->read_ac3_bytes_at(ac3_bin_path_, byte_offset, byte_count);
   }
 
   // --------------------------------------------------------------------------
@@ -807,6 +815,40 @@ class TBCDecodedFrameRepresentation final : public VideoFrameRepresentation,
     }
   }
 
+  // Pre-compute cumulative per-frame AC3 symbol offsets from the per-field
+  // symbol counts in the TBC metadata.  The raw .ac3sym sidecar stores one
+  // byte per QPSK symbol in field order, so a frame's byte offset is the
+  // running sum of all preceding fields' counts.  Mirrors
+  // compute_efm_offsets().
+  void compute_ac3_offsets() {
+    if (!has_ac3_) return;
+    const size_t fc = frame_count();
+    ac3_frame_offsets_.resize(fc, 0);
+    ac3_frame_byte_counts_.resize(fc, 0);
+
+    size_t cumulative = 0;
+    for (size_t frame_idx = 0; frame_idx < fc; ++frame_idx) {
+      const size_t fld1 = frame_idx * 2;
+      const size_t fld2 = fld1 + 1;
+
+      size_t bytes = 0;
+      if (fld1 < field_meta_.size()) {
+        if (const auto& cnt = field_meta_[fld1].ac3rf_symbol_count) {
+          bytes += static_cast<size_t>(*cnt);
+        }
+      }
+      if (fld2 < field_meta_.size()) {
+        if (const auto& cnt = field_meta_[fld2].ac3rf_symbol_count) {
+          bytes += static_cast<size_t>(*cnt);
+        }
+      }
+
+      ac3_frame_offsets_[frame_idx] = cumulative;
+      ac3_frame_byte_counts_[frame_idx] = bytes;
+      cumulative += bytes;
+    }
+  }
+
   TBCVideoParams video_params_;
   SourceParameters source_params_;
   std::vector<TBCFieldMeta> field_meta_;
@@ -816,7 +858,6 @@ class TBCDecodedFrameRepresentation final : public VideoFrameRepresentation,
   std::string pcm_path_;
   std::string efm_bin_path_;
   std::string ac3_bin_path_;
-  std::string ac3_meta_path_;
   bool has_audio_ = false;
   // Sidecar input rate for the ingest resample.  44100 Hz (the ld-decode
   // default) unless the metadata pcm_audio_parameters declare otherwise.
@@ -836,6 +877,10 @@ class TBCDecodedFrameRepresentation final : public VideoFrameRepresentation,
   // sidecar, one entry per frame.
   std::vector<size_t> efm_frame_offsets_;
   std::vector<size_t> efm_frame_byte_counts_;
+
+  // Pre-computed AC3 symbol layout (one byte per symbol, field order).
+  std::vector<size_t> ac3_frame_offsets_;
+  std::vector<size_t> ac3_frame_byte_counts_;
 
   // Per-frame converted audio blocks (48 kHz 24-bit-in-int32, cadence-sized).
   // Populated lazily by ensure_audio_converted() on first audio access.
@@ -1167,17 +1212,26 @@ class TBCSourceStageDeps final : public ITBCSourceStageDeps {
     return bytes;
   }
 
-  bool has_ac3_files(const std::string& ac3_bin_path,
-                     const std::string& ac3_meta_path) const override {
+  bool has_ac3_file(const std::string& ac3_bin_path) const override {
     namespace fs = std::filesystem;
     std::error_code ec;
-    return fs::exists(ac3_bin_path, ec) && fs::exists(ac3_meta_path, ec);
+    return fs::exists(ac3_bin_path, ec) &&
+           fs::is_regular_file(ac3_bin_path, ec);
   }
 
-  std::optional<std::vector<uint8_t>> read_ac3_for_frame(
-      const std::string& /*ac3_bin_path*/, const std::string& /*ac3_meta_path*/,
-      int32_t /*field_seq_no_a*/, int32_t /*field_seq_no_b*/) const override {
-    return std::nullopt;
+  std::vector<uint8_t> read_ac3_bytes_at(const std::string& ac3_bin_path,
+                                         size_t ac3_byte_offset,
+                                         size_t ac3_byte_count) const override {
+    std::ifstream ifs(ac3_bin_path, std::ios::binary);
+    if (!ifs.is_open()) return {};
+    ifs.seekg(static_cast<std::streamoff>(ac3_byte_offset), std::ios::beg);
+    if (!ifs.good()) return {};
+    std::vector<uint8_t> bytes(ac3_byte_count);
+    ifs.read(reinterpret_cast<char*>(bytes.data()),
+             static_cast<std::streamsize>(ac3_byte_count));
+    const size_t bytes_read = static_cast<size_t>(ifs.gcount());
+    if (bytes_read < ac3_byte_count) bytes.resize(bytes_read);
+    return bytes;
   }
 
  private:
@@ -1439,9 +1493,17 @@ std::vector<ArtifactPtr> TBCSourceStage::execute(
       });
   const bool has_efm = !sc.efm_path.empty() &&
                        deps_->has_efm_file(sc.efm_path) && metadata_has_efm;
-  const std::string ac3_meta = sc.ac3_path.empty() ? "" : sc.ac3_path + ".meta";
-  const bool has_ac3 =
-      !sc.ac3_path.empty() && deps_->has_ac3_files(sc.ac3_path, ac3_meta);
+  // TBC AC3 RF: same model as EFM — the raw .ac3sym sidecar holds one byte
+  // per QPSK symbol; per-field symbol counts come from the TBC metadata
+  // (there is no .meta index — that sidecar is CVBS-only).  AC3 is available
+  // only when the .ac3sym file exists and the metadata carries at least one
+  // field symbol count.
+  const bool metadata_has_ac3 = std::any_of(
+      field_meta.begin(), field_meta.end(), [](const TBCFieldMeta& fm) {
+        return fm.ac3rf_symbol_count.has_value() && *fm.ac3rf_symbol_count > 0;
+      });
+  const bool has_ac3 = !sc.ac3_path.empty() &&
+                       deps_->has_ac3_file(sc.ac3_path) && metadata_has_ac3;
 
   // Build SourceParameters.
   SourceParameters src_params = build_source_params(tvp, frame_count);
@@ -1451,9 +1513,8 @@ std::vector<ArtifactPtr> TBCSourceStage::execute(
       tvp, src_params, std::move(field_meta), deps_, tbc_path,
       is_yc ? c_path : std::string{}, has_audio ? sc.pcm_path : std::string{},
       has_efm ? sc.efm_path : std::string{},
-      has_ac3 ? sc.ac3_path : std::string{}, has_ac3 ? ac3_meta : std::string{},
-      has_audio, pcm_sample_rate_hz, has_efm, has_ac3, get_str("pcm_name"),
-      ArtifactID{}, Provenance{});
+      has_ac3 ? sc.ac3_path : std::string{}, has_audio, pcm_sample_rate_hz,
+      has_efm, has_ac3, get_str("pcm_name"), ArtifactID{}, Provenance{});
 
   // Update display name.
   const std::string new_display = make_display_name(tvp.system, is_yc);

--- a/orc/plugins/stages/tbc_source/tbc_source_stage.h
+++ b/orc/plugins/stages/tbc_source/tbc_source_stage.h
@@ -152,13 +152,18 @@ class ITBCSourceStageDeps {
       const std::string& efm_bin_path, size_t efm_byte_offset,
       size_t efm_byte_count) const = 0;
 
-  // AC3 RF symbols: same structure as EFM but for .ac3 / .ac3.meta.
-  virtual bool has_ac3_files(const std::string& ac3_bin_path,
-                             const std::string& ac3_meta_path) const = 0;
+  // AC3 RF symbols: same structure as EFM.  TBC captures store one byte per
+  // QPSK symbol in the .ac3sym file in field order; there is no .meta index
+  // sidecar (that is a CVBS-only construct) — per-field symbol counts come
+  // from the TBC metadata (ac3_symbols) instead.
+  virtual bool has_ac3_file(const std::string& ac3_bin_path) const = 0;
 
-  virtual std::optional<std::vector<uint8_t>> read_ac3_for_frame(
-      const std::string& ac3_bin_path, const std::string& ac3_meta_path,
-      int32_t field_seq_no_a, int32_t field_seq_no_b) const = 0;
+  // Read ac3_byte_count raw AC3 symbol bytes starting at ac3_byte_offset from
+  // the .ac3sym sidecar.  Offsets/counts are computed by the caller from the
+  // per-field symbol counts.  Returns empty vector on error.
+  virtual std::vector<uint8_t> read_ac3_bytes_at(
+      const std::string& ac3_bin_path, size_t ac3_byte_offset,
+      size_t ac3_byte_count) const = 0;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The stage-plugin refactor left the TBC source's AC3 path unfinished: the production implementation of `read_ac3_for_frame()` was a stub returning `std::nullopt`, and sidecar detection required an `.ac3sym.meta` index file that nothing produces. This contradicts the stage's own `instructions.md`, which states that `.meta` index sidecars are a CVBS-only construct and that per-field counts in the TBC metadata are authoritative. Net effect: `AC3RFSink` fails with "does not have AC3 RF symbols data" on any input, i.e. the functionality merged in #192 is absent from main.

This PR implements AC3 analogously to EFM:

- Availability requires the `.ac3sym` file **plus** at least one per-field `ac3_symbols` count in the TBC metadata (mirroring the `.efm` + `efm_t_values` rule). The `.ac3sym.meta` requirement is gone.
- Per-frame byte ranges are precomputed by summing field counts (`compute_ac3_offsets()`, mirroring `compute_efm_offsets()`); symbols are read directly from the flat `.ac3sym` file via a new `read_ac3_bytes_at()` deps method (same shape as `read_efm_bytes_at()`).
- `get_ac3_symbol_count(FrameID)` is now implemented (it previously fell through to the interface default of 0).

ld-decode records the per-field `ac3_symbols` counts analogously to `efm_t_values` (see the companion ld-decode PR happycube/ld-decode#1050).

## Testing

- Two new unit tests mirroring the existing EFM pair: the positive path asserting per-frame counts, byte offsets and concatenation; and AC3-unavailable when the `.ac3sym` file exists but the metadata carries no counts. All existing `tbc_source` tests and the MVP architecture check pass.
- End-to-end on a real AC3 LaserDisc capture: `ld-decode --AC3` output decoded through `tbc_source` → `AC3RFSink` produces an AC3 stream byte-identical to the pre-refactor (#192) implementation, with identical Reed-Solomon statistics.