### PR TITLE
Route the video sink's decoding through the Decoder interface

### DIFF
--- a/orc-tests/core/unit/stages/video_sink/ntsc_pal_decoder_wrapper_test.cpp
+++ b/orc-tests/core/unit/stages/video_sink/ntsc_pal_decoder_wrapper_test.cpp
@@ -1,7 +1,8 @@
 /*
  * File:        ntsc_pal_decoder_wrapper_test.cpp
  * Module:      orc-core-tests
- * Purpose:     Unit test(s) for NTSC/PAL decoder wrapper configuration
+ * Purpose:     Unit test(s) for NTSC/PAL decoder wrapper configuration and
+ *              decoding
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2026 decode-orc contributors
@@ -9,29 +10,13 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 #include "../../../../orc/plugins/stages/sinks/common/decoders/ntscdecoder.h"
 #include "../../../../orc/plugins/stages/sinks/common/decoders/paldecoder.h"
 
 namespace orc_unit_test {
 namespace {
-class TestableNtscDecoder : public NtscDecoder {
- public:
-  explicit TestableNtscDecoder(const Comb::Configuration& config)
-      : NtscDecoder(config) {}
-
-  void decodeFrames(const std::vector<SourceField>&, int32_t, int32_t,
-                    std::vector<ComponentFrame>&) override {}
-};
-
-class TestablePalDecoder : public PalDecoder {
- public:
-  explicit TestablePalDecoder(const PalColour::Configuration& config)
-      : PalDecoder(config) {}
-
-  void decodeFrames(const std::vector<SourceField>&, int32_t, int32_t,
-                    std::vector<ComponentFrame>&) override {}
-};
-
 orc::SourceParameters make_ntsc_params() {
   orc::SourceParameters p;
   p.system = orc::VideoSystem::NTSC;
@@ -45,11 +30,82 @@ orc::SourceParameters make_pal_params() {
   p.frame_width_nominal = 32;
   return p;
 }
+
+// Video parameters with an active region, as required to decode rather than
+// merely configure.
+orc::SourceParameters make_ntsc_decode_params() {
+  orc::SourceParameters p = make_ntsc_params();
+  p.active_video_start = 16;
+  p.active_video_end = 24;
+  p.first_active_frame_line = 0;
+  p.last_active_frame_line = 6;
+  return p;
+}
+
+orc::SourceParameters make_pal_decode_params() {
+  orc::SourceParameters p = make_pal_params();
+  p.active_video_start = 16;
+  p.active_video_end = 24;
+  p.first_active_frame_line = 0;
+  p.last_active_frame_line = 6;
+  return p;
+}
+
+// Owning wrapper: holds the sample buffers and the non-owning SourceField
+// that points into them.
+struct OwnedField {
+  std::vector<int16_t> composite_buf;
+  std::vector<int16_t> luma_buf;
+  std::vector<int16_t> chroma_buf;
+  SourceField field;
+
+  static OwnedField makeYc(bool is_first_field, int16_t luma_base,
+                           int16_t chroma_base, int width, int height) {
+    OwnedField of;
+    of.field.is_yc = true;
+    of.field.is_first_field = is_first_field;
+    of.field.frame_phase_id = is_first_field ? 1 : 2;
+    of.field.line_count = static_cast<size_t>(height);
+    of.field.samples_per_line = static_cast<size_t>(width);
+
+    of.luma_buf.reserve(static_cast<size_t>(width * height));
+    of.chroma_buf.reserve(static_cast<size_t>(width * height));
+    for (int line = 0; line < height; ++line) {
+      for (int x = 0; x < width; ++x) {
+        of.luma_buf.push_back(static_cast<int16_t>(luma_base + line * 4 + x));
+        of.chroma_buf.push_back(
+            static_cast<int16_t>(chroma_base + ((x % 4) * 10)));
+      }
+    }
+    of.field.luma_data = of.luma_buf.data();
+    of.field.chroma_data = of.chroma_buf.data();
+    return of;
+  }
+
+  static OwnedField makeComposite(bool is_first_field, int16_t base, int width,
+                                  int height) {
+    OwnedField of;
+    of.field.is_yc = false;
+    of.field.is_first_field = is_first_field;
+    of.field.frame_phase_id = is_first_field ? 1 : 2;
+    of.field.line_count = static_cast<size_t>(height);
+    of.field.samples_per_line = static_cast<size_t>(width);
+
+    of.composite_buf.reserve(static_cast<size_t>(width * height));
+    for (int line = 0; line < height; ++line) {
+      for (int x = 0; x < width; ++x) {
+        of.composite_buf.push_back(static_cast<int16_t>(base + line * 8 + x));
+      }
+    }
+    of.field.data = of.composite_buf.data();
+    return of;
+  }
+};
 }  // namespace
 
 TEST(NtscDecoderWrapperTest, Configure_AcceptsNtscAndRejectsPal) {
   Comb::Configuration config;
-  TestableNtscDecoder decoder(config);
+  NtscDecoder decoder(config);
 
   EXPECT_TRUE(decoder.configure(make_ntsc_params()));
   EXPECT_FALSE(decoder.configure(make_pal_params()));
@@ -58,7 +114,7 @@ TEST(NtscDecoderWrapperTest, Configure_AcceptsNtscAndRejectsPal) {
 TEST(NtscDecoderWrapperTest, Look_AroundFollowsCombConfiguration) {
   Comb::Configuration config;
   config.dimensions = 3;
-  TestableNtscDecoder decoder(config);
+  NtscDecoder decoder(config);
 
   EXPECT_EQ(decoder.getLookBehind(), 1);
   EXPECT_EQ(decoder.getLookAhead(), 1);
@@ -66,7 +122,7 @@ TEST(NtscDecoderWrapperTest, Look_AroundFollowsCombConfiguration) {
 
 TEST(PalDecoderWrapperTest, Configure_AcceptsPalAndRejectsNtsc) {
   PalColour::Configuration config;
-  TestablePalDecoder decoder(config);
+  PalDecoder decoder(config);
 
   EXPECT_TRUE(decoder.configure(make_pal_params()));
   EXPECT_FALSE(decoder.configure(make_ntsc_params()));
@@ -75,14 +131,14 @@ TEST(PalDecoderWrapperTest, Configure_AcceptsPalAndRejectsNtsc) {
 TEST(PalDecoderWrapperTest, Look_AroundDependsOnPalFilterMode) {
   PalColour::Configuration config_2d;
   config_2d.chromaFilter = PalColour::transform2DFilter;
-  TestablePalDecoder decoder_2d(config_2d);
+  PalDecoder decoder_2d(config_2d);
 
   EXPECT_EQ(decoder_2d.getLookBehind(), 0);
   EXPECT_EQ(decoder_2d.getLookAhead(), 0);
 
   PalColour::Configuration config_3d;
   config_3d.chromaFilter = PalColour::transform3DFilter;
-  TestablePalDecoder decoder_3d(config_3d);
+  PalDecoder decoder_3d(config_3d);
 
   EXPECT_GT(decoder_3d.getLookBehind(), 0);
   EXPECT_GT(decoder_3d.getLookAhead(), 0);
@@ -90,7 +146,7 @@ TEST(PalDecoderWrapperTest, Look_AroundDependsOnPalFilterMode) {
 
 TEST(NtscDecoderWrapperTest, Configure_RejectsInvalidGeometry) {
   Comb::Configuration config;
-  TestableNtscDecoder decoder(config);
+  NtscDecoder decoder(config);
 
   auto params = make_ntsc_params();
   params.frame_width_nominal = 8;
@@ -100,11 +156,124 @@ TEST(NtscDecoderWrapperTest, Configure_RejectsInvalidGeometry) {
 
 TEST(PalDecoderWrapperTest, Configure_RejectsInvalidGeometry) {
   PalColour::Configuration config;
-  TestablePalDecoder decoder(config);
+  PalDecoder decoder(config);
 
   auto params = make_pal_params();
   params.frame_width_nominal = 8;
 
   EXPECT_FALSE(decoder.configure(params));
+}
+
+TEST(NtscDecoderWrapperTest, DecodeFramesCompositePath_ProducesDecodedFrame) {
+  Comb::Configuration config;
+  config.dimensions = 2;
+  config.phaseCompensation = false;
+
+  NtscDecoder decoder(config);
+  ASSERT_TRUE(decoder.configure(make_ntsc_decode_params()));
+
+  auto first_owned = OwnedField::makeComposite(true, 1000, 32, 4);
+  auto second_owned = OwnedField::makeComposite(false, 2000, 32, 4);
+  std::vector<SourceField> fields = {first_owned.field, second_owned.field};
+  std::vector<ComponentFrame> output(1);
+
+  decoder.decodeFrames(fields, 0, 2, output);
+
+  EXPECT_EQ(output[0].getWidth(), 32);
+  EXPECT_EQ(output[0].getHeight(), 525);
+}
+
+TEST(NtscDecoderWrapperTest, DecodeFramesYcPath_PreservesLumaInActiveRegion) {
+  Comb::Configuration config;
+  config.dimensions = 2;
+  config.phaseCompensation = false;
+
+  NtscDecoder decoder(config);
+  ASSERT_TRUE(decoder.configure(make_ntsc_decode_params()));
+
+  auto first_owned = OwnedField::makeYc(true, 1000, 2000, 32, 4);
+  auto second_owned = OwnedField::makeYc(false, 3000, 4000, 32, 4);
+  std::vector<SourceField> fields = {first_owned.field, second_owned.field};
+  std::vector<ComponentFrame> output(1);
+
+  decoder.decodeFrames(fields, 0, 2, output);
+
+  // Y/C luma must survive the split-decode-merge round trip unchanged.
+  const double* line0 = output[0].y(0);
+  const double* line1 = output[0].y(1);
+
+  EXPECT_DOUBLE_EQ(line0[16],
+                   static_cast<double>(first_owned.field.luma_data[16]));
+  EXPECT_DOUBLE_EQ(line0[20],
+                   static_cast<double>(first_owned.field.luma_data[20]));
+  EXPECT_DOUBLE_EQ(line1[16],
+                   static_cast<double>(second_owned.field.luma_data[16]));
+  EXPECT_DOUBLE_EQ(line1[20],
+                   static_cast<double>(second_owned.field.luma_data[20]));
+}
+
+TEST(PalDecoderWrapperTest, DecodeFramesYcPath_PreservesLumaInActiveRegion) {
+  PalColour::Configuration config;
+  config.chromaFilter = PalColour::palColourFilter;
+
+  PalDecoder decoder(config);
+  ASSERT_TRUE(decoder.configure(make_pal_decode_params()));
+
+  auto first_owned = OwnedField::makeYc(true, 1000, 2000, 32, 4);
+  auto second_owned = OwnedField::makeYc(false, 3000, 4000, 32, 4);
+  std::vector<SourceField> fields = {first_owned.field, second_owned.field};
+  std::vector<ComponentFrame> output(1);
+
+  decoder.decodeFrames(fields, 0, 2, output);
+
+  const double* line0 = output[0].y(0);
+  const double* line1 = output[0].y(1);
+
+  EXPECT_DOUBLE_EQ(line0[16],
+                   static_cast<double>(first_owned.field.luma_data[16]));
+  EXPECT_DOUBLE_EQ(line1[16],
+                   static_cast<double>(second_owned.field.luma_data[16]));
+}
+
+// After a failed reconfigure the decoder must refuse, not decode with the
+// previous system's stale configuration.
+TEST(NtscDecoderWrapperTest,
+     DecodeFrames_AfterFailedReconfigure_DoesNotDecode) {
+  Comb::Configuration config;
+  config.dimensions = 2;
+
+  NtscDecoder decoder(config);
+  ASSERT_TRUE(decoder.configure(make_ntsc_decode_params()));
+  ASSERT_FALSE(decoder.configure(make_pal_params()));
+
+  auto first_owned = OwnedField::makeComposite(true, 1000, 32, 4);
+  auto second_owned = OwnedField::makeComposite(false, 2000, 32, 4);
+  std::vector<SourceField> fields = {first_owned.field, second_owned.field};
+  std::vector<ComponentFrame> output(1);
+
+  decoder.decodeFrames(fields, 0, 2, output);
+
+  // Left untouched: a default-constructed ComponentFrame has extent -1.
+  EXPECT_EQ(output[0].getWidth(), -1);
+  EXPECT_EQ(output[0].getHeight(), -1);
+}
+
+TEST(PalDecoderWrapperTest, DecodeFrames_AfterFailedReconfigure_DoesNotDecode) {
+  PalColour::Configuration config;
+  config.chromaFilter = PalColour::palColourFilter;
+
+  PalDecoder decoder(config);
+  ASSERT_TRUE(decoder.configure(make_pal_decode_params()));
+  ASSERT_FALSE(decoder.configure(make_ntsc_params()));
+
+  auto first_owned = OwnedField::makeComposite(true, 1000, 32, 4);
+  auto second_owned = OwnedField::makeComposite(false, 2000, 32, 4);
+  std::vector<SourceField> fields = {first_owned.field, second_owned.field};
+  std::vector<ComponentFrame> output(1);
+
+  decoder.decodeFrames(fields, 0, 2, output);
+
+  EXPECT_EQ(output[0].getWidth(), -1);
+  EXPECT_EQ(output[0].getHeight(), -1);
 }
 }  // namespace orc_unit_test

--- a/orc-tests/core/unit/stages/video_sink/ntsc_pal_decoder_wrapper_test.cpp
+++ b/orc-tests/core/unit/stages/video_sink/ntsc_pal_decoder_wrapper_test.cpp
@@ -10,9 +10,13 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <vector>
 
+#include "../../../../orc/plugins/stages/sinks/common/decoders/comb.h"
+#include "../../../../orc/plugins/stages/sinks/common/decoders/monodecoder.h"
 #include "../../../../orc/plugins/stages/sinks/common/decoders/ntscdecoder.h"
+#include "../../../../orc/plugins/stages/sinks/common/decoders/palcolour.h"
 #include "../../../../orc/plugins/stages/sinks/common/decoders/paldecoder.h"
 
 namespace orc_unit_test {
@@ -101,6 +105,73 @@ struct OwnedField {
     return of;
   }
 };
+
+// Decodes separate Y/C input the explicit way: split each field into a
+// luma-only and a chroma-only composite view, decode luma with a mono decoder
+// and chroma with the colour decoder, then merge the luma plane into the colour
+// frame. The wrapper's own Y/C handling must match this element for element.
+void decode_yc_reference(
+    const std::vector<SourceField>& inputFields, int32_t startIndex,
+    int32_t endIndex, const orc::SourceParameters& videoParameters,
+    MonoDecoder& lumaDecoder,
+    const std::function<void(const std::vector<SourceField>&, int32_t, int32_t,
+                             std::vector<ComponentFrame>&)>& decodeChroma,
+    std::vector<ComponentFrame>& output) {
+  std::vector<SourceField> lumaFields;
+  std::vector<SourceField> chromaFields;
+  lumaFields.reserve(inputFields.size());
+  chromaFields.reserve(inputFields.size());
+
+  for (const auto& field : inputFields) {
+    SourceField yField = field;
+    yField.is_yc = false;
+    yField.data = field.luma_data;
+    yField.luma_data = nullptr;
+    yField.chroma_data = nullptr;
+    yField.line_ptrs = field.luma_line_ptrs;
+    yField.luma_line_ptrs.clear();
+    yField.chroma_line_ptrs.clear();
+    lumaFields.push_back(std::move(yField));
+
+    SourceField cField = field;
+    cField.is_yc = false;
+    cField.data = field.chroma_data;
+    cField.luma_data = nullptr;
+    cField.chroma_data = nullptr;
+    cField.line_ptrs = field.chroma_line_ptrs;
+    cField.luma_line_ptrs.clear();
+    cField.chroma_line_ptrs.clear();
+    chromaFields.push_back(std::move(cField));
+  }
+
+  std::vector<ComponentFrame> lumaFrames(output.size());
+  lumaDecoder.decodeFrames(lumaFields, startIndex, endIndex, lumaFrames);
+  decodeChroma(chromaFields, startIndex, endIndex, output);
+
+  for (size_t i = 0; i < output.size(); i++) {
+    output[i].merge_luma_from(lumaFrames[i]);
+  }
+}
+
+// Byte-identical comparison of two component frames over their full extent.
+void expect_frames_equal(const ComponentFrame& a, const ComponentFrame& b) {
+  ASSERT_EQ(a.getWidth(), b.getWidth());
+  ASSERT_EQ(a.getHeight(), b.getHeight());
+  const int32_t h = a.getHeight();
+  for (int32_t line = 0; line < h; ++line) {
+    const double* ay = a.y(line);
+    const double* by = b.y(line);
+    const double* au = a.u(line);
+    const double* bu = b.u(line);
+    const double* av = a.v(line);
+    const double* bv = b.v(line);
+    for (int32_t x = 0; x < a.getWidth(); ++x) {
+      EXPECT_EQ(ay[x], by[x]) << "Y line " << line << " x " << x;
+      EXPECT_EQ(au[x], bu[x]) << "U line " << line << " x " << x;
+      EXPECT_EQ(av[x], bv[x]) << "V line " << line << " x " << x;
+    }
+  }
+}
 }  // namespace
 
 TEST(NtscDecoderWrapperTest, Configure_AcceptsNtscAndRejectsPal) {
@@ -275,5 +346,76 @@ TEST(PalDecoderWrapperTest, DecodeFrames_AfterFailedReconfigure_DoesNotDecode) {
 
   EXPECT_EQ(output[0].getWidth(), -1);
   EXPECT_EQ(output[0].getHeight(), -1);
+}
+
+// NtscDecoder's Y/C handling must produce the same frame, element for element,
+// as decoding luma and chroma separately and merging them.
+TEST(NtscDecoderWrapperTest, DecodeFramesYcPath_MatchesSeparateLumaChroma) {
+  const auto params = make_ntsc_decode_params();
+
+  Comb::Configuration combConfig;
+  combConfig.dimensions = 2;
+  combConfig.phaseCompensation = false;
+
+  auto first_owned = OwnedField::makeYc(true, 1000, 2000, 32, 4);
+  auto second_owned = OwnedField::makeYc(false, 3000, 4000, 32, 4);
+  std::vector<SourceField> fields = {first_owned.field, second_owned.field};
+
+  NtscDecoder wrapper(combConfig);
+  ASSERT_TRUE(wrapper.configure(params));
+  std::vector<ComponentFrame> wrapperOut(1);
+  wrapper.decodeFrames(fields, 0, 2, wrapperOut);
+
+  MonoDecoder::MonoConfiguration lumaConfig;
+  lumaConfig.filterChroma = false;
+  lumaConfig.videoParameters = params;
+  MonoDecoder lumaDecoder(lumaConfig);
+  Comb chroma;
+  chroma.updateConfiguration(params, combConfig);
+  std::vector<ComponentFrame> referenceOut(1);
+  decode_yc_reference(
+      fields, 0, 2, params, lumaDecoder,
+      [&chroma](const std::vector<SourceField>& f, int32_t s, int32_t e,
+                std::vector<ComponentFrame>& o) {
+        chroma.decodeFrames(f, s, e, o);
+      },
+      referenceOut);
+
+  expect_frames_equal(wrapperOut[0], referenceOut[0]);
+}
+
+// PalDecoder's Y/C handling must produce the same frame, element for element,
+// as decoding luma and chroma separately and merging them.
+TEST(PalDecoderWrapperTest, DecodeFramesYcPath_MatchesSeparateLumaChroma) {
+  const auto params = make_pal_decode_params();
+
+  PalColour::Configuration palConfig;
+  palConfig.chromaFilter = PalColour::palColourFilter;
+
+  auto first_owned = OwnedField::makeYc(true, 1000, 2000, 32, 4);
+  auto second_owned = OwnedField::makeYc(false, 3000, 4000, 32, 4);
+  std::vector<SourceField> fields = {first_owned.field, second_owned.field};
+
+  PalDecoder wrapper(palConfig);
+  ASSERT_TRUE(wrapper.configure(params));
+  std::vector<ComponentFrame> wrapperOut(1);
+  wrapper.decodeFrames(fields, 0, 2, wrapperOut);
+
+  MonoDecoder::MonoConfiguration lumaConfig;
+  lumaConfig.filterChroma = false;
+  lumaConfig.videoParameters = params;
+  MonoDecoder lumaDecoder(lumaConfig);
+  PalColour chroma;
+  chroma.updateConfiguration(params, palConfig);
+  std::vector<ComponentFrame> referenceOut(1);
+  decode_yc_reference(
+      fields, 0, 2, params, lumaDecoder,
+      [&chroma](const std::vector<SourceField>& f, int32_t s, int32_t e,
+                std::vector<ComponentFrame>& o) {
+        chroma.decodeFrames(f, s, e, o);
+      },
+      referenceOut);
+
+  expect_frames_equal(wrapperOut[0], referenceOut[0]);
 }
 }  // namespace orc_unit_test

--- a/orc-tests/core/unit/stages/video_sink/sourcefield_test.cpp
+++ b/orc-tests/core/unit/stages/video_sink/sourcefield_test.cpp
@@ -86,4 +86,100 @@ TEST(SourceFieldTest, GetLumaAndChromaLine_UsesLinePtrsWhenPopulated) {
   EXPECT_EQ(field.getChromaLine(1), chroma + 5);
 }
 
+TEST(SplitYcFieldsTest, RoutesLumaAndChromaToSeparateCompositeFields) {
+  const int16_t luma[] = {10, 11, 12, 13};
+  const int16_t chroma[] = {30, 31, 32, 33};
+
+  SourceField field;
+  field.seq_no = 7;
+  field.is_first_field = false;
+  field.is_yc = true;
+  field.luma_data = luma;
+  field.chroma_data = chroma;
+  field.samples_per_line = 4;
+  field.line_count = 1;
+
+  std::vector<SourceField> lumaFields;
+  std::vector<SourceField> chromaFields;
+  split_yc_fields({field}, lumaFields, chromaFields);
+
+  ASSERT_EQ(lumaFields.size(), 1u);
+  ASSERT_EQ(chromaFields.size(), 1u);
+
+  // Metadata is carried through; the channel becomes plain composite data.
+  EXPECT_EQ(lumaFields[0].seq_no, 7);
+  EXPECT_FALSE(lumaFields[0].is_first_field);
+  EXPECT_FALSE(lumaFields[0].is_yc);
+  EXPECT_EQ(lumaFields[0].data, luma);
+  EXPECT_EQ(lumaFields[0].luma_data, nullptr);
+  EXPECT_EQ(lumaFields[0].chroma_data, nullptr);
+
+  EXPECT_FALSE(chromaFields[0].is_yc);
+  EXPECT_EQ(chromaFields[0].data, chroma);
+  EXPECT_EQ(chromaFields[0].luma_data, nullptr);
+  EXPECT_EQ(chromaFields[0].chroma_data, nullptr);
+}
+
+TEST(SplitYcFieldsTest, MovesPalLinePtrsIntoCompositeLinePtrs) {
+  const int16_t luma[] = {10, 11, 12, 13, 20};
+  const int16_t chroma[] = {30, 31, 32, 33, 40};
+
+  SourceField field;
+  field.is_yc = true;
+  field.luma_data = luma;
+  field.chroma_data = chroma;
+  field.samples_per_line = 4;
+  field.line_count = 2;
+  field.luma_line_ptrs = {luma + 0, luma + 4};
+  field.chroma_line_ptrs = {chroma + 0, chroma + 4};
+
+  std::vector<SourceField> lumaFields;
+  std::vector<SourceField> chromaFields;
+  split_yc_fields({field}, lumaFields, chromaFields);
+
+  // The per-channel line pointers become the composite line_ptrs, and the
+  // Y/C line-pointer vectors are cleared.
+  EXPECT_EQ(lumaFields[0].line_ptrs,
+            std::vector<const int16_t*>({luma + 0, luma + 4}));
+  EXPECT_TRUE(lumaFields[0].luma_line_ptrs.empty());
+  EXPECT_TRUE(lumaFields[0].chroma_line_ptrs.empty());
+
+  EXPECT_EQ(chromaFields[0].line_ptrs,
+            std::vector<const int16_t*>({chroma + 0, chroma + 4}));
+  EXPECT_TRUE(chromaFields[0].luma_line_ptrs.empty());
+  EXPECT_TRUE(chromaFields[0].chroma_line_ptrs.empty());
+}
+
+TEST(SplitYcFieldsTest, ClearsExistingOutputAndPreservesInputOrder) {
+  const int16_t luma0[] = {1};
+  const int16_t chroma0[] = {2};
+  const int16_t luma1[] = {3};
+  const int16_t chroma1[] = {4};
+
+  auto make_field = [](const int16_t* l, const int16_t* c) {
+    SourceField f;
+    f.is_yc = true;
+    f.luma_data = l;
+    f.chroma_data = c;
+    f.samples_per_line = 1;
+    f.line_count = 1;
+    return f;
+  };
+
+  std::vector<SourceField> inputFields = {make_field(luma0, chroma0),
+                                          make_field(luma1, chroma1)};
+
+  // Pre-populate the outputs to confirm they are cleared, not appended to.
+  std::vector<SourceField> lumaFields(3);
+  std::vector<SourceField> chromaFields(1);
+  split_yc_fields(inputFields, lumaFields, chromaFields);
+
+  ASSERT_EQ(lumaFields.size(), 2u);
+  ASSERT_EQ(chromaFields.size(), 2u);
+  EXPECT_EQ(lumaFields[0].data, luma0);
+  EXPECT_EQ(lumaFields[1].data, luma1);
+  EXPECT_EQ(chromaFields[0].data, chroma0);
+  EXPECT_EQ(chromaFields[1].data, chroma1);
+}
+
 }  // namespace orc_unit_test

--- a/orc/plugins/stages/sinks/common/decoders/CMakeLists.txt
+++ b/orc/plugins/stages/sinks/common/decoders/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Define decoder library sources
 set(DECODER_SOURCES
     decoder.cpp
+    sourcefield.cpp
     paldecoder.cpp
     palcolour.cpp
     transformpal.cpp

--- a/orc/plugins/stages/sinks/common/decoders/decoder.h
+++ b/orc/plugins/stages/sinks/common/decoders/decoder.h
@@ -53,7 +53,16 @@ class Decoder {
   // decoders.
   virtual int32_t getLookAhead() const;
 
-  // Decode a sequence of composite fields into a sequence of component frames
+  // Decode a sequence of composite fields into component frames.
+  //
+  // inputFields runs look-behind, decode, look-ahead, two fields per frame.
+  // [startIndex, endIndex) is the half-open decode range; the caller aligns it
+  // to getLookBehind() * 2 so every frame decodes at the same temporal
+  // position (required by the 3D decoders).  Fields outside it are context.
+  // componentFrames must be pre-sized to (endIndex - startIndex) / 2.
+  //
+  // Y/C sources set is_yc and carry luma/chroma in luma_data/chroma_data;
+  // decoders without Y/C support decode the composite data channel instead.
   virtual void decodeFrames(const std::vector<SourceField>& inputFields,
                             int32_t startIndex, int32_t endIndex,
                             std::vector<ComponentFrame>& componentFrames) = 0;

--- a/orc/plugins/stages/sinks/common/decoders/decoder.h
+++ b/orc/plugins/stages/sinks/common/decoders/decoder.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "componentframe.h"
-#include "outputwriter.h"
 #include "sourcefield.h"
 
 // Abstract base class for chroma decoders.

--- a/orc/plugins/stages/sinks/common/decoders/ntscdecoder.cpp
+++ b/orc/plugins/stages/sinks/common/decoders/ntscdecoder.cpp
@@ -12,8 +12,6 @@
 
 #include <orc/support/logging.h>
 
-#include <utility>
-
 #include "../video_parameter_safety.h"
 
 NtscDecoder::NtscDecoder(const Comb::Configuration& combConfig) {
@@ -93,30 +91,7 @@ void NtscDecoder::decodeFramesYc(const std::vector<SourceField>& inputFields,
   // Split each Y/C field into a luma-only and a chroma-only composite field.
   std::vector<SourceField> lumaFields;
   std::vector<SourceField> chromaFields;
-  lumaFields.reserve(inputFields.size());
-  chromaFields.reserve(inputFields.size());
-
-  for (const auto& field : inputFields) {
-    SourceField lumaField = field;
-    lumaField.is_yc = false;
-    lumaField.data = field.luma_data;
-    lumaField.luma_data = nullptr;
-    lumaField.chroma_data = nullptr;
-    lumaField.line_ptrs = field.luma_line_ptrs;
-    lumaField.luma_line_ptrs.clear();
-    lumaField.chroma_line_ptrs.clear();
-    lumaFields.push_back(std::move(lumaField));
-
-    SourceField chromaField = field;
-    chromaField.is_yc = false;
-    chromaField.data = field.chroma_data;
-    chromaField.luma_data = nullptr;
-    chromaField.chroma_data = nullptr;
-    chromaField.line_ptrs = field.chroma_line_ptrs;
-    chromaField.luma_line_ptrs.clear();
-    chromaField.chroma_line_ptrs.clear();
-    chromaFields.push_back(std::move(chromaField));
-  }
+  split_yc_fields(inputFields, lumaFields, chromaFields);
 
   std::vector<ComponentFrame> lumaFrames(componentFrames.size());
   ycLumaDecoder->decodeFrames(lumaFields, startIndex, endIndex, lumaFrames);

--- a/orc/plugins/stages/sinks/common/decoders/ntscdecoder.cpp
+++ b/orc/plugins/stages/sinks/common/decoders/ntscdecoder.cpp
@@ -12,6 +12,8 @@
 
 #include <orc/support/logging.h>
 
+#include <utility>
+
 #include "../video_parameter_safety.h"
 
 NtscDecoder::NtscDecoder(const Comb::Configuration& combConfig) {
@@ -19,6 +21,9 @@ NtscDecoder::NtscDecoder(const Comb::Configuration& combConfig) {
 }
 
 bool NtscDecoder::configure(const ::orc::SourceParameters& videoParameters) {
+  // A failed reconfiguration must not leave the previous configuration usable.
+  configurationValid_ = false;
+
   // Ensure the source video is NTSC
   if (videoParameters.system != orc::VideoSystem::NTSC) {
     ORC_LOG_ERROR("This decoder is for NTSC video sources only");
@@ -42,6 +47,18 @@ bool NtscDecoder::configure(const ::orc::SourceParameters& videoParameters) {
 
   config.videoParameters = safety.params;
 
+  comb = std::make_unique<Comb>();
+  comb->updateConfiguration(config.videoParameters, config.combConfig);
+
+  // The Y/C luma channel is already clean, so filterChroma stays off.
+  MonoDecoder::MonoConfiguration lumaConfig;
+  lumaConfig.yNRLevel = config.combConfig.yNRLevel;
+  lumaConfig.filterChroma = false;
+  lumaConfig.videoParameters = config.videoParameters;
+  ycLumaDecoder = std::make_unique<MonoDecoder>(lumaConfig);
+
+  configurationValid_ = true;
+
   return true;
 }
 
@@ -51,4 +68,61 @@ int32_t NtscDecoder::getLookBehind() const {
 
 int32_t NtscDecoder::getLookAhead() const {
   return config.combConfig.getLookAhead();
+}
+
+void NtscDecoder::decodeFrames(const std::vector<SourceField>& inputFields,
+                               int32_t startIndex, int32_t endIndex,
+                               std::vector<ComponentFrame>& componentFrames) {
+  if (!configurationValid_) {
+    ORC_LOG_ERROR(
+        "NtscDecoder::decodeFrames(): Decoder configuration is invalid");
+    return;
+  }
+
+  if (!inputFields.empty() && inputFields[0].is_yc) {
+    decodeFramesYc(inputFields, startIndex, endIndex, componentFrames);
+    return;
+  }
+
+  comb->decodeFrames(inputFields, startIndex, endIndex, componentFrames);
+}
+
+void NtscDecoder::decodeFramesYc(const std::vector<SourceField>& inputFields,
+                                 int32_t startIndex, int32_t endIndex,
+                                 std::vector<ComponentFrame>& componentFrames) {
+  // Split each Y/C field into a luma-only and a chroma-only composite field.
+  std::vector<SourceField> lumaFields;
+  std::vector<SourceField> chromaFields;
+  lumaFields.reserve(inputFields.size());
+  chromaFields.reserve(inputFields.size());
+
+  for (const auto& field : inputFields) {
+    SourceField lumaField = field;
+    lumaField.is_yc = false;
+    lumaField.data = field.luma_data;
+    lumaField.luma_data = nullptr;
+    lumaField.chroma_data = nullptr;
+    lumaField.line_ptrs = field.luma_line_ptrs;
+    lumaField.luma_line_ptrs.clear();
+    lumaField.chroma_line_ptrs.clear();
+    lumaFields.push_back(std::move(lumaField));
+
+    SourceField chromaField = field;
+    chromaField.is_yc = false;
+    chromaField.data = field.chroma_data;
+    chromaField.luma_data = nullptr;
+    chromaField.chroma_data = nullptr;
+    chromaField.line_ptrs = field.chroma_line_ptrs;
+    chromaField.luma_line_ptrs.clear();
+    chromaField.chroma_line_ptrs.clear();
+    chromaFields.push_back(std::move(chromaField));
+  }
+
+  std::vector<ComponentFrame> lumaFrames(componentFrames.size());
+  ycLumaDecoder->decodeFrames(lumaFields, startIndex, endIndex, lumaFrames);
+  comb->decodeFrames(chromaFields, startIndex, endIndex, componentFrames);
+
+  for (size_t i = 0; i < componentFrames.size(); i++) {
+    componentFrames[i].merge_luma_from(lumaFrames[i]);
+  }
 }

--- a/orc/plugins/stages/sinks/common/decoders/ntscdecoder.h
+++ b/orc/plugins/stages/sinks/common/decoders/ntscdecoder.h
@@ -15,14 +15,20 @@
 
 #include <atomic>
 #include <iostream>
+#include <memory>
 #include <thread>
+#include <vector>
 
 #include "comb.h"
 #include "componentframe.h"
 #include "decoder.h"
+#include "monodecoder.h"
 #include "sourcefield.h"
 
 // 2D/3D NTSC decoder using Comb
+//
+// Thread safety: not thread-safe.  Each worker thread must construct and own
+// its own instance, as each holds mutable per-decode decoder state.
 class NtscDecoder : public Decoder {
  public:
   NtscDecoder(const Comb::Configuration& combConfig);
@@ -30,13 +36,27 @@ class NtscDecoder : public Decoder {
   int32_t getLookBehind() const override;
   int32_t getLookAhead() const override;
 
+  void decodeFrames(const std::vector<SourceField>& inputFields,
+                    int32_t startIndex, int32_t endIndex,
+                    std::vector<ComponentFrame>& componentFrames) override;
+
   // Parameters used by NtscDecoder and NtscThread
   struct Configuration : public Decoder::Configuration {
     Comb::Configuration combConfig;
   };
 
  private:
+  // Decode separate Y/C input: mono decoder for luma, Comb for chroma, merged.
+  // This is ld-chroma-decoder's separate Y/C output path, not the older
+  // preview-only Comb::decodeFramesYC().
+  void decodeFramesYc(const std::vector<SourceField>& inputFields,
+                      int32_t startIndex, int32_t endIndex,
+                      std::vector<ComponentFrame>& componentFrames);
+
   Configuration config;
+  std::unique_ptr<Comb> comb;
+  std::unique_ptr<MonoDecoder> ycLumaDecoder;
+  bool configurationValid_ = false;
 };
 
 #endif  // NTSCDECODER_H

--- a/orc/plugins/stages/sinks/common/decoders/paldecoder.cpp
+++ b/orc/plugins/stages/sinks/common/decoders/paldecoder.cpp
@@ -12,6 +12,8 @@
 
 #include <orc/support/logging.h>
 
+#include <utility>
+
 #include "../video_parameter_safety.h"
 
 PalDecoder::PalDecoder(const PalColour::Configuration& palConfig) {
@@ -19,6 +21,9 @@ PalDecoder::PalDecoder(const PalColour::Configuration& palConfig) {
 }
 
 bool PalDecoder::configure(const ::orc::SourceParameters& videoParameters) {
+  // A failed reconfiguration must not leave the previous configuration usable.
+  configurationValid_ = false;
+
   // Ensure the source video is PAL
   if (videoParameters.system != orc::VideoSystem::PAL &&
       videoParameters.system != orc::VideoSystem::PAL_M) {
@@ -43,9 +48,80 @@ bool PalDecoder::configure(const ::orc::SourceParameters& videoParameters) {
 
   config.videoParameters = safety.params;
 
+  // Transform PAL builds FFTW plans here with FFTW_MEASURE; per-thread
+  // construction must be serialised by the caller.
+  palColour = std::make_unique<PalColour>();
+  palColour->updateConfiguration(config.videoParameters, config.pal);
+
+  // The Y/C luma channel is already clean, so filterChroma stays off.
+  MonoDecoder::MonoConfiguration lumaConfig;
+  lumaConfig.yNRLevel = config.pal.yNRLevel;
+  lumaConfig.filterChroma = false;
+  lumaConfig.videoParameters = config.videoParameters;
+  ycLumaDecoder = std::make_unique<MonoDecoder>(lumaConfig);
+
+  configurationValid_ = true;
+
   return true;
 }
 
 int32_t PalDecoder::getLookBehind() const { return config.pal.getLookBehind(); }
 
 int32_t PalDecoder::getLookAhead() const { return config.pal.getLookAhead(); }
+
+void PalDecoder::decodeFrames(const std::vector<SourceField>& inputFields,
+                              int32_t startIndex, int32_t endIndex,
+                              std::vector<ComponentFrame>& componentFrames) {
+  if (!configurationValid_) {
+    ORC_LOG_ERROR(
+        "PalDecoder::decodeFrames(): Decoder configuration is invalid");
+    return;
+  }
+
+  if (!inputFields.empty() && inputFields[0].is_yc) {
+    decodeFramesYc(inputFields, startIndex, endIndex, componentFrames);
+    return;
+  }
+
+  palColour->decodeFrames(inputFields, startIndex, endIndex, componentFrames);
+}
+
+void PalDecoder::decodeFramesYc(const std::vector<SourceField>& inputFields,
+                                int32_t startIndex, int32_t endIndex,
+                                std::vector<ComponentFrame>& componentFrames) {
+  // Split each Y/C field into a luma-only and a chroma-only composite field.
+  std::vector<SourceField> lumaFields;
+  std::vector<SourceField> chromaFields;
+  lumaFields.reserve(inputFields.size());
+  chromaFields.reserve(inputFields.size());
+
+  for (const auto& field : inputFields) {
+    SourceField lumaField = field;
+    lumaField.is_yc = false;
+    lumaField.data = field.luma_data;
+    lumaField.luma_data = nullptr;
+    lumaField.chroma_data = nullptr;
+    lumaField.line_ptrs = field.luma_line_ptrs;
+    lumaField.luma_line_ptrs.clear();
+    lumaField.chroma_line_ptrs.clear();
+    lumaFields.push_back(std::move(lumaField));
+
+    SourceField chromaField = field;
+    chromaField.is_yc = false;
+    chromaField.data = field.chroma_data;
+    chromaField.luma_data = nullptr;
+    chromaField.chroma_data = nullptr;
+    chromaField.line_ptrs = field.chroma_line_ptrs;
+    chromaField.luma_line_ptrs.clear();
+    chromaField.chroma_line_ptrs.clear();
+    chromaFields.push_back(std::move(chromaField));
+  }
+
+  std::vector<ComponentFrame> lumaFrames(componentFrames.size());
+  ycLumaDecoder->decodeFrames(lumaFields, startIndex, endIndex, lumaFrames);
+  palColour->decodeFrames(chromaFields, startIndex, endIndex, componentFrames);
+
+  for (size_t i = 0; i < componentFrames.size(); i++) {
+    componentFrames[i].merge_luma_from(lumaFrames[i]);
+  }
+}

--- a/orc/plugins/stages/sinks/common/decoders/paldecoder.cpp
+++ b/orc/plugins/stages/sinks/common/decoders/paldecoder.cpp
@@ -12,8 +12,6 @@
 
 #include <orc/support/logging.h>
 
-#include <utility>
-
 #include "../video_parameter_safety.h"
 
 PalDecoder::PalDecoder(const PalColour::Configuration& palConfig) {
@@ -92,30 +90,7 @@ void PalDecoder::decodeFramesYc(const std::vector<SourceField>& inputFields,
   // Split each Y/C field into a luma-only and a chroma-only composite field.
   std::vector<SourceField> lumaFields;
   std::vector<SourceField> chromaFields;
-  lumaFields.reserve(inputFields.size());
-  chromaFields.reserve(inputFields.size());
-
-  for (const auto& field : inputFields) {
-    SourceField lumaField = field;
-    lumaField.is_yc = false;
-    lumaField.data = field.luma_data;
-    lumaField.luma_data = nullptr;
-    lumaField.chroma_data = nullptr;
-    lumaField.line_ptrs = field.luma_line_ptrs;
-    lumaField.luma_line_ptrs.clear();
-    lumaField.chroma_line_ptrs.clear();
-    lumaFields.push_back(std::move(lumaField));
-
-    SourceField chromaField = field;
-    chromaField.is_yc = false;
-    chromaField.data = field.chroma_data;
-    chromaField.luma_data = nullptr;
-    chromaField.chroma_data = nullptr;
-    chromaField.line_ptrs = field.chroma_line_ptrs;
-    chromaField.luma_line_ptrs.clear();
-    chromaField.chroma_line_ptrs.clear();
-    chromaFields.push_back(std::move(chromaField));
-  }
+  split_yc_fields(inputFields, lumaFields, chromaFields);
 
   std::vector<ComponentFrame> lumaFrames(componentFrames.size());
   ycLumaDecoder->decodeFrames(lumaFields, startIndex, endIndex, lumaFrames);

--- a/orc/plugins/stages/sinks/common/decoders/paldecoder.h
+++ b/orc/plugins/stages/sinks/common/decoders/paldecoder.h
@@ -15,14 +15,23 @@
 
 #include <atomic>
 #include <iostream>
+#include <memory>
 #include <thread>
+#include <vector>
 
 #include "componentframe.h"
 #include "decoder.h"
+#include "monodecoder.h"
 #include "palcolour.h"
 #include "sourcefield.h"
 
 // 2D PAL decoder using PALcolour
+//
+// Thread safety: not thread-safe.  Each worker thread must construct and own
+// its own instance, as each holds mutable per-decode decoder state.  Transform
+// PAL builds FFTW plans with FFTW_MEASURE during configure(), which is not
+// thread-safe, so concurrent configure() calls must be serialised by the
+// caller.
 class PalDecoder : public Decoder {
  public:
   PalDecoder(const PalColour::Configuration& palConfig);
@@ -30,13 +39,29 @@ class PalDecoder : public Decoder {
   int32_t getLookBehind() const override;
   int32_t getLookAhead() const override;
 
+  void decodeFrames(const std::vector<SourceField>& inputFields,
+                    int32_t startIndex, int32_t endIndex,
+                    std::vector<ComponentFrame>& componentFrames) override;
+
   // Parameters used by PalDecoder and PalThread
   struct Configuration : public Decoder::Configuration {
     PalColour::Configuration pal;
   };
 
  private:
+  // Decode separate Y/C input: mono decoder for luma, PALcolour for chroma,
+  // merged.  This is ld-chroma-decoder's separate Y/C output path, not the
+  // older preview-only PalColour::decodeFieldYC().  The Transform PAL modes
+  // are meaningless on already-separated chroma, so the caller must select
+  // palColourFilter for Y/C sources.
+  void decodeFramesYc(const std::vector<SourceField>& inputFields,
+                      int32_t startIndex, int32_t endIndex,
+                      std::vector<ComponentFrame>& componentFrames);
+
   Configuration config;
+  std::unique_ptr<PalColour> palColour;
+  std::unique_ptr<MonoDecoder> ycLumaDecoder;
+  bool configurationValid_ = false;
 };
 
 #endif  // PALDECODER

--- a/orc/plugins/stages/sinks/common/decoders/sourcefield.cpp
+++ b/orc/plugins/stages/sinks/common/decoders/sourcefield.cpp
@@ -1,0 +1,43 @@
+/*
+ * File:        sourcefield.cpp
+ * Module:      orc-core
+ * Purpose:     Non-owning field view for CVBS_U10_4FSC decoder input
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#include "sourcefield.h"
+
+#include <utility>
+
+void split_yc_fields(const std::vector<SourceField>& inputFields,
+                     std::vector<SourceField>& lumaFields,
+                     std::vector<SourceField>& chromaFields) {
+  lumaFields.clear();
+  chromaFields.clear();
+  lumaFields.reserve(inputFields.size());
+  chromaFields.reserve(inputFields.size());
+
+  for (const auto& field : inputFields) {
+    SourceField lumaField = field;
+    lumaField.is_yc = false;
+    lumaField.data = field.luma_data;
+    lumaField.luma_data = nullptr;
+    lumaField.chroma_data = nullptr;
+    lumaField.line_ptrs = field.luma_line_ptrs;
+    lumaField.luma_line_ptrs.clear();
+    lumaField.chroma_line_ptrs.clear();
+    lumaFields.push_back(std::move(lumaField));
+
+    SourceField chromaField = field;
+    chromaField.is_yc = false;
+    chromaField.data = field.chroma_data;
+    chromaField.luma_data = nullptr;
+    chromaField.chroma_data = nullptr;
+    chromaField.line_ptrs = field.chroma_line_ptrs;
+    chromaField.luma_line_ptrs.clear();
+    chromaField.chroma_line_ptrs.clear();
+    chromaFields.push_back(std::move(chromaField));
+  }
+}

--- a/orc/plugins/stages/sinks/common/decoders/sourcefield.h
+++ b/orc/plugins/stages/sinks/common/decoders/sourcefield.h
@@ -118,4 +118,15 @@ struct SourceField {
   }
 };
 
+// Split each Y/C field in `inputFields` into a luma-only and a chroma-only
+// composite field, writing them to `lumaFields` and `chromaFields`.  Each
+// output field aliases the input's luma_data/chroma_data (and the matching
+// PAL line pointers) as its composite `data`, with is_yc cleared, so a
+// composite decoder can process the two channels separately.  The outputs are
+// cleared first; they reference the same buffers as the inputs and must not
+// outlive them.
+void split_yc_fields(const std::vector<SourceField>& inputFields,
+                     std::vector<SourceField>& lumaFields,
+                     std::vector<SourceField>& chromaFields);
+
 #endif  // SOURCEFIELD_H

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -2225,10 +2225,21 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
 
   std::vector<SourceField> inputFields;
 
+  const bool is_yc_source = local_input->has_separate_channels();
+
   // Build (or reuse) the preview decoder before gathering fields so the
   // look-around comes from the decoder itself, matching the render path
   // instead of duplicating per-type values here.
   std::string effectiveDecoderType = decoder_type_;
+
+  // Transform PAL filters operate on composite chroma; a Y/C source has no
+  // composite chroma to filter, so fall back to pal2d.  The render path applies
+  // the same downgrade (there it mutates decoder_type_ to surface it in the
+  // UI); the preview only needs it locally so it decodes what the export will.
+  if (is_yc_source && (effectiveDecoderType == "transform2d" ||
+                       effectiveDecoderType == "transform3d")) {
+    effectiveDecoderType = "pal2d";
+  }
 
   if (!preview_decoder_cache_.matches_config(
           effectiveDecoderType, chroma_gain_, chroma_phase_, luma_nr_,
@@ -2269,7 +2280,6 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
   int64_t end_frame_idx =
       static_cast<int64_t>(frame_a_index) + num_lookahead_frames;
 
-  const bool is_yc_source = local_input->has_separate_channels();
   // PAL_M has NTSC-like frame geometry (525 lines, 909 samples/line); only
   // pure PAL uses the 625-line non-uniform layout.
   const bool preview_is_pal = (safeVideoParams.system == orc::VideoSystem::PAL);

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -2224,23 +2224,45 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
   const uint64_t frame_a_index = preview_frame_range.first + index;
 
   std::vector<SourceField> inputFields;
-  int32_t num_lookbehind_frames = 0;
-  int32_t num_lookahead_frames = 0;
 
-  std::string temp_decoder_type = decoder_type_;
-  if (temp_decoder_type == "transform3d") {
-    // TransformPal3D::getLookBehind() = 1, getLookAhead() = 4 (frames).
-    // Preview must supply at least getLookAhead()*2 = 8 fields after endIndex.
-    num_lookbehind_frames = 2;
-    num_lookahead_frames = 4;
-  } else if (temp_decoder_type == "ntsc3d" ||
-             temp_decoder_type == "ntsc3dnoadapt") {
-    num_lookbehind_frames = 2;
-    num_lookahead_frames = 2;
-  } else {
-    num_lookbehind_frames = 1;
-    num_lookahead_frames = 1;
+  // Build (or reuse) the preview decoder before gathering fields so the
+  // look-around comes from the decoder itself, matching the render path
+  // instead of duplicating per-type values here.
+  std::string effectiveDecoderType = decoder_type_;
+
+  if (!preview_decoder_cache_.matches_config(
+          effectiveDecoderType, chroma_gain_, chroma_phase_, luma_nr_,
+          chroma_nr_, ntsc_phase_comp_, simple_pal_, false,
+          transform_threshold_, chroma_weight_, adapt_threshold_)) {
+    preview_decoder_cache_.decoder.reset();
+    preview_decoder_cache_.decoder_type = effectiveDecoderType;
+    preview_decoder_cache_.chroma_gain = chroma_gain_;
+    preview_decoder_cache_.chroma_phase = chroma_phase_;
+    preview_decoder_cache_.luma_nr = luma_nr_;
+    preview_decoder_cache_.chroma_nr = chroma_nr_;
+    preview_decoder_cache_.ntsc_phase_comp = ntsc_phase_comp_;
+    preview_decoder_cache_.simple_pal = simple_pal_;
+    preview_decoder_cache_.blackandwhite = false;
+    preview_decoder_cache_.transform_threshold = transform_threshold_;
+    preview_decoder_cache_.chroma_weight = chroma_weight_;
+    preview_decoder_cache_.adapt_threshold = adapt_threshold_;
+
+    const DecoderParams decoderParams{
+        chroma_gain_,         chroma_phase_,    luma_nr_,
+        chroma_nr_,           ntsc_phase_comp_, simple_pal_,
+        transform_threshold_, chroma_weight_,   adapt_threshold_};
+    preview_decoder_cache_.decoder =
+        make_decoder(effectiveDecoderType, decoderParams, safeVideoParams);
   }
+
+  if (!preview_decoder_cache_.decoder) {
+    return std::nullopt;
+  }
+
+  const int32_t num_lookbehind_frames =
+      preview_decoder_cache_.decoder->getLookBehind();
+  const int32_t num_lookahead_frames =
+      preview_decoder_cache_.decoder->getLookAhead();
 
   int64_t start_frame_idx =
       static_cast<int64_t>(frame_a_index) - num_lookbehind_frames;
@@ -2344,40 +2366,11 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
   // Each frame contributes 2 SourceFields; lookbehind frames come first.
   const int32_t frameStartIndex = num_lookbehind_frames * 2;
 
-  std::string effectiveDecoderType = decoder_type_;
-
-  if (!preview_decoder_cache_.matches_config(
-          effectiveDecoderType, chroma_gain_, chroma_phase_, luma_nr_,
-          chroma_nr_, ntsc_phase_comp_, simple_pal_, false,
-          transform_threshold_, chroma_weight_, adapt_threshold_)) {
-    preview_decoder_cache_.decoder.reset();
-    preview_decoder_cache_.decoder_type = effectiveDecoderType;
-    preview_decoder_cache_.chroma_gain = chroma_gain_;
-    preview_decoder_cache_.chroma_phase = chroma_phase_;
-    preview_decoder_cache_.luma_nr = luma_nr_;
-    preview_decoder_cache_.chroma_nr = chroma_nr_;
-    preview_decoder_cache_.ntsc_phase_comp = ntsc_phase_comp_;
-    preview_decoder_cache_.simple_pal = simple_pal_;
-    preview_decoder_cache_.blackandwhite = false;
-    preview_decoder_cache_.transform_threshold = transform_threshold_;
-    preview_decoder_cache_.chroma_weight = chroma_weight_;
-    preview_decoder_cache_.adapt_threshold = adapt_threshold_;
-
-    const DecoderParams decoderParams{
-        chroma_gain_,         chroma_phase_,    luma_nr_,
-        chroma_nr_,           ntsc_phase_comp_, simple_pal_,
-        transform_threshold_, chroma_weight_,   adapt_threshold_};
-    preview_decoder_cache_.decoder =
-        make_decoder(effectiveDecoderType, decoderParams, safeVideoParams);
-  }
-
   std::vector<::ComponentFrame> outputFrames(1);
   const int32_t frameEndIndex = frameStartIndex + 2;
 
-  if (preview_decoder_cache_.decoder) {
-    preview_decoder_cache_.decoder->decodeFrames(inputFields, frameStartIndex,
-                                                 frameEndIndex, outputFrames);
-  }
+  preview_decoder_cache_.decoder->decodeFrames(inputFields, frameStartIndex,
+                                               frameEndIndex, outputFrames);
 
   ::ComponentFrame& frame = outputFrames[0];
   int32_t width = frame.getWidth();

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -1433,10 +1433,16 @@ bool VideoSinkStage::run_export_trigger(
     return false;
   }
 
-  const DecoderParams decoderParams{
-      chroma_gain_,         chroma_phase_,    luma_nr_,
-      chroma_nr_,           ntsc_phase_comp_, simple_pal_,
-      transform_threshold_, chroma_weight_,   adapt_threshold_};
+  DecoderParams decoderParams;
+  decoderParams.chromaGain = chroma_gain_;
+  decoderParams.chromaPhase = chroma_phase_;
+  decoderParams.lumaNr = luma_nr_;
+  decoderParams.chromaNr = chroma_nr_;
+  decoderParams.ntscPhaseComp = ntsc_phase_comp_;
+  decoderParams.simplePal = simple_pal_;
+  decoderParams.transformThreshold = transform_threshold_;
+  decoderParams.chromaWeight = chroma_weight_;
+  decoderParams.adaptThreshold = adapt_threshold_;
 
   std::unique_ptr<Decoder> decoder =
       make_decoder(decoder_type_, decoderParams, videoParams);
@@ -2258,10 +2264,16 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
     preview_decoder_cache_.chroma_weight = chroma_weight_;
     preview_decoder_cache_.adapt_threshold = adapt_threshold_;
 
-    const DecoderParams decoderParams{
-        chroma_gain_,         chroma_phase_,    luma_nr_,
-        chroma_nr_,           ntsc_phase_comp_, simple_pal_,
-        transform_threshold_, chroma_weight_,   adapt_threshold_};
+    DecoderParams decoderParams;
+    decoderParams.chromaGain = chroma_gain_;
+    decoderParams.chromaPhase = chroma_phase_;
+    decoderParams.lumaNr = luma_nr_;
+    decoderParams.chromaNr = chroma_nr_;
+    decoderParams.ntscPhaseComp = ntsc_phase_comp_;
+    decoderParams.simplePal = simple_pal_;
+    decoderParams.transformThreshold = transform_threshold_;
+    decoderParams.chromaWeight = chroma_weight_;
+    decoderParams.adaptThreshold = adapt_threshold_;
     preview_decoder_cache_.decoder =
         make_decoder(effectiveDecoderType, decoderParams, safeVideoParams);
   }

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -19,9 +19,12 @@
 
 #include "decoders/comb.h"
 #include "decoders/componentframe.h"
+#include "decoders/decoder.h"
 #include "decoders/monodecoder.h"
+#include "decoders/ntscdecoder.h"
 #include "decoders/outputwriter.h"
 #include "decoders/palcolour.h"
+#include "decoders/paldecoder.h"
 #include "decoders/sourcefield.h"
 #include "decoders/vectorscope_extract.h"
 #include "video_parameter_safety.h"
@@ -63,6 +66,85 @@ chroma_sink::DecoderVideoProfile decoder_video_profile_for_type(
   }
 
   return chroma_sink::DecoderVideoProfile::NtscColour;
+}
+
+// Decode parameters carried from the stage into the decoder factory, so the
+// factory does not reach back into VideoSinkStage.
+struct DecoderParams {
+  double chromaGain;
+  double chromaPhase;
+  double lumaNr;
+  double chromaNr;
+  bool ntscPhaseComp;
+  bool simplePal;
+  double transformThreshold;
+  double chromaWeight;
+  double adaptThreshold;
+};
+
+// Build the decoder for an already-resolved decoder_type (the caller has
+// applied any transform->pal2d downgrade for Y/C, which is stage policy).
+// The config fields set here match what the stage set when it drove the
+// filters directly, so output is unchanged.  Transform PAL creates FFTW plans
+// in configure(); callers constructing per-thread decoders must serialise this
+// behind fftwPlanMutex.
+std::unique_ptr<Decoder> make_decoder(const std::string& decoder_type,
+                                      const DecoderParams& params,
+                                      const SourceParameters& videoParameters) {
+  if (decoder_type == "mono") {
+    MonoDecoder::MonoConfiguration config;
+    config.yNRLevel = params.lumaNr;
+    config.filterChroma = false;
+    config.videoParameters = videoParameters;
+    return std::make_unique<MonoDecoder>(config);
+  }
+
+  if (decoder_type == "pal2d" || decoder_type == "transform2d" ||
+      decoder_type == "transform3d") {
+    PalColour::Configuration config;
+    config.chromaGain = params.chromaGain;
+    config.chromaPhase = params.chromaPhase;
+    config.yNRLevel = params.lumaNr;
+    config.simplePAL = params.simplePal;
+    config.transformThreshold = params.transformThreshold;
+    config.showFFTs = false;
+    if (decoder_type == "transform3d") {
+      config.chromaFilter = PalColour::transform3DFilter;
+    } else if (decoder_type == "transform2d") {
+      config.chromaFilter = PalColour::transform2DFilter;
+    } else {
+      config.chromaFilter = PalColour::palColourFilter;
+    }
+    auto decoder = std::make_unique<PalDecoder>(config);
+    decoder->configure(videoParameters);
+    return decoder;
+  }
+
+  Comb::Configuration config;
+  config.chromaGain = params.chromaGain;
+  config.chromaPhase = params.chromaPhase;
+  config.cNRLevel = params.chromaNr;
+  config.yNRLevel = params.lumaNr;
+  config.phaseCompensation = params.ntscPhaseComp;
+  config.chromaWeight = params.chromaWeight;
+  config.adaptThreshold = params.adaptThreshold;
+  config.showMap = false;
+  if (decoder_type == "ntsc1d") {
+    config.dimensions = 1;
+    config.adaptive = false;
+  } else if (decoder_type == "ntsc3d") {
+    config.dimensions = 3;
+    config.adaptive = true;
+  } else if (decoder_type == "ntsc3dnoadapt") {
+    config.dimensions = 3;
+    config.adaptive = false;
+  } else {
+    config.dimensions = 2;
+    config.adaptive = false;
+  }
+  auto decoder = std::make_unique<NtscDecoder>(config);
+  decoder->configure(videoParameters);
+  return decoder;
 }
 
 bool apply_decoder_safe_video_parameters(
@@ -1319,21 +1401,26 @@ bool VideoSinkStage::run_export_trigger(
   // Note: We'll use the decoder classes directly (synchronously)
   // without the threading infrastructure for now
 
-  std::unique_ptr<MonoDecoder> monoDecoder;
-  std::unique_ptr<MonoDecoder> ycMonoDecoder;
-  std::unique_ptr<PalColour> palDecoder;
-  std::unique_ptr<Comb> ntscDecoder;
-
   const bool is_yc_source = vfr->has_separate_channels();
   // PAL_M has NTSC-like frame geometry (525 lines, 909 samples/line); only
   // pure PAL uses the 625-line non-uniform layout.
   const bool isPal = (videoParams.system == orc::VideoSystem::PAL);
 
-  bool useMonoDecoder = (decoder_type_ == "mono");
-  bool usePalDecoder =
-      (decoder_type_ == "pal2d" || decoder_type_ == "transform2d" ||
-       decoder_type_ == "transform3d");
-  bool useNtscDecoder = (decoder_type_.find("ntsc") == 0);
+  // Transform PAL filters operate on composite chroma; a Y/C source has no
+  // composite chroma to filter, so fall back to pal2d.  Mutates decoder_type_
+  // (persistent stage state, surfaced in the parameter UI).
+  if (is_yc_source && (decoder_type_ == "transform2d" ||
+                       decoder_type_ == "transform3d")) {
+    ORC_LOG_ERROR(
+        "VideoSink: Transform PAL filters (transform2d/transform3d) are not "
+        "compatible with YC sources.");
+    ORC_LOG_ERROR(
+        "VideoSink: YC sources have already-separated Y and C channels and "
+        "do not need frequency-domain filtering.");
+    ORC_LOG_ERROR("VideoSink: Please use 'pal2d' or 'mono' decoder instead.");
+    ORC_LOG_ERROR("VideoSink: Falling back to 'pal2d' decoder for YC source.");
+    decoder_type_ = "pal2d";
+  }
 
   std::string parameter_error;
   const auto decoder_profile =
@@ -1346,107 +1433,21 @@ bool VideoSinkStage::run_export_trigger(
     return false;
   }
 
-  if (useMonoDecoder) {
-    MonoDecoder::MonoConfiguration config;
-    config.yNRLevel = luma_nr_;
-    config.filterChroma = false;  // Mono decoder doesn't need comb filtering
-    config.videoParameters = videoParams;
-    monoDecoder = std::make_unique<MonoDecoder>(config);
-    ORC_LOG_DEBUG("VideoSink: Using decoder: mono");
-  } else if (usePalDecoder) {
-    // Check if we're trying to use Transform PAL filters with YC sources
-    bool isTransformFilter =
-        (decoder_type_ == "transform2d" || decoder_type_ == "transform3d");
+  const DecoderParams decoderParams{chroma_gain_,   chroma_phase_,
+                                    luma_nr_,        chroma_nr_,
+                                    ntsc_phase_comp_, simple_pal_,
+                                    transform_threshold_, chroma_weight_,
+                                    adapt_threshold_};
 
-    if (is_yc_source && isTransformFilter) {
-      ORC_LOG_ERROR(
-          "VideoSink: Transform PAL filters (transform2d/transform3d) are not "
-          "compatible with YC sources.");
-      ORC_LOG_ERROR(
-          "VideoSink: YC sources have already-separated Y and C channels and "
-          "do not need frequency-domain filtering.");
-      ORC_LOG_ERROR("VideoSink: Please use 'pal2d' or 'mono' decoder instead.");
-      ORC_LOG_ERROR(
-          "VideoSink: Falling back to 'pal2d' decoder for YC source.");
-      // Override to pal2d for YC sources
-      decoder_type_ = "pal2d";
-    }
-
-    PalColour::Configuration config;
-    config.chromaGain = chroma_gain_;
-    config.chromaPhase = chroma_phase_;
-    config.yNRLevel = luma_nr_;
-    config.simplePAL = simple_pal_;
-    config.transformThreshold = transform_threshold_;
-    config.showFFTs = false;
-
-    // Set filter mode based on decoder type
-    std::string filterName;
-    if (decoder_type_ == "transform3d") {
-      config.chromaFilter = PalColour::transform3DFilter;
-      filterName = "transform3d";
-    } else if (decoder_type_ == "transform2d") {
-      config.chromaFilter = PalColour::transform2DFilter;
-      filterName = "transform2d";
-    } else if (decoder_type_ == "pal2d") {
-      // pal2d uses the basic PAL colour filter (default)
-      config.chromaFilter = PalColour::palColourFilter;
-      filterName = "pal2d";
-    } else {
-      config.chromaFilter = PalColour::palColourFilter;
-      filterName = "pal2d (default)";
-    }
-
-    palDecoder = std::make_unique<PalColour>();
-    palDecoder->updateConfiguration(videoParams, config);
-    ORC_LOG_DEBUG("VideoSink: Using decoder: {} (PAL)", filterName);
-  } else if (useNtscDecoder) {
-    Comb::Configuration config;
-    config.chromaGain = chroma_gain_;
-    config.chromaPhase = chroma_phase_;
-    config.cNRLevel = chroma_nr_;
-    config.yNRLevel = luma_nr_;
-    config.phaseCompensation = ntsc_phase_comp_;
-    config.chromaWeight = chroma_weight_;
-    config.adaptThreshold = adapt_threshold_;
-    config.showMap = false;
-
-    // Set dimensions based on decoder type
-    std::string decoderName;
-    if (decoder_type_ == "ntsc1d") {
-      config.dimensions = 1;
-      config.adaptive = false;
-      decoderName = "ntsc1d";
-    } else if (decoder_type_ == "ntsc3d") {
-      config.dimensions = 3;
-      config.adaptive = true;
-      decoderName = "ntsc3d";
-    } else if (decoder_type_ == "ntsc3dnoadapt") {
-      config.dimensions = 3;
-      config.adaptive = false;
-      decoderName = "ntsc3dnoadapt";
-    } else {
-      config.dimensions = 2;
-      config.adaptive = false;
-      decoderName = "ntsc2d";
-    }
-
-    ntscDecoder = std::make_unique<Comb>();
-    ntscDecoder->updateConfiguration(videoParams, config);
-    ORC_LOG_DEBUG("VideoSink: Using decoder: {} (NTSC)", decoderName);
-  } else {
+  std::unique_ptr<Decoder> decoder =
+      make_decoder(decoder_type_, decoderParams, videoParams);
+  if (!decoder) {
     ORC_LOG_ERROR("VideoSink: Unknown decoder type: {}", decoder_type_);
     trigger_status_ = "Error: Unknown decoder type";
     trigger_in_progress_.store(false);
     return false;
   }
-
-  if (is_yc_source && !useMonoDecoder) {
-    ycMonoDecoder = create_yc_mono_decoder(videoParams);
-    ORC_LOG_DEBUG(
-        "VideoSink: YC source dual-decode enabled (mono Y route + colour UV "
-        "route)");
-  }
+  ORC_LOG_DEBUG("VideoSink: Using decoder: {}", decoder_type_);
 
   // 5. Determine frame range to process.
   // Use the frame_range from VFrameR (may be filtered by upstream stages like
@@ -1475,43 +1476,15 @@ bool VideoSinkStage::run_export_trigger(
   // This relationship is consistent across both NTSC and PAL systems.
   // Frame N (1-based) consists of fields (2*N-2, 2*N-1) in 0-based indexing.
 
-  // 6. Determine decoder lookbehind/lookahead requirements.
-  // For YC dual-decode, this is always driven by the colour route decoder.
-  // The mono Y route is decoded over the same extended range only to keep
-  // frame/field indexing aligned for merge_luma_from().
-  const bool use_yc_dual_decode = (ycMonoDecoder != nullptr);
-  int32_t colourLookBehindFrames = 0;
-  int32_t colourLookAheadFrames = 0;
-
-  if (palDecoder) {
-    // PalColour internally uses Transform3D which needs lookbehind/lookahead
-    if (decoder_type_ == "transform3d" || decoder_type_ == "transform2d") {
-      // Design §8.7: VFrameR frame-based architecture; Transform3D returns 1
-      // frame of look-behind and 4 frames of look-ahead.
-      colourLookBehindFrames = (decoder_type_ == "transform3d") ? 1 : 0;
-      colourLookAheadFrames = (decoder_type_ == "transform3d") ? 4 : 0;
-    }
-  } else if (ntscDecoder) {
-    // NTSC 3D comb filters across the previous, current, and next frame
-    if (decoder_type_ == "ntsc3d" || decoder_type_ == "ntsc3dnoadapt") {
-      // Comb::Configuration::getLookBehind()/getLookAhead() both return 1 in
-      // 3D mode; decodeFramesComposite() never reads past one frame ahead.
-      colourLookBehindFrames = 1;
-      colourLookAheadFrames = 1;
-    }
-  }
-
-  int32_t lookBehindFrames = colourLookBehindFrames;
-  int32_t lookAheadFrames = colourLookAheadFrames;
+  // 6. Determine decoder lookbehind/lookahead requirements from the decoder
+  // itself.  For Y/C sources the wrapper decodes luma and chroma over the same
+  // range internally, so a single look-around covers both.
+  int32_t lookBehindFrames = decoder->getLookBehind();
+  int32_t lookAheadFrames = decoder->getLookAhead();
 
   ORC_LOG_DEBUG(
       "VideoSink: Decoder requires lookBehind={} frames, lookAhead={} frames",
       lookBehindFrames, lookAheadFrames);
-  if (use_yc_dual_decode) {
-    ORC_LOG_DEBUG(
-        "VideoSink: YC dual decode lookaround is colour-route driven; Y-route "
-        "reuses the same extended range for alignment");
-  }
 
   // 7. Calculate extended frame range including lookbehind/lookahead
   // Note: extended_start_frame can be negative (will use black padding)
@@ -1692,78 +1665,14 @@ bool VideoSinkStage::run_export_trigger(
   // We must serialize all decoder instantiations that create FFTW plans
   std::mutex fftwPlanMutex;
 
-  // Worker thread function - each worker creates its own decoder instance
+  // Worker thread function - each worker creates its own decoder instance.
   auto workerFunc = [&]() {
-    // Create thread-local decoder instance
-    std::unique_ptr<MonoDecoder> threadMonoDecoder;
-    std::unique_ptr<MonoDecoder> threadYcMonoDecoder;
-    std::unique_ptr<PalColour> threadPalDecoder;
-    std::unique_ptr<Comb> threadNtscDecoder;
-
-    if (monoDecoder) {
-      // Clone configuration from main decoder
-      MonoDecoder::MonoConfiguration config;
-      config.yNRLevel = luma_nr_;
-      config.filterChroma = false;
-      config.videoParameters = videoParams;
-      threadMonoDecoder = std::make_unique<MonoDecoder>(config);
-    } else if (palDecoder) {
-      // Clone configuration from main decoder
-      PalColour::Configuration config;
-      config.chromaGain = chroma_gain_;
-      config.chromaPhase = chroma_phase_;
-      config.yNRLevel = luma_nr_;
-      config.simplePAL = simple_pal_;
-      config.transformThreshold = transform_threshold_;
-      config.showFFTs = false;
-
-      if (decoder_type_ == "transform3d") {
-        config.chromaFilter = PalColour::transform3DFilter;
-      } else if (decoder_type_ == "transform2d") {
-        config.chromaFilter = PalColour::transform2DFilter;
-      } else {
-        config.chromaFilter = PalColour::palColourFilter;
-      }
-
-      // CRITICAL: Protect FFTW plan creation (Transform PAL uses FFTW_MEASURE
-      // which is not thread-safe)
-      {
-        std::lock_guard<std::mutex> lock(fftwPlanMutex);
-        threadPalDecoder = std::make_unique<PalColour>();
-        threadPalDecoder->updateConfiguration(videoParams, config);
-      }
-    } else if (ntscDecoder) {
-      // Clone configuration from main decoder
-      Comb::Configuration config;
-      config.chromaGain = chroma_gain_;
-      config.chromaPhase = chroma_phase_;
-      config.cNRLevel = chroma_nr_;
-      config.yNRLevel = luma_nr_;
-      config.phaseCompensation = ntsc_phase_comp_;
-      config.chromaWeight = chroma_weight_;
-      config.adaptThreshold = adapt_threshold_;
-      config.showMap = false;
-
-      if (decoder_type_ == "ntsc1d") {
-        config.dimensions = 1;
-        config.adaptive = false;
-      } else if (decoder_type_ == "ntsc3d") {
-        config.dimensions = 3;
-        config.adaptive = true;
-      } else if (decoder_type_ == "ntsc3dnoadapt") {
-        config.dimensions = 3;
-        config.adaptive = false;
-      } else {
-        config.dimensions = 2;
-        config.adaptive = false;
-      }
-
-      threadNtscDecoder = std::make_unique<Comb>();
-      threadNtscDecoder->updateConfiguration(videoParams, config);
-    }
-
-    if (ycMonoDecoder) {
-      threadYcMonoDecoder = create_yc_mono_decoder(videoParams);
+    // Transform PAL builds FFTW plans in the factory (FFTW_MEASURE is not
+    // thread-safe), so serialise construction across workers.
+    std::unique_ptr<Decoder> threadDecoder;
+    {
+      std::lock_guard<std::mutex> lock(fftwPlanMutex);
+      threadDecoder = make_decoder(decoder_type_, decoderParams, videoParams);
     }
 
     while (!abortFlag) {
@@ -1929,63 +1838,10 @@ bool VideoSinkStage::run_export_trigger(
       std::vector<::ComponentFrame> singleOutput;
       singleOutput.resize(1);
 
-      // Decode this ONE frame using thread-local decoder
-      if (threadYcMonoDecoder) {
-        std::vector<SourceField> ycYFields;
-        std::vector<SourceField> ycCFields;
-        ycYFields.reserve(frameFields.size());
-        ycCFields.reserve(frameFields.size());
-
-        for (const auto& field : frameFields) {
-          // Y-route: composite view of luma channel only
-          SourceField yField = field;
-          yField.is_yc = false;
-          yField.data = field.luma_data;
-          yField.luma_data = nullptr;
-          yField.chroma_data = nullptr;
-          yField.line_ptrs = field.luma_line_ptrs;
-          yField.luma_line_ptrs.clear();
-          yField.chroma_line_ptrs.clear();
-          ycYFields.push_back(std::move(yField));
-
-          // C-route: composite view of chroma channel only
-          SourceField cField = field;
-          cField.is_yc = false;
-          cField.data = field.chroma_data;
-          cField.luma_data = nullptr;
-          cField.chroma_data = nullptr;
-          cField.line_ptrs = field.chroma_line_ptrs;
-          cField.luma_line_ptrs.clear();
-          cField.chroma_line_ptrs.clear();
-          ycCFields.push_back(std::move(cField));
-        }
-
-        std::vector<::ComponentFrame> yFrames(1);
-        std::vector<::ComponentFrame> uvFrames(1);
-
-        threadYcMonoDecoder->decodeFrames(ycYFields, frameStartIndex,
-                                          frameEndIndex, yFrames);
-
-        if (threadPalDecoder) {
-          threadPalDecoder->decodeFrames(ycCFields, frameStartIndex,
-                                         frameEndIndex, uvFrames);
-        } else if (threadNtscDecoder) {
-          threadNtscDecoder->decodeFrames(ycCFields, frameStartIndex,
-                                          frameEndIndex, uvFrames);
-        }
-
-        uvFrames[0].merge_luma_from(yFrames[0]);
-        singleOutput[0] = std::move(uvFrames[0]);
-      } else if (threadMonoDecoder) {
-        threadMonoDecoder->decodeFrames(frameFields, frameStartIndex,
-                                        frameEndIndex, singleOutput);
-      } else if (threadPalDecoder) {
-        threadPalDecoder->decodeFrames(frameFields, frameStartIndex,
-                                       frameEndIndex, singleOutput);
-      } else if (threadNtscDecoder) {
-        threadNtscDecoder->decodeFrames(frameFields, frameStartIndex,
-                                        frameEndIndex, singleOutput);
-      }
+      // Decode this ONE frame using the thread-local decoder.  Y/C splitting
+      // and luma merge happen inside the decoder for Y/C sources.
+      threadDecoder->decodeFrames(frameFields, frameStartIndex, frameEndIndex,
+                                  singleOutput);
 
       // Store the result in the buffer
       {

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -88,6 +88,10 @@ struct DecoderParams {
 // filters directly, so output is unchanged.  Transform PAL creates FFTW plans
 // in configure(); callers constructing per-thread decoders must serialise this
 // behind fftwPlanMutex.
+//
+// Returns nullptr for an unrecognized decoder_type, or when the decoder rejects
+// the source (e.g. a PAL source with an ntsc type), so the caller can abort
+// instead of exporting garbage or black frames.
 std::unique_ptr<Decoder> make_decoder(const std::string& decoder_type,
                                       const DecoderParams& params,
                                       const SourceParameters& videoParameters) {
@@ -116,35 +120,40 @@ std::unique_ptr<Decoder> make_decoder(const std::string& decoder_type,
       config.chromaFilter = PalColour::palColourFilter;
     }
     auto decoder = std::make_unique<PalDecoder>(config);
-    decoder->configure(videoParameters);
-    return decoder;
+    return decoder->configure(videoParameters) ? std::move(decoder) : nullptr;
   }
 
-  Comb::Configuration config;
-  config.chromaGain = params.chromaGain;
-  config.chromaPhase = params.chromaPhase;
-  config.cNRLevel = params.chromaNr;
-  config.yNRLevel = params.lumaNr;
-  config.phaseCompensation = params.ntscPhaseComp;
-  config.chromaWeight = params.chromaWeight;
-  config.adaptThreshold = params.adaptThreshold;
-  config.showMap = false;
-  if (decoder_type == "ntsc1d") {
-    config.dimensions = 1;
-    config.adaptive = false;
-  } else if (decoder_type == "ntsc3d") {
-    config.dimensions = 3;
-    config.adaptive = true;
-  } else if (decoder_type == "ntsc3dnoadapt") {
-    config.dimensions = 3;
-    config.adaptive = false;
-  } else {
-    config.dimensions = 2;
-    config.adaptive = false;
+  if (decoder_type == "ntsc1d" || decoder_type == "ntsc2d" ||
+      decoder_type == "ntsc3d" || decoder_type == "ntsc3dnoadapt") {
+    Comb::Configuration config;
+    config.chromaGain = params.chromaGain;
+    config.chromaPhase = params.chromaPhase;
+    config.cNRLevel = params.chromaNr;
+    config.yNRLevel = params.lumaNr;
+    config.phaseCompensation = params.ntscPhaseComp;
+    config.chromaWeight = params.chromaWeight;
+    config.adaptThreshold = params.adaptThreshold;
+    config.showMap = false;
+    if (decoder_type == "ntsc1d") {
+      config.dimensions = 1;
+      config.adaptive = false;
+    } else if (decoder_type == "ntsc3d") {
+      config.dimensions = 3;
+      config.adaptive = true;
+    } else if (decoder_type == "ntsc3dnoadapt") {
+      config.dimensions = 3;
+      config.adaptive = false;
+    } else {
+      config.dimensions = 2;
+      config.adaptive = false;
+    }
+    auto decoder = std::make_unique<NtscDecoder>(config);
+    return decoder->configure(videoParameters) ? std::move(decoder) : nullptr;
   }
-  auto decoder = std::make_unique<NtscDecoder>(config);
-  decoder->configure(videoParameters);
-  return decoder;
+
+  // Unknown decoder type: return nullptr so the caller's null check aborts the
+  // export rather than silently decoding as NTSC 2D.
+  return nullptr;
 }
 
 bool apply_decoder_safe_video_parameters(

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -100,7 +100,8 @@ std::unique_ptr<Decoder> make_decoder(const std::string& decoder_type,
     config.yNRLevel = params.lumaNr;
     config.filterChroma = false;
     config.videoParameters = videoParameters;
-    return std::make_unique<MonoDecoder>(config);
+    auto decoder = std::make_unique<MonoDecoder>(config);
+    return decoder->configure(videoParameters) ? std::move(decoder) : nullptr;
   }
 
   if (decoder_type == "pal2d" || decoder_type == "transform2d" ||

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -221,15 +221,6 @@ VideoSinkStage::VideoSinkStage()
 
 VideoSinkStage::~VideoSinkStage() {}
 
-std::unique_ptr<MonoDecoder> VideoSinkStage::create_yc_mono_decoder(
-    const orc::SourceParameters& videoParams) const {
-  MonoDecoder::MonoConfiguration config;
-  config.yNRLevel = luma_nr_;
-  config.filterChroma = false;  // Luma-only input contains no chroma to filter.
-  config.videoParameters = videoParams;
-  return std::make_unique<MonoDecoder>(config);
-}
-
 NodeTypeInfo VideoSinkStage::get_node_type_info() const {
   return NodeTypeInfo{
       NodeType::SINK,
@@ -1409,8 +1400,8 @@ bool VideoSinkStage::run_export_trigger(
   // Transform PAL filters operate on composite chroma; a Y/C source has no
   // composite chroma to filter, so fall back to pal2d.  Mutates decoder_type_
   // (persistent stage state, surfaced in the parameter UI).
-  if (is_yc_source && (decoder_type_ == "transform2d" ||
-                       decoder_type_ == "transform3d")) {
+  if (is_yc_source &&
+      (decoder_type_ == "transform2d" || decoder_type_ == "transform3d")) {
     ORC_LOG_ERROR(
         "VideoSink: Transform PAL filters (transform2d/transform3d) are not "
         "compatible with YC sources.");
@@ -1433,11 +1424,10 @@ bool VideoSinkStage::run_export_trigger(
     return false;
   }
 
-  const DecoderParams decoderParams{chroma_gain_,   chroma_phase_,
-                                    luma_nr_,        chroma_nr_,
-                                    ntsc_phase_comp_, simple_pal_,
-                                    transform_threshold_, chroma_weight_,
-                                    adapt_threshold_};
+  const DecoderParams decoderParams{
+      chroma_gain_,         chroma_phase_,    luma_nr_,
+      chroma_nr_,           ntsc_phase_comp_, simple_pal_,
+      transform_threshold_, chroma_weight_,   adapt_threshold_};
 
   std::unique_ptr<Decoder> decoder =
       make_decoder(decoder_type_, decoderParams, videoParams);
@@ -2351,10 +2341,7 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
           effectiveDecoderType, chroma_gain_, chroma_phase_, luma_nr_,
           chroma_nr_, ntsc_phase_comp_, simple_pal_, false,
           transform_threshold_, chroma_weight_, adapt_threshold_)) {
-    preview_decoder_cache_.mono_decoder.reset();
-    preview_decoder_cache_.yc_mono_decoder.reset();
-    preview_decoder_cache_.pal_decoder.reset();
-    preview_decoder_cache_.ntsc_decoder.reset();
+    preview_decoder_cache_.decoder.reset();
     preview_decoder_cache_.decoder_type = effectiveDecoderType;
     preview_decoder_cache_.chroma_gain = chroma_gain_;
     preview_decoder_cache_.chroma_phase = chroma_phase_;
@@ -2367,129 +2354,20 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
     preview_decoder_cache_.chroma_weight = chroma_weight_;
     preview_decoder_cache_.adapt_threshold = adapt_threshold_;
 
-    if (effectiveDecoderType == "mono") {
-      MonoDecoder::MonoConfiguration config;
-      config.yNRLevel = luma_nr_;
-      config.filterChroma = false;
-      config.videoParameters = safeVideoParams;
-      preview_decoder_cache_.mono_decoder =
-          std::make_unique<MonoDecoder>(config);
-    } else if (effectiveDecoderType == "pal2d" ||
-               effectiveDecoderType == "transform2d" ||
-               effectiveDecoderType == "transform3d") {
-      PalColour::Configuration config;
-      config.chromaGain = chroma_gain_;
-      config.chromaPhase = chroma_phase_;
-      config.yNRLevel = luma_nr_;
-      config.simplePAL = simple_pal_;
-      config.transformThreshold = transform_threshold_;
-      config.showFFTs = false;
-
-      if (effectiveDecoderType == "transform3d") {
-        config.chromaFilter = PalColour::transform3DFilter;
-      } else if (effectiveDecoderType == "transform2d") {
-        config.chromaFilter = PalColour::transform2DFilter;
-      } else {
-        config.chromaFilter = PalColour::palColourFilter;
-      }
-
-      preview_decoder_cache_.pal_decoder = std::make_unique<PalColour>();
-      preview_decoder_cache_.pal_decoder->updateConfiguration(safeVideoParams,
-                                                              config);
-    } else {
-      Comb::Configuration config;
-      config.chromaGain = chroma_gain_;
-      config.chromaPhase = chroma_phase_;
-      config.cNRLevel = chroma_nr_;
-      config.yNRLevel = luma_nr_;
-      config.phaseCompensation = ntsc_phase_comp_;
-      config.chromaWeight = chroma_weight_;
-      config.adaptThreshold = adapt_threshold_;
-      config.showMap = false;
-
-      if (effectiveDecoderType == "ntsc1d") {
-        config.dimensions = 1;
-        config.adaptive = false;
-      } else if (effectiveDecoderType == "ntsc3d") {
-        config.dimensions = 3;
-        config.adaptive = true;
-      } else if (effectiveDecoderType == "ntsc3dnoadapt") {
-        config.dimensions = 3;
-        config.adaptive = false;
-      } else {
-        config.dimensions = 2;
-        config.adaptive = false;
-      }
-
-      preview_decoder_cache_.ntsc_decoder = std::make_unique<Comb>();
-      preview_decoder_cache_.ntsc_decoder->updateConfiguration(safeVideoParams,
-                                                               config);
-    }
-
-    if (is_yc_source && effectiveDecoderType != "mono") {
-      preview_decoder_cache_.yc_mono_decoder =
-          create_yc_mono_decoder(safeVideoParams);
-    }
+    const DecoderParams decoderParams{
+        chroma_gain_,         chroma_phase_,    luma_nr_,
+        chroma_nr_,           ntsc_phase_comp_, simple_pal_,
+        transform_threshold_, chroma_weight_,   adapt_threshold_};
+    preview_decoder_cache_.decoder =
+        make_decoder(effectiveDecoderType, decoderParams, safeVideoParams);
   }
 
   std::vector<::ComponentFrame> outputFrames(1);
   const int32_t frameEndIndex = frameStartIndex + 2;
 
-  if (preview_decoder_cache_.yc_mono_decoder) {
-    std::vector<SourceField> ycYFields;
-    std::vector<SourceField> ycCFields;
-    ycYFields.reserve(inputFields.size());
-    ycCFields.reserve(inputFields.size());
-
-    for (const auto& field : inputFields) {
-      SourceField yField = field;
-      yField.is_yc = false;
-      yField.data = field.luma_data;
-      yField.luma_data = nullptr;
-      yField.chroma_data = nullptr;
-      yField.line_ptrs = field.luma_line_ptrs;
-      yField.luma_line_ptrs.clear();
-      yField.chroma_line_ptrs.clear();
-      ycYFields.push_back(std::move(yField));
-
-      SourceField cField = field;
-      cField.is_yc = false;
-      cField.data = field.chroma_data;
-      cField.luma_data = nullptr;
-      cField.chroma_data = nullptr;
-      cField.line_ptrs = field.chroma_line_ptrs;
-      cField.luma_line_ptrs.clear();
-      cField.chroma_line_ptrs.clear();
-      ycCFields.push_back(std::move(cField));
-    }
-
-    std::vector<::ComponentFrame> yFrames(1);
-    std::vector<::ComponentFrame> uvFrames(1);
-
-    preview_decoder_cache_.yc_mono_decoder->decodeFrames(
-        ycYFields, frameStartIndex, frameEndIndex, yFrames);
-
-    if (preview_decoder_cache_.pal_decoder) {
-      preview_decoder_cache_.pal_decoder->decodeFrames(
-          ycCFields, frameStartIndex, frameEndIndex, uvFrames);
-    } else if (preview_decoder_cache_.ntsc_decoder) {
-      preview_decoder_cache_.ntsc_decoder->decodeFrames(
-          ycCFields, frameStartIndex, frameEndIndex, uvFrames);
-    } else {
-      uvFrames[0] = yFrames[0];
-    }
-
-    uvFrames[0].merge_luma_from(yFrames[0]);
-    outputFrames[0] = std::move(uvFrames[0]);
-  } else if (preview_decoder_cache_.mono_decoder) {
-    preview_decoder_cache_.mono_decoder->decodeFrames(
-        inputFields, frameStartIndex, frameEndIndex, outputFrames);
-  } else if (preview_decoder_cache_.pal_decoder) {
-    preview_decoder_cache_.pal_decoder->decodeFrames(
-        inputFields, frameStartIndex, frameEndIndex, outputFrames);
-  } else if (preview_decoder_cache_.ntsc_decoder) {
-    preview_decoder_cache_.ntsc_decoder->decodeFrames(
-        inputFields, frameStartIndex, frameEndIndex, outputFrames);
+  if (preview_decoder_cache_.decoder) {
+    preview_decoder_cache_.decoder->decodeFrames(inputFields, frameStartIndex,
+                                                 frameEndIndex, outputFrames);
   }
 
   ::ComponentFrame& frame = outputFrames[0];

--- a/orc/plugins/stages/sinks/common/video_sink_stage.h
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.h
@@ -38,9 +38,6 @@
 struct SourceField;
 class Decoder;
 class ComponentFrame;
-class MonoDecoder;
-class PalColour;
-class Comb;
 
 namespace orc {
 
@@ -180,40 +177,19 @@ class VideoSinkStage : public DAGStage,
     double chroma_weight;
     double adapt_threshold;
 
-    std::unique_ptr<MonoDecoder> mono_decoder;
-    std::unique_ptr<MonoDecoder> yc_mono_decoder;
-    std::unique_ptr<PalColour> pal_decoder;
-    std::unique_ptr<Comb> ntsc_decoder;
+    std::unique_ptr<Decoder> decoder;
 
     bool matches_config(const std::string& dec_type, double cg, double cp,
                         double ln, double cn, bool npc, bool sp, bool bw,
                         double tt, double cw, double at) const {
-      bool config_matches = decoder_type == dec_type && chroma_gain == cg &&
-                            chroma_phase == cp && luma_nr == ln &&
-                            chroma_nr == cn && ntsc_phase_comp == npc &&
-                            simple_pal == sp && blackandwhite == bw &&
-                            transform_threshold == tt && chroma_weight == cw &&
-                            adapt_threshold == at;
-
-      if (!config_matches) {
-        return false;
-      }
-
-      // Keep cache validity strict by ensuring the active decoder pointer shape
-      // matches the requested decoder type.
-      if (dec_type == "mono") {
-        return mono_decoder != nullptr && pal_decoder == nullptr &&
-               ntsc_decoder == nullptr && yc_mono_decoder == nullptr;
-      }
-
-      if (dec_type == "pal2d" || dec_type == "transform2d" ||
-          dec_type == "transform3d") {
-        return mono_decoder == nullptr && pal_decoder != nullptr &&
-               ntsc_decoder == nullptr;
-      }
-
-      return mono_decoder == nullptr && pal_decoder == nullptr &&
-             ntsc_decoder != nullptr;
+      // decoder_type is part of this comparison, so a type change already
+      // invalidates the cache; a single built decoder needs no pointer-shape
+      // check beyond being present.
+      return decoder != nullptr && decoder_type == dec_type &&
+             chroma_gain == cg && chroma_phase == cp && luma_nr == ln &&
+             chroma_nr == cn && ntsc_phase_comp == npc && simple_pal == sp &&
+             blackandwhite == bw && transform_threshold == tt &&
+             chroma_weight == cw && adapt_threshold == at;
     }
   };
   mutable PreviewDecoderCache preview_decoder_cache_;
@@ -270,9 +246,6 @@ class VideoSinkStage : public DAGStage,
       const std::vector<ArtifactPtr>& inputs,
       const std::map<std::string, ParameterValue>& parameters,
       IObservationContext& observation_context);
-
-  std::unique_ptr<MonoDecoder> create_yc_mono_decoder(
-      const orc::SourceParameters& videoParams) const;
 
   // Helper methods for integration
 


### PR DESCRIPTION
## Summary

**VideoSinkStage** constructed **PalColour**, **Comb**, and **MonoDecoder** directly and dispatched to them through a four-way if-chain that was duplicated across the trigger, worker, and preview paths, with the separate-Y/C split-decode-merge open-coded at each call site. This made adding or swapping a decoder a matter of editing several parallel switches inside the sink.

This PR routes all decoding through the existing **Decoder** interface. The **PalDecoder**/**NtscDecoder** wrappers - previously present but abstract and unused - now implement **decodeFrames()** and own the Y/C luma route internally, so the sink holds a single **unique_ptr<Decoder>** built by one **make_decoder()** factory. Decoder construction now happens in exactly one place. The change is behavior-preserving; output is unchanged.

- Complete the wrappers - **PalDecoder**/**NtscDecoder** implement **decodeFrames()**, own their decoder, and route separate Y/C through a mono luma decoder plus the colour decoder. **configure()** invalidates the decoder up front so a failed reconfigure can't decode with stale settings. The **decodeFrames()** interface is documented on the base.
- Render path → **make_decoder()** factory; the four-way dispatch and inline Y/C split collapse to a single **decoder->decodeFrames()** call. Look-around comes from the decoder (**getLookBehind()**/**getLookAhead()**) instead of hardcoded per-type values.
- Preview path → the same factory; **PreviewDecoderCache**'s four typed pointers become one **unique_ptr<Decoder>. create_yc_mono_decoder** and now-dead forward declarations removed.

Net −90 lines of production code (excluding tests). 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Other

## Validation

All changes are verified by deterministic in-memory unit tests. Synthetic **SourceField**s are fed directly to the decoders and the output planes are asserted. The full sinks suite passes.

- Interface conformance - the wrapper tests instantiate **PalDecoder**/**NtscDecoder** directly, so the suite compiling at all confirms **decodeFrames()** is implemented (the classes were previously abstract). Covers system accept/reject, look-around, and invalid-geometry rejection.
- Decode paths - composite input reaches the underlying decoder; separate Y/C input preserves luma through split-decode-merge, for both PAL and NTSC.
- Behavior preservation (the refactor) - dedicated tests assert the wrapper's internal Y/C handling is identical to decoding luma and chroma separately and merging, across all Y/U/V planes. The composite path is covered by the pre-existing sink tests, which continue to pass.
- Guard against stale configuration - a failed reconfigure must invalidate the decoder rather than decode with the previous system's settings; this test fails when the guard is removed.

## Checklist

- [X] Scope is focused and minimal
- [X] Build passes locally
- [ ] Related docs were updated if needed
- [ ] Linked issue (if applicable)
