### PR TITLE
Fix frame drop and reordering in F3 to F2 section assembly

### DIFF
--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -262,6 +262,19 @@ gtest_discover_tests(orc-core-unit-tests-efm-f2-tail
         DISCOVERY_TIMEOUT 30
         PROPERTIES LABELS "unit\;sinks")
 
+# F3-to-F2 section framing: boundary repair must never drop, reorder or pad
+# frames when the underlying stream is intact. Links the shared EFM decode
+# library directly, as with the de-emphasis DSP above.
+add_executable(orc-core-unit-tests-efm-section-framing
+        stages/efm_common/f3frametof2section_test.cpp)
+target_link_libraries(orc-core-unit-tests-efm-section-framing
+        orc-efm-decode
+        GTest::gmock_main)
+gtest_discover_tests(orc-core-unit-tests-efm-section-framing
+        DISCOVERY_MODE POST_BUILD
+        DISCOVERY_TIMEOUT 30
+        PROPERTIES LABELS "unit\;sinks")
+
 # End-to-end boundary attribution: a stream that is clean by construction is run
 # through the real F2 -> F1 -> Data24 -> Audio -> concealment chain and must
 # report no input defects at all. Guards the regression where drain codewords

--- a/orc-tests/core/unit/stages/efm_common/f3frametof2section_test.cpp
+++ b/orc-tests/core/unit/stages/efm_common/f3frametof2section_test.cpp
@@ -1,0 +1,111 @@
+/*
+ * File:        f3frametof2section_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Unit tests for F3 frame to F2 section assembly framing
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "dec_f3frametof2section.h"
+#include "efm_constants.h"
+#include "frame.h"
+#include "section.h"
+
+namespace {
+
+// Frames are tagged with a sequence number in every payload byte so that a
+// popped section can be checked for exact frame content and order.
+F3Frame makeFrame(uint8_t tag) {
+  F3Frame frame;
+  frame.setData(std::vector<uint8_t>(32, tag));
+  frame.setErrorData(std::vector<uint8_t>(32, 0));
+  frame.setPaddedData(std::vector<uint8_t>(32, 0));
+  frame.setFrameTypeAsSubcode(0);
+  return frame;
+}
+
+F3Frame makeSync0Frame(uint8_t tag) {
+  F3Frame frame = makeFrame(tag);
+  frame.setFrameTypeAsSync0();
+  return frame;
+}
+
+F3Frame makeSync1Frame(uint8_t tag) {
+  F3Frame frame = makeFrame(tag);
+  frame.setFrameTypeAsSync1();
+  return frame;
+}
+
+// Expects the section to consist of exactly the cleanly-received frames tagged
+// firstTag, firstTag + 1, ... in their original stream order.
+void expectSectionTags(const F2Section& section, uint8_t firstTag) {
+  for (int32_t i = 0; i < efm::kFramesPerSection; ++i) {
+    const uint8_t expected = static_cast<uint8_t>(firstTag + i);
+    EXPECT_EQ(section.frame(i).data()[0], expected)
+        << "frame " << i << " has wrong content or is out of order";
+    for (uint8_t errorByte : section.frame(i).errorData()) {
+      EXPECT_EQ(errorByte, 0) << "frame " << i << " unexpectedly padded";
+    }
+  }
+}
+
+TEST(F3FrameToF2Section, RetainsSync1FrameWhenSync0IsMissing) {
+  F3FrameToF2Section decoder;
+  uint8_t tag = 0;
+
+  // Section A with an intact sync0/sync1 boundary.
+  decoder.pushFrame(makeSync0Frame(tag++));
+  decoder.pushFrame(makeSync1Frame(tag++));
+  for (int i = 0; i < 96; ++i) decoder.pushFrame(makeFrame(tag++));
+
+  // Section B's sync0 symbol was destroyed: the frame arrives as an ordinary
+  // subcode frame, followed by a normal sync1.
+  decoder.pushFrame(makeFrame(tag++));       // tag 98: the damaged sync0
+  decoder.pushFrame(makeSync1Frame(tag++));  // tag 99: triggers the repair
+  for (int i = 0; i < 96; ++i) decoder.pushFrame(makeFrame(tag++));
+
+  // Section C boundary carves section B; a few extra frames let the state
+  // machine emit its output.
+  decoder.pushFrame(makeSync0Frame(tag++));
+  decoder.pushFrame(makeSync1Frame(tag++));
+  for (int i = 0; i < 4; ++i) decoder.pushFrame(makeFrame(tag++));
+
+  ASSERT_TRUE(decoder.isReady());
+  expectSectionTags(decoder.popSection(), 0);
+
+  // The repaired section must contain all 98 frames, including the sync1
+  // frame (tag 99), with nothing dropped or padded.
+  ASSERT_TRUE(decoder.isReady());
+  expectSectionTags(decoder.popSection(), 98);
+}
+
+TEST(F3FrameToF2Section, PreservesFrameOrderWhenIgnoringUndershootSync0) {
+  F3FrameToF2Section decoder;
+  uint8_t tag = 0;
+
+  decoder.pushFrame(makeSync0Frame(tag++));
+  decoder.pushFrame(makeSync1Frame(tag++));
+  for (int i = 0; i < 40; ++i) decoder.pushFrame(makeFrame(tag++));
+
+  // A corrupted subcode symbol aliases to sync0 in mid-section (tag 42). The
+  // resulting 42-frame undershoot section must be merged back without
+  // disturbing the stream order.
+  decoder.pushFrame(makeSync0Frame(tag++));
+  for (int i = 0; i < 55; ++i) decoder.pushFrame(makeFrame(tag++));
+
+  // The true boundary arrives on the 98-frame grid.
+  decoder.pushFrame(makeSync0Frame(tag++));  // tag 98
+  decoder.pushFrame(makeSync1Frame(tag++));
+  for (int i = 0; i < 4; ++i) decoder.pushFrame(makeFrame(tag++));
+
+  ASSERT_TRUE(decoder.isReady());
+  expectSectionTags(decoder.popSection(), 0);
+}
+
+}  // namespace

--- a/orc/plugins/stages/common/efm-decode/decoders/dec_f3frametof2section.cpp
+++ b/orc/plugins/stages/common/efm-decode/decoders/dec_f3frametof2section.cpp
@@ -134,11 +134,12 @@ F3FrameToF2Section::State F3FrameToF2Section::expectingSync() {
       m_missingSync0++;
       m_internalBuffer[m_internalBuffer.size() - 2].setFrameTypeAsSync0();
 
-      // Extract the section frames and remove them from the internal buffer
+      // Extract the section frames and remove them from the internal buffer,
+      // keeping both the repaired sync0 frame and the sync1 frame.
       m_sectionFrames = std::vector<F3Frame>(m_internalBuffer.begin(),
                                              m_internalBuffer.end() - 2);
       m_internalBuffer = std::vector<F3Frame>(m_internalBuffer.end() - 2,
-                                              m_internalBuffer.end() - 1);
+                                              m_internalBuffer.end());
       ORC_LOG_DEBUG(
           "F3FrameToF2Section::expectingSync - Got sync1 frame without a sync0 "
           "frame - section frame size is {}",
@@ -197,9 +198,10 @@ F3FrameToF2Section::State F3FrameToF2Section::handleUndershoot() {
         "F3FrameToF2Section::handleUndershoot - Undershoot is {} frames; "
         "ignoring sync0 frame",
         padding);
-    // Put the section frames back into the internal buffer (append AFTER the
-    // sync0 that is already there)
-    m_internalBuffer.insert(m_internalBuffer.end(), m_sectionFrames.begin(),
+    // Put the section frames back into the internal buffer, BEFORE the
+    // pending sync frame(s) already there: the put-back frames precede the
+    // sync in the frame stream.
+    m_internalBuffer.insert(m_internalBuffer.begin(), m_sectionFrames.begin(),
                             m_sectionFrames.end());
     m_sectionFrames.clear();
     nextState = ExpectingSync;


### PR DESCRIPTION
Two bugs in `F3FrameToF2Section` corrupt the F3 frame stream during section boundary repair. Both preserve the frame *count*, so no existing statistic flags them, but the CIRC de-interleave downstream depends on frame *order* as well — each occurrence surfaces as a burst of uncorrectable C2 words.

## Bug 1 — missing-sync0 recovery drops the sync1 frame

When a section boundary is recovered from a sync1 frame whose sync0 was destroyed, the buffer trim keeps only the repaired sync0 and drops the sync1 frame from the stream, shortening the next section by one frame.

## Bug 2 — undershoot merge-back reorders the frame stream

When an undershoot section (>4 frames short — a suspect mid-section sync0) is merged back, the put-back frames are appended *after* the pending sync frames already in the buffer, hoisting those sync frames ahead of their true stream position and displacing the intervening real frames by two slots. Frame count is preserved, so no statistic flags it; and since consecutive disc frames stay consecutive, the displaced frames remain valid C1 codewords and pass C1 cleanly. The C2 input words assembled across the displaced span therefore mix bytes from different codewords while carrying no erasure flags, leaving C2 nothing to correct with — roughly 150 failed C2 words per event.

## How it was found

Differential testing against an independent EFM decoder implementation on identical T-value input: substituting the Reed-Solomon layer proved it equivalent; PCM cross-alignment ruled out global slips; frame-level stream comparison then isolated a local two-frame displacement zone at each failure burst, bounded by a section boundary, with the merge-back debug message naming the code path.

## Measurements

Domesday CommunitySouth (PAL AIV, marginal capture), 120 s data-region span, identical T-value input:

| chain | C2 failures | data loss |
|---|---:|---:|
| current code | 1,943 | 0.220% |
| + fix 1 (sync1 retention) | 1,790 | 0.203% |
| + fix 2 (frame order) | 374 | 0.042% |

The residual traces to gaps in the .efm input itself (field-boundary losses in the producing decoder), not to this stage.

A rot-damaged NTSC music disc, 121 s span, identical T-value input:

| chain | C2 failures | data loss |
|---|---:|---:|
| current code | 7,220 | 0.812% |
| with both fixes | 1,021 | 0.115% |
| reference: museld's CIRC (independent implementation), same input | 3 | ~0.000% |

The residual 0.115% is dominated by undershoot padding inserted at position 4 rather than at the true gap — the same displacement mechanism, so there is room for further improvement here.

## Validation

- New unit tests in `orc-tests/core/unit/stages/efm_common/f3frametof2section_test.cpp`: section content and order are checked frame-by-frame through a missing-sync0 repair and through an ignored undershoot sync0 (both fail against the previous code).
- Full unit suite, `MVPArchitectureCheck`, and `-L sdk` gates pass locally (Linux/Nix flow).
- End-to-end decode validated on the two captures above.
