### PR TITLE
Add a filtergraph to the CLI

### DIFF
--- a/docs/cli-user-guide/overview.md
+++ b/docs/cli-user-guide/overview.md
@@ -32,6 +32,11 @@ orc-cli <project-file> [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--process` | Process the complete DAG pipeline (trigger all sink nodes) | Required |
+| `--filter GRAPH` | Build and process a DAG from an ffmpeg-style filtergraph string (no `.orcprj` file) | - |
+| `--filter-file FILE` | Read the filtergraph from `FILE` (`-` for stdin) | - |
+| `--input GRAPH` | Input (source) stage(s), for the input/filters/output triad | - |
+| `--filters GRAPH` | Processing stage(s), for the triad | - |
+| `--output GRAPH` | Output (sink) stage(s), for the triad | - |
 | `--log-level LEVEL` | Set logging verbosity level | `info` |
 | `--log-file FILE` | Write logs to specified file | None (console only) |
 | `--help`, `-h` | Display help message and exit | - |
@@ -81,6 +86,87 @@ Process with debug logging saved to file:
 ```bash
 orc-cli my-project.orcprj --process --log-level debug --log-file debug.log
 ```
+
+## Filtergraph Mode
+
+As an alternative to authoring a `.orcprj` file, a linear decode pipeline can
+be described directly on the command line. This builds the same in-memory DAG
+a `.orcprj` file would and triggers all sink nodes, so results are identical.
+The `.orcprj` workflow itself is unchanged.
+
+Video format (NTSC/PAL/PAL-M) and source signal type (composite/Y-C) are
+**never specified separately** — they are detected automatically from the
+stage modules used (a stage that is exclusively NTSC-compatible implies NTSC;
+supplying `y_path`/`c_path` implies Y/C; supplying `input_path` implies
+composite). If two stages imply conflicting formats, that is reported as an
+error before anything runs.
+
+### Style 1: a single filtergraph string (`--filter`)
+
+```
+stage_name=key=value:key=value, stage_name=key=value
+```
+
+- **Stages** are separated by `,` and are auto-connected in order.
+- **Values** may be wrapped in single quotes (`'...'`) **or** double quotes
+  (`"..."`) — whichever is more convenient for your shell — to include `:`
+  `,` `;` and spaces literally; the two quote styles are interchangeable, and
+  a value quoted with one may freely contain the other. A value may also be
+  escaped with a backslash (`\`) instead of quoting, and may itself contain
+  `=`.
+
+```bash
+orc-cli --filter "tbc_source=input_path=capture.tbc, hvd_chroma_decoder, video_sink=output_path=capture.mp4"
+```
+
+Reading the graph from a file or standard input:
+
+```bash
+orc-cli --filter-file graph.txt
+cat graph.txt | orc-cli --filter-file -
+```
+
+### Style 2: the input/filters/output triad
+
+For the common case — one input, a chain of processing stages, one output —
+`--input`, `--filters`, and `--output` avoid needing to know the full
+filtergraph grammar, and they enforce that stages go where they belong:
+**every stage named in `--input` must be a source, every stage in `--output`
+must be a sink, and every stage in `--filters` must be neither** (a transform
+or similar processing stage). Putting a sink in `--input`, for example, is
+rejected with a clear error naming the correct flag — this is checked against
+each stage's real role (the same metadata the GUI uses), not guessed from its
+name, so it works for any third-party plugin stage too.
+
+```bash
+orc-cli \
+  --input "tbc_source=input_path=capture.tbc" \
+  --filters "hvd_chroma_decoder" \
+  --output "video_sink=output_path=capture.mp4"
+```
+
+Any of the three may be omitted, and each may itself contain a
+comma-separated chain of stages. `--input`/`--filters`/`--output` cannot be
+combined with `--filter`/`--filter-file` in the same run — pick one style.
+
+### Windows paths
+
+Unquoted Windows paths (drive letters and backslashes) are parsed correctly
+in both styles above:
+
+```bash
+orc-cli --input "tbc_source=input_path=C:\Users\me\capture.tbc" --output video_sink
+```
+
+If a value needs to rule out any ambiguity — for instance it contains a
+literal comma or semicolon — wrap it in single **or** double quotes,
+whichever your shell passes through more conveniently.
+
+### Non-linear graphs
+
+Anything with real shape — fan-in (multiple sources into one stage), fan-out
+(one stage into several sinks), or branching — is not expressible this way by
+design, and remains a `.orcprj` project file.
 
 ## Processing Workflow
 
@@ -230,6 +316,32 @@ Error: No command specified. You must use --process
 Failed to load project: <reason>
 ```
 → Check project file syntax and input file paths
+
+**Filtergraph parse error:**
+```
+Failed to parse filtergraph: <reason> (at offset N)
+```
+→ Check the filtergraph syntax near character `N`; quote values containing
+`:` `,` `;` or spaces (single or double quotes both work)
+
+**Unknown stage:**
+```
+Unknown stage '<name>'.
+```
+→ Use a stage name that exists in your build
+
+**Stage used in the wrong triad category:**
+```
+--input: stage 'video_sink' (Video Sink) is an output (sink) stage — it
+belongs under --output, not --input.
+```
+→ Move the stage to the flag matching its actual role
+
+**Missing required parameter:**
+```
+Stage '<name>': missing required parameter '<param>'.
+```
+→ Supply the parameter
 
 ### Crash Diagnostics
 

--- a/docs/cli-user-guide/overview.md
+++ b/docs/cli-user-guide/overview.md
@@ -36,8 +36,8 @@ orc-cli <project-file> [options]
 | `--filters GRAPH`, `-f GRAPH` | Processing stage(s), for the triad | - |
 | `--sink GRAPH`, `-o GRAPH` | Output (sink) stage(s), for the triad | - |
 | `--export-project FILE` | Save the assembled filtergraph as a `.orcprj` file instead of running it | - |
-| `--video-format NTSC\|PAL\|PAL-M` | Export-only override, only needed if no stage implies a video format | - |
-| `--source-type composite\|yc` | Export-only override, only needed if no stage implies a source signal type | - |
+| `--video-format NTSC\|PAL\|PAL-M` | Set the video format if no stage implies one (works when running directly too, but only `--export-project` requires it) | - |
+| `--source-type composite\|yc` | Same idea, for the source signal type | - |
 | `--log-level LEVEL` | Set logging verbosity level | `info` |
 | `--log-file FILE` | Write logs to specified file | None (console only) |
 | `--help`, `-h` | Display help message and exit | - |
@@ -191,15 +191,20 @@ A saved `.orcprj` file requires an explicit video format *and* source signal
 type — unlike running in memory, which tolerates either being undetermined.
 If no stage implies one (a format-agnostic source like `tbc_source` reads
 its own format from its metadata sidecar file rather than implying one),
-`--video-format` and/or `--source-type` set them for the export:
+`--video-format` and/or `--source-type` set them explicitly:
 
 ```bash
 orc-cli --source "tbc_source=input_path=capture.tbc" --sink video_sink \
   --export-project capture.orcprj --video-format NTSC --source-type composite
 ```
 
-`--video-format` and `--source-type` are only meaningful together with
-`--export-project`; they have no effect on running the pipeline directly.
+`--video-format`/`--source-type` also work without `--export-project` — set
+them when running a graph directly and no stage implies a format, and the
+graph gets the same format-specific parameter defaults it would after being
+exported and reprocessed with `--process`, rather than only the
+exported/reprocessed path ever getting a concrete value. `--export-project`
+is the only thing that actually *requires* one, since it's the `.orcprj`
+file format itself that demands an explicit value, not the pipeline.
 
 ### Discovering stages and their parameters
 
@@ -389,9 +394,8 @@ Stage '<name>': missing required parameter '<param>'.
 **Cannot export — no video format:**
 ```
 Cannot export: none of the stages used imply a video format (NTSC/PAL/PAL-M),
-so the saved project would fail to reload. Pass --video-format NTSC|PAL|PAL-M
-to set it explicitly for the export, or run the pipeline directly instead of
-exporting.
+so the saved project would fail to reload. Pass --video-format NTSC|PAL|PAL-M,
+or run the pipeline directly instead of exporting.
 ```
 → Add `--video-format`, or add a format-specific source stage to the graph
 
@@ -399,8 +403,8 @@ exporting.
 ```
 Cannot export: none of the stages used imply a source signal type
 (composite/Y-C), so the saved project would fail to reload. Pass
---source-type composite|yc to set it explicitly for the export, or run the
-pipeline directly instead of exporting.
+--source-type composite|yc, or run the pipeline directly instead of
+exporting.
 ```
 → Add `--source-type`, or ensure a source stage's parameters reveal its
 signal type (`y_path`+`c_path`, or `input_path`)

--- a/docs/cli-user-guide/overview.md
+++ b/docs/cli-user-guide/overview.md
@@ -32,11 +32,12 @@ orc-cli <project-file> [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--process` | Process the complete DAG pipeline (trigger all sink nodes) | Required |
-| `--filter GRAPH` | Build and process a DAG from an ffmpeg-style filtergraph string (no `.orcprj` file) | - |
-| `--filter-file FILE` | Read the filtergraph from `FILE` (`-` for stdin) | - |
-| `--input GRAPH` | Input (source) stage(s), for the input/filters/output triad | - |
-| `--filters GRAPH` | Processing stage(s), for the triad | - |
-| `--output GRAPH` | Output (sink) stage(s), for the triad | - |
+| `--source GRAPH`, `-i GRAPH` | Input (source) stage(s), for the source/filters/sink triad | - |
+| `--filters GRAPH`, `-f GRAPH` | Processing stage(s), for the triad | - |
+| `--sink GRAPH`, `-o GRAPH` | Output (sink) stage(s), for the triad | - |
+| `--export-project FILE` | Save the assembled filtergraph as a `.orcprj` file instead of running it | - |
+| `--video-format NTSC\|PAL\|PAL-M` | Export-only override, only needed if no stage implies a video format | - |
+| `--source-type composite\|yc` | Export-only override, only needed if no stage implies a source signal type | - |
 | `--log-level LEVEL` | Set logging verbosity level | `info` |
 | `--log-file FILE` | Write logs to specified file | None (console only) |
 | `--help`, `-h` | Display help message and exit | - |
@@ -89,25 +90,41 @@ orc-cli my-project.orcprj --process --log-level debug --log-file debug.log
 
 ## Filtergraph Mode
 
-As an alternative to authoring a `.orcprj` file, a linear decode pipeline can
-be described directly on the command line. This builds the same in-memory DAG
-a `.orcprj` file would and triggers all sink nodes, so results are identical.
+As an alternative to authoring a `.orcprj` file, a decode pipeline can be
+described directly on the command line with `--source`, `--filters`, and
+`--sink` (short forms `-i`, `-f`, `-o`). This builds the same in-memory DAG a
+`.orcprj` file would and triggers all sink nodes, so results are identical.
 The `.orcprj` workflow itself is unchanged.
 
 Video format (NTSC/PAL/PAL-M) and source signal type (composite/Y-C) are
-**never specified separately** — they are detected automatically from the
-stage modules used (a stage that is exclusively NTSC-compatible implies NTSC;
-supplying `y_path`/`c_path` implies Y/C; supplying `input_path` implies
-composite). If two stages imply conflicting formats, that is reported as an
-error before anything runs.
+**usually detected automatically** from the stage modules used — a stage
+that is exclusively NTSC-compatible implies NTSC; a source stage with both
+`y_path` and `c_path` set implies Y/C; one with `input_path` set implies
+composite. If two stages imply conflicting formats, that is reported as an
+error before anything runs. Some stages (`tbc_source` in particular) are
+format-agnostic — they read their own format from a metadata sidecar file
+rather than declaring one — so no stage in the graph may give any hint at
+all; running in memory tolerates this, but see
+[Exporting instead of running](#exporting-instead-of-running) below for the
+one case where it matters.
 
-### Style 1: a single filtergraph string (`--filter`)
+### The source/filters/sink triad
+
+`--source`, `--filters`, and `--sink` enforce that stages go where they
+belong: **every stage named in `--source` must be a source, every stage in
+`--sink` must be a sink, and every stage in `--filters` must be neither** (a
+transform or similar processing stage). Putting a sink in `--source`, for
+example, is rejected with a clear error naming the correct flag — this is
+checked against each stage's real role (the same metadata the GUI uses), not
+guessed from its name, so it works for any third-party plugin stage too.
 
 ```
 stage_name=key=value:key=value, stage_name=key=value
 ```
 
-- **Stages** are separated by `,` and are auto-connected in order.
+- **Stages** within a single `--source`/`--filters`/`--sink` value are
+  separated by `,` (or `;`, for a separate filterchain) and are
+  auto-connected in order.
 - **Values** may be wrapped in single quotes (`'...'`) **or** double quotes
   (`"..."`) — whichever is more convenient for your shell — to include `:`
   `,` `;` and spaces literally; the two quote styles are interchangeable, and
@@ -116,46 +133,26 @@ stage_name=key=value:key=value, stage_name=key=value
   `=`.
 
 ```bash
-orc-cli --filter "tbc_source=input_path=capture.tbc, hvd_chroma_decoder, video_sink=output_path=capture.mp4"
-```
-
-Reading the graph from a file or standard input:
-
-```bash
-orc-cli --filter-file graph.txt
-cat graph.txt | orc-cli --filter-file -
-```
-
-### Style 2: the input/filters/output triad
-
-For the common case — one input, a chain of processing stages, one output —
-`--input`, `--filters`, and `--output` avoid needing to know the full
-filtergraph grammar, and they enforce that stages go where they belong:
-**every stage named in `--input` must be a source, every stage in `--output`
-must be a sink, and every stage in `--filters` must be neither** (a transform
-or similar processing stage). Putting a sink in `--input`, for example, is
-rejected with a clear error naming the correct flag — this is checked against
-each stage's real role (the same metadata the GUI uses), not guessed from its
-name, so it works for any third-party plugin stage too.
-
-```bash
 orc-cli \
-  --input "tbc_source=input_path=capture.tbc" \
-  --filters "hvd_chroma_decoder" \
-  --output "video_sink=output_path=capture.mp4"
+  --source "tbc_source=input_path=capture.tbc" \
+  --filters "dropout_correct" \
+  --sink "video_sink=output_path=capture.mp4"
 ```
 
-Any of the three may be omitted, and each may itself contain a
-comma-separated chain of stages. `--input`/`--filters`/`--output` cannot be
-combined with `--filter`/`--filter-file` in the same run — pick one style.
+The same thing with short options and a CVBS source:
+
+```bash
+orc-cli -i "NTSC_CVBS_Source=input_path=capture.composite" -o "video_sink=output_path=capture.mp4"
+```
+
+Any of the three may be omitted, but at least one must be non-empty.
 
 ### Windows paths
 
-Unquoted Windows paths (drive letters and backslashes) are parsed correctly
-in both styles above:
+Unquoted Windows paths (drive letters and backslashes) are parsed correctly:
 
 ```bash
-orc-cli --input "tbc_source=input_path=C:\Users\me\capture.tbc" --output video_sink
+orc-cli --source "tbc_source=input_path=C:\Users\me\capture.tbc" --sink video_sink
 ```
 
 If a value needs to rule out any ambiguity — for instance it contains a
@@ -164,9 +161,55 @@ whichever your shell passes through more conveniently.
 
 ### Non-linear graphs
 
-Anything with real shape — fan-in (multiple sources into one stage), fan-out
-(one stage into several sinks), or branching — is not expressible this way by
-design, and remains a `.orcprj` project file.
+Fan-in (multiple sources into one stage, e.g. a stacker) and fan-out (one
+stage feeding several sinks) are fully supported, using `[label]` link
+syntax to connect stages across `--source`/`--filters`/`--sink`:
+
+```bash
+orc-cli --source "tbc_source=input_path=a.tbc[a]; tbc_source=input_path=b.tbc[b]; tbc_source=input_path=c.tbc[c]" \
+  --filters "[a][b][c] stacker" \
+  --sink video_sink
+```
+
+### Exporting instead of running
+
+`--export-project` builds the project exactly as `--source`/`--filters`/
+`--sink` normally would, but saves it as a `.orcprj` file instead of
+triggering it — using the same `saveProject()` writer the GUI's "Save As"
+uses, so this isn't a new save format, just a different way to reach the
+existing one:
+
+```bash
+orc-cli --source "tbc_source=input_path=capture.tbc" --sink video_sink \
+  --export-project capture.orcprj
+```
+
+Useful for building a project quickly from the command line and then
+opening it in the GUI, or reusing it later with `--process`.
+
+A saved `.orcprj` file requires an explicit video format *and* source signal
+type — unlike running in memory, which tolerates either being undetermined.
+If no stage implies one (a format-agnostic source like `tbc_source` reads
+its own format from its metadata sidecar file rather than implying one),
+`--video-format` and/or `--source-type` set them for the export:
+
+```bash
+orc-cli --source "tbc_source=input_path=capture.tbc" --sink video_sink \
+  --export-project capture.orcprj --video-format NTSC --source-type composite
+```
+
+`--video-format` and `--source-type` are only meaningful together with
+`--export-project`; they have no effect on running the pipeline directly.
+
+### Discovering stages and their parameters
+
+Every stage's parameter names, types, and which ones are required come from
+the same descriptors the GUI uses (`getStageParameters()`), so a mismatch
+between a filtergraph and what a stage actually accepts is caught before
+anything runs — see the "Missing required parameter" and "not recognised"
+errors below. There is currently no CLI subcommand to list available stages
+directly; check the GUI's stage palette, or a stage's own documentation, for
+its exact name and parameters.
 
 ## Processing Workflow
 
@@ -332,8 +375,8 @@ Unknown stage '<name>'.
 
 **Stage used in the wrong triad category:**
 ```
---input: stage 'video_sink' (Video Sink) is an output (sink) stage — it
-belongs under --output, not --input.
+--source: stage 'video_sink' (Video Sink) is an output (sink) stage — it
+belongs under --sink, not --source.
 ```
 → Move the stage to the flag matching its actual role
 
@@ -342,6 +385,25 @@ belongs under --output, not --input.
 Stage '<name>': missing required parameter '<param>'.
 ```
 → Supply the parameter
+
+**Cannot export — no video format:**
+```
+Cannot export: none of the stages used imply a video format (NTSC/PAL/PAL-M),
+so the saved project would fail to reload. Pass --video-format NTSC|PAL|PAL-M
+to set it explicitly for the export, or run the pipeline directly instead of
+exporting.
+```
+→ Add `--video-format`, or add a format-specific source stage to the graph
+
+**Cannot export — no source signal type:**
+```
+Cannot export: none of the stages used imply a source signal type
+(composite/Y-C), so the saved project would fail to reload. Pass
+--source-type composite|yc to set it explicitly for the export, or run the
+pipeline directly instead of exporting.
+```
+→ Add `--source-type`, or ensure a source stage's parameters reveal its
+signal type (`y_path`+`c_path`, or `input_path`)
 
 ### Crash Diagnostics
 

--- a/orc-plugin-registry/index.yaml
+++ b/orc-plugin-registry/index.yaml
@@ -33,3 +33,26 @@ plugins:
         url: https://github.com/simoninns/orc-plugin_skeleton/releases/download/v1.0.5/orc-plugin_skeleton_passthrough_windows.dll
         sha256: 2f95ede8dd4e99d27b948c4a19340cb91ef8cd24e3d765bd2e2eba533df1e561
         plugin_version: 1.0.5
+  - id: org.decodeorc.stage.hvd_chroma_decoder
+    display_name: HVD Chroma decoder
+    description: Holographic chroma decoder without comb filter
+    maintainer: vrunk11
+    license_spdx: GPL-3.0-or-later
+    source_repo_url: https://github.com/vrunk11/hvd-cvbs-decoding
+    tags: [transform, example]
+    artifacts:
+      - platform: linux
+        host_abi: 11
+        url: https://github.com/vrunk11/hvd-cvbs-decoding/releases/download/v0.1.0/orc-plugin_hvd_chroma_decoder_linux.so
+        sha256: 4931248d419a640b559fb6fb33547ac64f8698fd1dcc17fc610dc1c15f629e27
+        plugin_version: 0.1.0
+      - platform: macos
+        host_abi: 11
+        url: https://github.com/vrunk11/hvd-cvbs-decoding/releases/download/v0.1.0/orc-plugin_hvd_chroma_decoder_macos.dylib
+        sha256: 7c492092795dc06d55534f581450a9869090aefc5da82ae4da9c0adb2d536ed5
+        plugin_version: 0.1.0
+      - platform: windows
+        host_abi: 11
+        url: https://github.com/vrunk11/hvd-cvbs-decoding/releases/download/v0.1.0/orc-plugin_hvd_chroma_decoder_windows.dll
+        sha256: b349e47e07d1f2b8c72a2a5c5c6964a6024cd61b7addadce25c238601b598ab4
+        plugin_version: 0.1.0

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -188,6 +188,7 @@ orc_add_core_unit_tests(
         "unit;presenters"
 
         presenters/project_presenter_validation_test.cpp
+        presenters/filtergraph_import_test.cpp
 )
 target_link_libraries(orc-core-unit-tests-presenters orc-presenters)
 

--- a/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
+++ b/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
@@ -1,0 +1,418 @@
+/*
+ * File:        filtergraph_import_test.cpp
+ * Module:      orc-presenters unit tests
+ * Purpose:     Unit tests for import_filtergraph_into_project(), mocking
+ *              IProjectPresenter per AGENTS.md §4.2 (no filesystem, no real
+ *              stage registry — the class under test only ever talks to the
+ *              interface).
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include "presenters/include/filtergraph_import.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "presenters/include/i_project_presenter.h"
+
+namespace orc::presenters::test {
+
+// Self-contained GMock scaffold for IProjectPresenter, scoped to this test
+// file (mirrors orc-tests/gui/unit/mocks/mock_project_presenter.h, which
+// belongs to the GUI test suite and is not reused here to avoid coupling
+// two independently-built test binaries).
+class MockProjectPresenter : public IProjectPresenter {
+ public:
+  MOCK_METHOD(bool, createQuickProject,
+              (VideoFormat format, SourceType source,
+               const std::vector<std::string>& input_files),
+              (override));
+  MOCK_METHOD(bool, loadProject, (const std::string& project_path), (override));
+  MOCK_METHOD(bool, saveProject, (const std::string& project_path), (override));
+  MOCK_METHOD(void, clearProject, (), (override));
+  MOCK_METHOD(bool, isModified, (), (const, override));
+  MOCK_METHOD(void, clearModifiedFlag, (), (override));
+  MOCK_METHOD(std::string, getProjectPath, (), (const, override));
+
+  MOCK_METHOD(std::string, getProjectName, (), (const, override));
+  MOCK_METHOD(void, setProjectName, (const std::string& name), (override));
+  MOCK_METHOD(std::string, getProjectDescription, (), (const, override));
+  MOCK_METHOD(void, setProjectDescription, (const std::string& description),
+              (override));
+  MOCK_METHOD(VideoFormat, getVideoFormat, (), (const, override));
+  MOCK_METHOD(void, setVideoFormat, (VideoFormat format), (override));
+  MOCK_METHOD(SourceType, getSourceFormat, (), (const, override));
+  MOCK_METHOD(void, setSourceFormat, (SourceType source), (override));
+  MOCK_METHOD(std::shared_ptr<const void>, createSnapshot, (),
+              (const, override));
+  MOCK_METHOD(SourceType, getSourceType, (), (const, override));
+  MOCK_METHOD(void, setSourceType, (SourceType source), (override));
+  MOCK_METHOD(orc::AmplitudeDisplayUnit, getAmplitudeUnit, (),
+              (const, override));
+  MOCK_METHOD(void, setAmplitudeUnit, (orc::AmplitudeDisplayUnit unit),
+              (override));
+
+  MOCK_METHOD(NodeID, addNode,
+              (const std::string& stage_name, double x_position,
+               double y_position),
+              (override));
+  MOCK_METHOD(bool, removeNode, (NodeID node_id), (override));
+  MOCK_METHOD(bool, canRemoveNode, (NodeID node_id, std::string* reason),
+              (const, override));
+  MOCK_METHOD(void, setNodePosition, (NodeID node_id, double x, double y),
+              (override));
+  MOCK_METHOD(void, setNodeLabel, (NodeID node_id, const std::string& label),
+              (override));
+  MOCK_METHOD(void, setNodeParameters,
+              (NodeID node_id,
+               (const std::map<std::string, std::string>& parameters)),
+              (override));
+  MOCK_METHOD(void, addEdge, (NodeID source_node, NodeID target_node),
+              (override));
+  MOCK_METHOD(void, removeEdge, (NodeID source_node, NodeID target_node),
+              (override));
+  MOCK_METHOD(std::vector<NodeInfo>, getNodes, (), (const, override));
+  MOCK_METHOD(NodeID, getFirstNode, (), (const, override));
+  MOCK_METHOD(bool, hasNode, (NodeID node_id), (const, override));
+  MOCK_METHOD(std::vector<EdgeInfo>, getEdges, (), (const, override));
+  MOCK_METHOD(NodeInfo, getNodeInfo, (NodeID node_id), (const, override));
+
+  MOCK_METHOD(std::vector<StageInfo>, listAvailableStagesForFormat,
+              (VideoFormat format), (const, override));
+  MOCK_METHOD(std::vector<StageInfo>, listAllStages, (), (const, override));
+  MOCK_METHOD(bool, stageExists, (const std::string& stage_name),
+              (const, override));
+  MOCK_METHOD(std::shared_ptr<void>, instantiateStage,
+              (const std::string& stage_name), (const, override));
+  MOCK_METHOD(std::vector<LoadedPluginInfo>, listLoadedPlugins, (),
+              (const, override));
+  MOCK_METHOD(std::vector<PluginDiagnosticInfo>, listPluginDiagnostics, (),
+              (const, override));
+  MOCK_METHOD(std::vector<std::string>, listPluginSearchPaths, (),
+              (const, override));
+  MOCK_METHOD(PluginRegistryInfo, getPluginRegistry, (), (const, override));
+  MOCK_METHOD(PluginRegistryMutationResult, addPlugin,
+              (const std::string& path, const std::string& plugin_id,
+               const std::string& plugin_version,
+               const std::string& license_spdx, bool is_core_plugin,
+               bool trusted),
+              (const, override));
+  MOCK_METHOD(PluginRegistryMutationResult, addPluginEntry,
+              (const PluginRegistryEntryInfo& entry_info), (const, override));
+  MOCK_METHOD(PluginRegistryMutationResult, addPluginFromUrl,
+              (const std::string& releases_url, bool trusted),
+              (const, override));
+  MOCK_METHOD(PluginRegistryMutationResult, removePlugin,
+              (const std::string& plugin_id), (const, override));
+  MOCK_METHOD(PluginRegistryMutationResult, setPluginEnabled,
+              (const std::string& plugin_id, bool enabled), (const, override));
+  MOCK_METHOD(PluginRegistryMutationResult, setPluginTrusted,
+              (const std::string& plugin_id, bool trusted), (const, override));
+  MOCK_METHOD(PluginIndexInfo, fetchPluginIndex, (), (const, override));
+  MOCK_METHOD(PluginRegistryMutationResult, installPluginFromIndex,
+              (const std::string& plugin_id), (const, override));
+
+  MOCK_METHOD(bool, canTriggerNode, (NodeID node_id, std::string* reason),
+              (const, override));
+  MOCK_METHOD(bool, triggerNode,
+              (NodeID node_id, ProgressCallback progress_callback), (override));
+  MOCK_METHOD(bool, triggerAllSinks, (ProgressCallback progress_callback),
+              (override));
+
+  MOCK_METHOD(bool, validateProject, (), (const, override));
+  MOCK_METHOD(std::vector<std::string>, getValidationErrors, (),
+              (const, override));
+
+  MOCK_METHOD(orc::ConfigurationStatus, getNodeConfigurationStatus,
+              (NodeID node_id), (const, override));
+
+  MOCK_METHOD(std::shared_ptr<void>, getDAG, (), (const, override));
+  MOCK_METHOD(std::shared_ptr<void>, buildDAG, (), (override));
+  MOCK_METHOD(bool, validateDAG, (), (override));
+
+  MOCK_METHOD(std::string, getStageInstructions,
+              (const std::string& stage_name), (const, override));
+
+  MOCK_METHOD(std::vector<ParameterDescriptor>, getStageParameters,
+              (const std::string& stage_name), (override));
+  MOCK_METHOD((std::map<std::string, ParameterValue>), getNodeParameters,
+              (NodeID node_id), (override));
+  MOCK_METHOD(bool, setNodeParameters,
+              (NodeID node_id,
+               (const std::map<std::string, ParameterValue>& params)),
+              (override));
+
+  MOCK_METHOD(void*, getCoreProjectHandle, (), (override));
+};
+
+}  // namespace orc::presenters::test
+
+namespace orc_unit_test {
+namespace {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+using orc::NodeID;
+using orc::ParameterDescriptor;
+using orc::presenters::import_filtergraph_into_project;
+using orc::presenters::SourceType;
+using orc::presenters::StageInfo;
+using orc::presenters::VideoFormat;
+using orc::presenters::test::MockProjectPresenter;
+
+StageInfo make_stage(const std::string& name, bool is_source, bool is_sink) {
+  StageInfo info;
+  info.name = name;
+  info.display_name = name;
+  info.is_source = is_source;
+  info.is_sink = is_sink;
+  return info;
+}
+
+ParameterDescriptor make_param(const std::string& name, bool required) {
+  ParameterDescriptor p;
+  p.name = name;
+  p.constraints.required = required;
+  return p;
+}
+
+// Wires up the common expectations shared by most tests: a source stage and
+// a sink stage, both compatible with every video format (so no accidental
+// video-format inference kicks in unless a test wants it to), with no
+// required parameters unless a test overrides that stage's descriptors.
+void set_up_generic_source_and_sink(NiceMock<MockProjectPresenter>& presenter,
+                                    const std::string& source_name,
+                                    const std::string& sink_name) {
+  const std::vector<StageInfo> all_stages = {
+      make_stage(source_name, /*is_source=*/true, /*is_sink=*/false),
+      make_stage(sink_name, /*is_source=*/false, /*is_sink=*/true)};
+
+  ON_CALL(presenter, stageExists(_)).WillByDefault(Return(true));
+  ON_CALL(presenter, listAllStages()).WillByDefault(Return(all_stages));
+  // Present in every format list => contributes no video-format signal.
+  ON_CALL(presenter, listAvailableStagesForFormat(_))
+      .WillByDefault(Return(all_stages));
+  ON_CALL(presenter, getStageParameters(_))
+      .WillByDefault(Return(std::vector<ParameterDescriptor>{}));
+
+  int next_id = 0;
+  ON_CALL(presenter, addNode(_, _, _))
+      .WillByDefault([&next_id](const std::string&, double, double) {
+        return NodeID(next_id++);
+      });
+}
+
+TEST(FiltergraphImportTest, BuildsSimpleLinearGraph) {
+  NiceMock<MockProjectPresenter> presenter;
+  set_up_generic_source_and_sink(presenter, "tbc_source", "video_sink");
+
+  EXPECT_CALL(presenter, addNode("tbc_source", _, _)).Times(1);
+  EXPECT_CALL(presenter, addNode("video_sink", _, _)).Times(1);
+  EXPECT_CALL(
+      presenter,
+      setNodeParameters(
+          _, ::testing::Matcher<const std::map<std::string, std::string>&>(_)))
+      .Times(1);  // only tbc_source has a non-empty params map
+  EXPECT_CALL(presenter, addEdge(NodeID(0), NodeID(1))).Times(1);
+
+  const auto result = import_filtergraph_into_project(
+      presenter, "tbc_source=input_path=a.tbc, video_sink");
+
+  EXPECT_TRUE(result.ok);
+  EXPECT_TRUE(result.errors.empty());
+}
+
+TEST(FiltergraphImportTest, UnknownStageFailsWithoutBuildingAnything) {
+  NiceMock<MockProjectPresenter> presenter;
+  ON_CALL(presenter, stageExists(_)).WillByDefault(Return(false));
+
+  EXPECT_CALL(presenter, addNode(_, _, _)).Times(0);
+
+  const auto result =
+      import_filtergraph_into_project(presenter, "not_a_real_stage");
+
+  EXPECT_FALSE(result.ok);
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_THAT(result.errors[0], ::testing::HasSubstr("not_a_real_stage"));
+}
+
+TEST(FiltergraphImportTest, MissingRequiredParameterFailsWithoutBuilding) {
+  NiceMock<MockProjectPresenter> presenter;
+  set_up_generic_source_and_sink(presenter, "tbc_source", "video_sink");
+  ON_CALL(presenter, getStageParameters("tbc_source"))
+      .WillByDefault(Return(
+          std::vector<ParameterDescriptor>{make_param("input_path", true)}));
+
+  EXPECT_CALL(presenter, addNode(_, _, _)).Times(0);
+
+  const auto result =
+      import_filtergraph_into_project(presenter, "tbc_source, video_sink");
+
+  EXPECT_FALSE(result.ok);
+  bool mentions_input_path = false;
+  for (const auto& e : result.errors) {
+    if (e.find("input_path") != std::string::npos) mentions_input_path = true;
+  }
+  EXPECT_TRUE(mentions_input_path);
+}
+
+// Regression test for the bug found in review: y_path present as a key but
+// with an *empty* value (e.g. a composite tbc_source that still carries
+// y_path='' for parameter symmetry) must not be mistaken for a Y/C source.
+TEST(FiltergraphImportTest, EmptyYPathIsNotTreatedAsYC) {
+  NiceMock<MockProjectPresenter> presenter;
+  set_up_generic_source_and_sink(presenter, "tbc_source", "video_sink");
+
+  EXPECT_CALL(presenter, setSourceType(SourceType::Composite)).Times(1);
+  EXPECT_CALL(presenter, setSourceType(SourceType::YC)).Times(0);
+
+  const auto result = import_filtergraph_into_project(
+      presenter, "tbc_source=input_path=a.tbc:y_path='', video_sink");
+
+  EXPECT_TRUE(result.ok);
+}
+
+TEST(FiltergraphImportTest, BothYAndCPathNonEmptyIsDetectedAsYC) {
+  NiceMock<MockProjectPresenter> presenter;
+  set_up_generic_source_and_sink(presenter, "tbc_source", "video_sink");
+
+  EXPECT_CALL(presenter, setSourceType(SourceType::YC)).Times(1);
+
+  const auto result = import_filtergraph_into_project(
+      presenter, "tbc_source=y_path=a.y:c_path=a.c, video_sink");
+
+  EXPECT_TRUE(result.ok);
+}
+
+TEST(FiltergraphImportTest, OnlyYPathAloneDoesNotImplyYC) {
+  NiceMock<MockProjectPresenter> presenter;
+  set_up_generic_source_and_sink(presenter, "tbc_source", "video_sink");
+
+  EXPECT_CALL(presenter, setSourceType(_)).Times(0);  // stays Unknown
+
+  const auto result = import_filtergraph_into_project(
+      presenter, "tbc_source=y_path=a.y, video_sink");
+
+  EXPECT_TRUE(result.ok);
+}
+
+// Regression test for the validation-ordering bug found in review:
+// getStageParameters() must be called *after* setVideoFormat()/
+// setSourceType(), not before, so stages that narrow their descriptor set
+// by format see the real context rather than Unknown.
+TEST(FiltergraphImportTest, FormatIsSetBeforeParameterDescriptorsAreFetched) {
+  NiceMock<MockProjectPresenter> presenter;
+  const std::vector<StageInfo> all_stages = {
+      make_stage("NTSC_CVBS_Source", true, false),
+      make_stage("video_sink", false, true)};
+  ON_CALL(presenter, stageExists(_)).WillByDefault(Return(true));
+  ON_CALL(presenter, listAllStages()).WillByDefault(Return(all_stages));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::NTSC))
+      .WillByDefault(Return(all_stages));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::PAL))
+      .WillByDefault(Return(
+          std::vector<StageInfo>{make_stage("video_sink", false, true)}));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::PAL_M))
+      .WillByDefault(Return(
+          std::vector<StageInfo>{make_stage("video_sink", false, true)}));
+  ON_CALL(presenter, getStageParameters(_))
+      .WillByDefault(Return(std::vector<ParameterDescriptor>{}));
+  ON_CALL(presenter, addNode(_, _, _)).WillByDefault(Return(NodeID(0)));
+
+  {
+    InSequence seq;
+    EXPECT_CALL(presenter, setVideoFormat(VideoFormat::NTSC));
+    EXPECT_CALL(presenter, getStageParameters(_)).Times(::testing::AnyNumber());
+  }
+
+  const auto result = import_filtergraph_into_project(
+      presenter, "NTSC_CVBS_Source=input_path=a.composite, video_sink");
+
+  EXPECT_TRUE(result.ok);
+}
+
+// Regression test: if parameter validation fails *after* the format was
+// already set (needed so descriptor-fetching sees the right context), the
+// presenter must be left exactly as it started — the format set above must
+// be rolled back to Unknown, matching the documented contract in
+// filtergraph_import.h.
+TEST(FiltergraphImportTest, FailedParameterValidationRollsBackFormat) {
+  NiceMock<MockProjectPresenter> presenter;
+  const std::vector<StageInfo> all_stages = {
+      make_stage("NTSC_CVBS_Source", true, false),
+      make_stage("video_sink", false, true)};
+  ON_CALL(presenter, stageExists(_)).WillByDefault(Return(true));
+  ON_CALL(presenter, listAllStages()).WillByDefault(Return(all_stages));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::NTSC))
+      .WillByDefault(Return(all_stages));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::PAL))
+      .WillByDefault(Return(
+          std::vector<StageInfo>{make_stage("video_sink", false, true)}));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::PAL_M))
+      .WillByDefault(Return(
+          std::vector<StageInfo>{make_stage("video_sink", false, true)}));
+  // Force a missing-required-parameter failure on the source stage.
+  ON_CALL(presenter, getStageParameters("NTSC_CVBS_Source"))
+      .WillByDefault(Return(
+          std::vector<ParameterDescriptor>{make_param("input_path", true)}));
+  ON_CALL(presenter, getStageParameters("video_sink"))
+      .WillByDefault(Return(std::vector<ParameterDescriptor>{}));
+
+  EXPECT_CALL(presenter, setVideoFormat(VideoFormat::NTSC)).Times(1);
+  EXPECT_CALL(presenter, setVideoFormat(VideoFormat::Unknown)).Times(1);
+  EXPECT_CALL(presenter, addNode(_, _, _)).Times(0);
+
+  const auto result = import_filtergraph_into_project(
+      presenter, "NTSC_CVBS_Source, video_sink");
+
+  EXPECT_FALSE(result.ok);
+}
+
+TEST(FiltergraphImportTest, ConflictingVideoFormatsFailWithoutMutation) {
+  NiceMock<MockProjectPresenter> presenter;
+  const std::vector<StageInfo> ntsc_source = {
+      make_stage("NTSC_CVBS_Source", true, false)};
+  const std::vector<StageInfo> pal_source = {
+      make_stage("PAL_CVBS_Source", true, false)};
+  const std::vector<StageInfo> sink_only = {
+      make_stage("video_sink", false, true)};
+  const std::vector<StageInfo> all_stages = {
+      make_stage("NTSC_CVBS_Source", true, false),
+      make_stage("PAL_CVBS_Source", true, false),
+      make_stage("video_sink", false, true)};
+
+  ON_CALL(presenter, stageExists(_)).WillByDefault(Return(true));
+  ON_CALL(presenter, listAllStages()).WillByDefault(Return(all_stages));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::NTSC))
+      .WillByDefault(Return(
+          std::vector<StageInfo>{make_stage("NTSC_CVBS_Source", true, false),
+                                 make_stage("video_sink", false, true)}));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::PAL))
+      .WillByDefault(Return(
+          std::vector<StageInfo>{make_stage("PAL_CVBS_Source", true, false),
+                                 make_stage("video_sink", false, true)}));
+  ON_CALL(presenter, listAvailableStagesForFormat(VideoFormat::PAL_M))
+      .WillByDefault(Return(sink_only));
+
+  EXPECT_CALL(presenter, setVideoFormat(_)).Times(0);
+  EXPECT_CALL(presenter, addNode(_, _, _)).Times(0);
+
+  const auto result = import_filtergraph_into_project(
+      presenter,
+      "NTSC_CVBS_Source=input_path=a.composite[x]; "
+      "PAL_CVBS_Source=input_path=b.composite[y]; [x][y] video_sink");
+
+  EXPECT_FALSE(result.ok);
+}
+
+}  // namespace
+}  // namespace orc_unit_test

--- a/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
+++ b/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
@@ -204,19 +204,23 @@ void set_up_generic_source_and_sink(NiceMock<MockProjectPresenter>& presenter,
   ON_CALL(presenter, getStageParameters(_))
       .WillByDefault(Return(std::vector<ParameterDescriptor>{}));
 
-  int next_id = 0;
-  ON_CALL(presenter, addNode(_, _, _))
-      .WillByDefault([&next_id](const std::string&, double, double) {
-        return NodeID(next_id++);
-      });
+  // A single fixed default is enough for every test that doesn't care about
+  // exact, distinct NodeID sequencing (most of them, below) — tests that do
+  // (BuildsSimpleLinearGraph) override this locally with their own
+  // EXPECT_CALL, which GMock matches in preference to this ON_CALL default.
+  ON_CALL(presenter, addNode(_, _, _)).WillByDefault(Return(NodeID(0)));
 }
 
 TEST(FiltergraphImportTest, BuildsSimpleLinearGraph) {
   NiceMock<MockProjectPresenter> presenter;
   set_up_generic_source_and_sink(presenter, "tbc_source", "video_sink");
 
-  EXPECT_CALL(presenter, addNode("tbc_source", _, _)).Times(1);
-  EXPECT_CALL(presenter, addNode("video_sink", _, _)).Times(1);
+  EXPECT_CALL(presenter, addNode("tbc_source", _, _))
+      .Times(1)
+      .WillOnce(Return(NodeID(0)));
+  EXPECT_CALL(presenter, addNode("video_sink", _, _))
+      .Times(1)
+      .WillOnce(Return(NodeID(1)));
   EXPECT_CALL(
       presenter,
       setNodeParameters(

--- a/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
+++ b/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
@@ -10,7 +10,7 @@
  * SPDX-FileCopyrightText: 2026 decode-orc contributors
  */
 
-#include "presenters/include/filtergraph_import.h"
+#include "filtergraph_import.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "presenters/include/i_project_presenter.h"
+#include "i_project_presenter.h"
 
 namespace orc::presenters::test {
 

--- a/orc/cli/CMakeLists.txt
+++ b/orc/cli/CMakeLists.txt
@@ -281,13 +281,23 @@ if(BUILD_UNIT_TESTS)
     )
 
     add_test(
-        NAME CLI.VideoFormatRejectedWithoutExportProject
+        NAME CLI.VideoFormatRejectedWithoutTriad
+        COMMAND $<TARGET_FILE:orc-cli> --video-format NTSC
+    )
+    set_tests_properties(CLI.VideoFormatRejectedWithoutTriad PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.VideoFormatWorksWithoutExportProject
         COMMAND $<TARGET_FILE:orc-cli> --source "src" --sink "sink"
                 --video-format NTSC
     )
-    set_tests_properties(CLI.VideoFormatRejectedWithoutExportProject PROPERTIES
+    set_tests_properties(CLI.VideoFormatWorksWithoutExportProject PROPERTIES
         LABELS "unit;cli"
-        WILL_FAIL TRUE
+        WILL_FAIL TRUE  # fails on "unknown stage 'src'", not on --video-format
+        FAIL_REGULAR_EXPRESSION "only makes sense with"
     )
 
     add_test(
@@ -297,6 +307,35 @@ if(BUILD_UNIT_TESTS)
     set_tests_properties(CLI.HelpShowsVideoFormatOption PROPERTIES
         LABELS "unit;cli"
         PASS_REGULAR_EXPRESSION "--video-format"
+    )
+
+    add_test(
+        NAME CLI.SourceTypeRejectedWithoutTriad
+        COMMAND $<TARGET_FILE:orc-cli> --source-type composite
+    )
+    set_tests_properties(CLI.SourceTypeRejectedWithoutTriad PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.SourceTypeWorksWithoutExportProject
+        COMMAND $<TARGET_FILE:orc-cli> --source "src" --sink "sink"
+                --source-type composite
+    )
+    set_tests_properties(CLI.SourceTypeWorksWithoutExportProject PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE  # fails on "unknown stage 'src'", not on --source-type
+        FAIL_REGULAR_EXPRESSION "only makes sense with"
+    )
+
+    add_test(
+        NAME CLI.HelpShowsSourceTypeOption
+        COMMAND $<TARGET_FILE:orc-cli> --help
+    )
+    set_tests_properties(CLI.HelpShowsSourceTypeOption PROPERTIES
+        LABELS "unit;cli"
+        PASS_REGULAR_EXPRESSION "--source-type"
     )
 
     # Pure unit test for the filtergraph parser (no orc-core dependency).

--- a/orc/cli/CMakeLists.txt
+++ b/orc/cli/CMakeLists.txt
@@ -212,13 +212,13 @@ if(BUILD_UNIT_TESTS)
     )
     set_tests_properties(CLI.HelpShowsFilterCommand PROPERTIES
         LABELS "unit;cli"
-        PASS_REGULAR_EXPRESSION "--input"
+        PASS_REGULAR_EXPRESSION "--source"
     )
 
     add_test(
         NAME CLI.FilterUnknownStageFails
         COMMAND $<TARGET_FILE:orc-cli>
-                --input "definitely_not_a_stage" --output "video_sink"
+                --source "definitely_not_a_stage" --sink "video_sink"
     )
     set_tests_properties(CLI.FilterUnknownStageFails PROPERTIES
         LABELS "unit;cli"
@@ -227,7 +227,7 @@ if(BUILD_UNIT_TESTS)
 
     add_test(
         NAME CLI.FilterMalformedGraphFails
-        COMMAND $<TARGET_FILE:orc-cli> --input "src=badparam" --output sink
+        COMMAND $<TARGET_FILE:orc-cli> --source "src=badparam" --sink sink
     )
     set_tests_properties(CLI.FilterMalformedGraphFails PROPERTIES
         LABELS "unit;cli"
@@ -236,7 +236,7 @@ if(BUILD_UNIT_TESTS)
 
     add_test(
         NAME CLI.FilterRejectsProjectFileCombination
-        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --input "src" --output sink
+        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --source "src" --sink sink
     )
     set_tests_properties(CLI.FilterRejectsProjectFileCombination PROPERTIES
         LABELS "unit;cli"
@@ -245,7 +245,7 @@ if(BUILD_UNIT_TESTS)
 
     add_test(
         NAME CLI.ProcessAndTriadCannotCombine
-        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --process --input "src"
+        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --process --source "src"
     )
     set_tests_properties(CLI.ProcessAndTriadCannotCombine PROPERTIES
         LABELS "unit;cli"
@@ -253,10 +253,10 @@ if(BUILD_UNIT_TESTS)
     )
 
     add_test(
-        NAME CLI.TriadRejectsSinkStageInInput
-        COMMAND $<TARGET_FILE:orc-cli> --input "video_sink" --output "video_sink"
+        NAME CLI.TriadRejectsSinkStageInSource
+        COMMAND $<TARGET_FILE:orc-cli> --source "video_sink" --sink "video_sink"
     )
-    set_tests_properties(CLI.TriadRejectsSinkStageInInput PROPERTIES
+    set_tests_properties(CLI.TriadRejectsSinkStageInSource PROPERTIES
         LABELS "unit;cli"
         WILL_FAIL TRUE
     )
@@ -282,7 +282,7 @@ if(BUILD_UNIT_TESTS)
 
     add_test(
         NAME CLI.VideoFormatRejectedWithoutExportProject
-        COMMAND $<TARGET_FILE:orc-cli> --input "src" --output "sink"
+        COMMAND $<TARGET_FILE:orc-cli> --source "src" --sink "sink"
                 --video-format NTSC
     )
     set_tests_properties(CLI.VideoFormatRejectedWithoutExportProject PROPERTIES

--- a/orc/cli/CMakeLists.txt
+++ b/orc/cli/CMakeLists.txt
@@ -3,7 +3,9 @@
 add_executable(orc-cli 
     orc_cli.cpp
     command_process.cpp
+    command_filter.cpp
     command_plugins.cpp
+    stage_category.cpp
 )
 
 # Section: Architecture enforcement (MVP)
@@ -200,5 +202,83 @@ if(BUILD_UNIT_TESTS)
     set_tests_properties(CLI.ProcessNoSinksFails PROPERTIES
         LABELS "unit;cli"
         WILL_FAIL TRUE
+    )
+
+    # --- Filtergraph mode -----------------------------------------------------
+
+    add_test(
+        NAME CLI.HelpShowsFilterCommand
+        COMMAND $<TARGET_FILE:orc-cli> --help
+    )
+    set_tests_properties(CLI.HelpShowsFilterCommand PROPERTIES
+        LABELS "unit;cli"
+        PASS_REGULAR_EXPRESSION "--filter"
+    )
+
+    add_test(
+        NAME CLI.FilterUnknownStageFails
+        COMMAND $<TARGET_FILE:orc-cli>
+                --filter "definitely_not_a_stage, video_sink"
+    )
+    set_tests_properties(CLI.FilterUnknownStageFails PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.FilterMalformedGraphFails
+        COMMAND $<TARGET_FILE:orc-cli> --filter "src=badparam, sink"
+    )
+    set_tests_properties(CLI.FilterMalformedGraphFails PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.FilterRejectsProjectFileCombination
+        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --filter "src, sink"
+    )
+    set_tests_properties(CLI.FilterRejectsProjectFileCombination PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.TriadRejectsCombinationWithFilter
+        COMMAND $<TARGET_FILE:orc-cli> --input "src" --filter "src, sink"
+    )
+    set_tests_properties(CLI.TriadRejectsCombinationWithFilter PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.TriadRejectsSinkStageInInput
+        COMMAND $<TARGET_FILE:orc-cli> --input "video_sink" --output "video_sink"
+    )
+    set_tests_properties(CLI.TriadRejectsSinkStageInInput PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    # Pure unit test for the filtergraph parser (no orc-core dependency).
+    find_package(GTest REQUIRED)
+    add_executable(orc-cli-filtergraph-parser-test
+        filtergraph_parser_test.cpp
+        ${CMAKE_SOURCE_DIR}/orc/presenters/src/filtergraph_parser.cpp
+    )
+    target_include_directories(orc-cli-filtergraph-parser-test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/orc/presenters/include
+    )
+    target_link_libraries(orc-cli-filtergraph-parser-test PRIVATE
+        GTest::gtest_main
+    )
+    add_test(
+        NAME CLI.FiltergraphParserUnit
+        COMMAND $<TARGET_FILE:orc-cli-filtergraph-parser-test>
+    )
+    set_tests_properties(CLI.FiltergraphParserUnit PROPERTIES
+        LABELS "unit;cli"
     )
 endif()

--- a/orc/cli/CMakeLists.txt
+++ b/orc/cli/CMakeLists.txt
@@ -280,6 +280,25 @@ if(BUILD_UNIT_TESTS)
         WILL_FAIL TRUE
     )
 
+    add_test(
+        NAME CLI.VideoFormatRejectedWithoutExportProject
+        COMMAND $<TARGET_FILE:orc-cli> --input "src" --output "sink"
+                --video-format NTSC
+    )
+    set_tests_properties(CLI.VideoFormatRejectedWithoutExportProject PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.HelpShowsVideoFormatOption
+        COMMAND $<TARGET_FILE:orc-cli> --help
+    )
+    set_tests_properties(CLI.HelpShowsVideoFormatOption PROPERTIES
+        LABELS "unit;cli"
+        PASS_REGULAR_EXPRESSION "--video-format"
+    )
+
     # Pure unit test for the filtergraph parser (no orc-core dependency).
     find_package(GTest REQUIRED)
     add_executable(orc-cli-filtergraph-parser-test

--- a/orc/cli/CMakeLists.txt
+++ b/orc/cli/CMakeLists.txt
@@ -204,7 +204,7 @@ if(BUILD_UNIT_TESTS)
         WILL_FAIL TRUE
     )
 
-    # --- Filtergraph mode -----------------------------------------------------
+    # --- Filtergraph mode (input/filters/output triad) ------------------------
 
     add_test(
         NAME CLI.HelpShowsFilterCommand
@@ -212,13 +212,13 @@ if(BUILD_UNIT_TESTS)
     )
     set_tests_properties(CLI.HelpShowsFilterCommand PROPERTIES
         LABELS "unit;cli"
-        PASS_REGULAR_EXPRESSION "--filter"
+        PASS_REGULAR_EXPRESSION "--input"
     )
 
     add_test(
         NAME CLI.FilterUnknownStageFails
         COMMAND $<TARGET_FILE:orc-cli>
-                --filter "definitely_not_a_stage, video_sink"
+                --input "definitely_not_a_stage" --output "video_sink"
     )
     set_tests_properties(CLI.FilterUnknownStageFails PROPERTIES
         LABELS "unit;cli"
@@ -227,7 +227,7 @@ if(BUILD_UNIT_TESTS)
 
     add_test(
         NAME CLI.FilterMalformedGraphFails
-        COMMAND $<TARGET_FILE:orc-cli> --filter "src=badparam, sink"
+        COMMAND $<TARGET_FILE:orc-cli> --input "src=badparam" --output sink
     )
     set_tests_properties(CLI.FilterMalformedGraphFails PROPERTIES
         LABELS "unit;cli"
@@ -236,7 +236,7 @@ if(BUILD_UNIT_TESTS)
 
     add_test(
         NAME CLI.FilterRejectsProjectFileCombination
-        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --filter "src, sink"
+        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --input "src" --output sink
     )
     set_tests_properties(CLI.FilterRejectsProjectFileCombination PROPERTIES
         LABELS "unit;cli"
@@ -244,10 +244,10 @@ if(BUILD_UNIT_TESTS)
     )
 
     add_test(
-        NAME CLI.TriadRejectsCombinationWithFilter
-        COMMAND $<TARGET_FILE:orc-cli> --input "src" --filter "src, sink"
+        NAME CLI.ProcessAndTriadCannotCombine
+        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --process --input "src"
     )
-    set_tests_properties(CLI.TriadRejectsCombinationWithFilter PROPERTIES
+    set_tests_properties(CLI.ProcessAndTriadCannotCombine PROPERTIES
         LABELS "unit;cli"
         WILL_FAIL TRUE
     )
@@ -257,6 +257,25 @@ if(BUILD_UNIT_TESTS)
         COMMAND $<TARGET_FILE:orc-cli> --input "video_sink" --output "video_sink"
     )
     set_tests_properties(CLI.TriadRejectsSinkStageInInput PROPERTIES
+        LABELS "unit;cli"
+        WILL_FAIL TRUE
+    )
+
+    add_test(
+        NAME CLI.HelpShowsExportProjectOption
+        COMMAND $<TARGET_FILE:orc-cli> --help
+    )
+    set_tests_properties(CLI.HelpShowsExportProjectOption PROPERTIES
+        LABELS "unit;cli"
+        PASS_REGULAR_EXPRESSION "--export-project"
+    )
+
+    add_test(
+        NAME CLI.ExportProjectRejectedWithProjectFile
+        COMMAND $<TARGET_FILE:orc-cli> project.orcprj --process
+                --export-project out.orcprj
+    )
+    set_tests_properties(CLI.ExportProjectRejectedWithProjectFile PROPERTIES
         LABELS "unit;cli"
         WILL_FAIL TRUE
     )

--- a/orc/cli/command_filter.cpp
+++ b/orc/cli/command_filter.cpp
@@ -1,8 +1,7 @@
 /*
  * File:        command_filter.cpp
  * Module:      orc-cli
- * Purpose:     Build and process a DAG from an ffmpeg-style filtergraph
- *              (or an input/filters/output triad).
+ * Purpose:     Build and process a DAG from an input/filters/output triad.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025-2026 Simon Inns
@@ -98,39 +97,32 @@ void log_plugin_diagnostics(const ProjectPresenter& presenter) {
 }  // namespace
 
 int filter_command(const FilterOptions& options) {
-  const bool triad_mode = options.filtergraph.empty();
+  const auto stage_index = build_stage_index();
 
+  std::string error;
+  if (!validate_triad_segment(options.input_stages, StageCategory::kInput,
+                              stage_index, error) ||
+      !validate_triad_segment(options.filters_stages, StageCategory::kFilters,
+                              stage_index, error) ||
+      !validate_triad_segment(options.output_stages, StageCategory::kOutput,
+                              stage_index, error)) {
+    ORC_LOG_ERROR("{}", error);
+    return 1;
+  }
+
+  std::vector<std::string> segments;
+  for (const auto& segment :
+       {options.input_stages, options.filters_stages, options.output_stages}) {
+    if (!segment.empty()) {
+      segments.push_back(segment);
+    }
+  }
   std::string combined_graph;
-
-  if (triad_mode) {
-    const auto stage_index = build_stage_index();
-
-    std::string error;
-    if (!validate_triad_segment(options.input_stages, StageCategory::kInput,
-                                stage_index, error) ||
-        !validate_triad_segment(options.filters_stages, StageCategory::kFilters,
-                                stage_index, error) ||
-        !validate_triad_segment(options.output_stages, StageCategory::kOutput,
-                                stage_index, error)) {
-      ORC_LOG_ERROR("{}", error);
-      return 1;
+  for (size_t i = 0; i < segments.size(); ++i) {
+    if (i > 0) {
+      combined_graph += ",";
     }
-
-    std::vector<std::string> segments;
-    for (const auto& segment : {options.input_stages, options.filters_stages,
-                                options.output_stages}) {
-      if (!segment.empty()) {
-        segments.push_back(segment);
-      }
-    }
-    for (size_t i = 0; i < segments.size(); ++i) {
-      if (i > 0) {
-        combined_graph += ",";
-      }
-      combined_graph += segments[i];
-    }
-  } else {
-    combined_graph = options.filtergraph;
+    combined_graph += segments[i];
   }
 
   ProjectPresenter presenter;
@@ -155,6 +147,20 @@ int filter_command(const FilterOptions& options) {
 
   ORC_LOG_INFO("Parsed filtergraph successfully");
   log_plugin_diagnostics(presenter);
+
+  // --export-project: save the assembled project instead of running it.
+  // This calls the presenter's existing saveProject() (the same YAML writer
+  // used elsewhere), so it's a different entry point into the existing save
+  // path, not a new one.
+  if (!options.export_project_path.empty()) {
+    if (!presenter.saveProject(options.export_project_path)) {
+      ORC_LOG_ERROR("Failed to save project to '{}'",
+                    options.export_project_path);
+      return 1;
+    }
+    ORC_LOG_INFO("Project saved to '{}'", options.export_project_path);
+    return 0;
+  }
 
   // Validate the assembled project before running.
   if (!presenter.validateProject()) {

--- a/orc/cli/command_filter.cpp
+++ b/orc/cli/command_filter.cpp
@@ -9,6 +9,7 @@
 
 #include "command_filter.h"
 
+#include <cctype>
 #include <map>
 #include <string>
 #include <vector>
@@ -27,6 +28,34 @@ namespace {
 
 using orc::presenters::ProjectPresenter;
 using orc::presenters::StageInfo;
+using orc::presenters::VideoFormat;
+
+/**
+ * Parse a video format name for --video-format (export-only override).
+ * Accepts "NTSC", "PAL", or "PAL-M" (case-insensitive; "PAL_M"/"PALM" also
+ * accepted for convenience). Returns false, leaving `out` untouched, for
+ * anything else.
+ */
+bool parse_video_format_name(const std::string& text, VideoFormat& out) {
+  std::string upper;
+  upper.reserve(text.size());
+  for (char c : text) {
+    upper += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  }
+  if (upper == "NTSC") {
+    out = VideoFormat::NTSC;
+    return true;
+  }
+  if (upper == "PAL") {
+    out = VideoFormat::PAL;
+    return true;
+  }
+  if (upper == "PAL-M" || upper == "PAL_M" || upper == "PALM") {
+    out = VideoFormat::PAL_M;
+    return true;
+  }
+  return false;
+}
 
 /**
  * Validate that every stage named in `segment` belongs to `category`
@@ -153,6 +182,34 @@ int filter_command(const FilterOptions& options) {
   // used elsewhere), so it's a different entry point into the existing save
   // path, not a new one.
   if (!options.export_project_path.empty()) {
+    // Running in memory tolerates an undetermined video format (the core's
+    // own compatibility checks are simply skipped), but a saved .orcprj file
+    // is not: the loader requires an explicit NTSC/PAL/PAL-M value and
+    // rejects a project without one. If none of the stages used gave any
+    // format hint (e.g. tbc_source, which reads its own format from its
+    // metadata sidecar rather than the project), --video-format lets the
+    // export succeed anyway.
+    if (presenter.getVideoFormat() == orc::presenters::VideoFormat::Unknown) {
+      if (options.export_video_format.empty()) {
+        ORC_LOG_ERROR(
+            "Cannot export: none of the stages used imply a video format "
+            "(NTSC/PAL/PAL-M), so the saved project would fail to reload. "
+            "Pass --video-format NTSC|PAL|PAL-M to set it explicitly for "
+            "the export, or run the pipeline directly instead of "
+            "exporting.");
+        return 1;
+      }
+      orc::presenters::VideoFormat forced =
+          orc::presenters::VideoFormat::Unknown;
+      if (!parse_video_format_name(options.export_video_format, forced)) {
+        ORC_LOG_ERROR(
+            "Unknown --video-format value '{}': expected NTSC, PAL, or "
+            "PAL-M",
+            options.export_video_format);
+        return 1;
+      }
+      presenter.setVideoFormat(forced);
+    }
     if (!presenter.saveProject(options.export_project_path)) {
       ORC_LOG_ERROR("Failed to save project to '{}'",
                     options.export_project_path);

--- a/orc/cli/command_filter.cpp
+++ b/orc/cli/command_filter.cpp
@@ -1,7 +1,7 @@
 /*
  * File:        command_filter.cpp
  * Module:      orc-cli
- * Purpose:     Build and process a DAG from an input/filters/output triad.
+ * Purpose:     Build and process a DAG from a source/filters/sink triad.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025-2026 Simon Inns
@@ -9,7 +9,9 @@
 
 #include "command_filter.h"
 
+#include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <map>
 #include <string>
 #include <vector>
@@ -26,7 +28,10 @@ namespace cli {
 
 namespace {
 
+using orc::presenters::FilterGraphParseResult;
+using orc::presenters::parse_filtergraph;
 using orc::presenters::ProjectPresenter;
+using orc::presenters::SourceType;
 using orc::presenters::StageInfo;
 using orc::presenters::VideoFormat;
 
@@ -58,6 +63,30 @@ bool parse_video_format_name(const std::string& text, VideoFormat& out) {
 }
 
 /**
+ * Parse a source type name for --source-type (export-only override).
+ * Accepts "composite" or "yc" (case-insensitive; "y/c" and "s-video" also
+ * accepted for convenience). Returns false, leaving `out` untouched, for
+ * anything else.
+ */
+bool parse_source_type_name(const std::string& text, SourceType& out) {
+  std::string lower;
+  lower.reserve(text.size());
+  for (char c : text) {
+    lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  if (lower == "composite" || lower == "cvbs") {
+    out = SourceType::Composite;
+    return true;
+  }
+  if (lower == "yc" || lower == "y/c" || lower == "svideo" ||
+      lower == "s-video") {
+    out = SourceType::YC;
+    return true;
+  }
+  return false;
+}
+
+/**
  * Validate that every stage named in `segment` belongs to `category`
  * (input segments must be sources, filters segments must be neither
  * source nor sink, output segments must be sinks). A stage's category is
@@ -82,7 +111,8 @@ bool validate_triad_segment(const std::string& segment, StageCategory category,
     if (it == stage_index.end()) {
       error = std::string(category_flag(category)) + ": unknown stage '" +
               stage.stage_name +
-              "'. Run 'orc-cli plugins stages' to see available stages.";
+              "'. Check the exact name in the GUI's stage palette or the "
+              "stage's own documentation.";
       return false;
     }
     if (!stage_matches_category(it->second, category)) {
@@ -210,6 +240,66 @@ int filter_command(const FilterOptions& options) {
       }
       presenter.setVideoFormat(forced);
     }
+
+    // Mirror the same guard for source signal type: the loader also
+    // hard-requires 'source_format' even though running in memory never
+    // needs it, and infer_source_format() can only conclude anything when a
+    // source stage's parameters actually reveal it (see
+    // filtergraph_import.cpp) — some legitimate graphs give no such hint.
+    if (presenter.getSourceFormat() == SourceType::Unknown) {
+      if (options.export_source_type.empty()) {
+        ORC_LOG_ERROR(
+            "Cannot export: none of the stages used imply a source signal "
+            "type (composite/Y-C), so the saved project would fail to "
+            "reload. Pass --source-type composite|yc to set it explicitly "
+            "for the export, or run the pipeline directly instead of "
+            "exporting.");
+        return 1;
+      }
+      SourceType forced_source = SourceType::Unknown;
+      if (!parse_source_type_name(options.export_source_type, forced_source)) {
+        ORC_LOG_ERROR(
+            "Unknown --source-type value '{}': expected composite or yc",
+            options.export_source_type);
+        return 1;
+      }
+      presenter.setSourceType(forced_source);
+    }
+
+    // A saved .orcprj resolves relative file-path parameters against the
+    // *file's own* directory on reload (see Project::project_root_), not
+    // the directory the export command was run from. Absolutise any
+    // relative FILE_PATH parameter now, while it still means what the
+    // person typed, so the path doesn't silently change meaning once saved
+    // elsewhere.
+    for (const auto& node : presenter.getNodes()) {
+      const auto descriptors = presenter.getStageParameters(node.stage_name);
+      auto params = presenter.getNodeParameters(node.node_id);
+      bool changed = false;
+      for (auto& [key, value] : params) {
+        const auto descriptor_it =
+            std::find_if(descriptors.begin(), descriptors.end(),
+                         [&](const auto& d) { return d.name == key; });
+        if (descriptor_it == descriptors.end() ||
+            descriptor_it->type != orc::ParameterType::FILE_PATH ||
+            !std::holds_alternative<std::string>(value)) {
+          continue;
+        }
+        const std::string& path_str = std::get<std::string>(value);
+        if (path_str.empty()) {
+          continue;
+        }
+        const std::filesystem::path path(path_str);
+        if (path.is_relative()) {
+          value = std::filesystem::absolute(path).lexically_normal().string();
+          changed = true;
+        }
+      }
+      if (changed) {
+        presenter.setNodeParameters(node.node_id, params);
+      }
+    }
+
     if (!presenter.saveProject(options.export_project_path)) {
       ORC_LOG_ERROR("Failed to save project to '{}'",
                     options.export_project_path);

--- a/orc/cli/command_filter.cpp
+++ b/orc/cli/command_filter.cpp
@@ -207,6 +207,37 @@ int filter_command(const FilterOptions& options) {
   ORC_LOG_INFO("Parsed filtergraph successfully");
   log_plugin_diagnostics(presenter);
 
+  // If the user supplied an explicit --video-format/--source-type and none
+  // of the stages implied one, apply it now — regardless of whether we're
+  // about to export or run directly. This is what makes a graph decoded
+  // directly with --video-format behave identically to the same graph
+  // exported then processed with --process: both see the same format-
+  // specific parameter defaults (project_to_dag.cpp selects them from
+  // video_format/source_type), rather than only the exported/reprocessed
+  // path ever getting a concrete value.
+  if (presenter.getVideoFormat() == orc::presenters::VideoFormat::Unknown &&
+      !options.video_format_override.empty()) {
+    orc::presenters::VideoFormat forced = orc::presenters::VideoFormat::Unknown;
+    if (!parse_video_format_name(options.video_format_override, forced)) {
+      ORC_LOG_ERROR(
+          "Unknown --video-format value '{}': expected NTSC, PAL, or PAL-M",
+          options.video_format_override);
+      return 1;
+    }
+    presenter.setVideoFormat(forced);
+  }
+  if (presenter.getSourceFormat() == SourceType::Unknown &&
+      !options.source_type_override.empty()) {
+    SourceType forced_source = SourceType::Unknown;
+    if (!parse_source_type_name(options.source_type_override, forced_source)) {
+      ORC_LOG_ERROR(
+          "Unknown --source-type value '{}': expected composite or yc",
+          options.source_type_override);
+      return 1;
+    }
+    presenter.setSourceType(forced_source);
+  }
+
   // --export-project: save the assembled project instead of running it.
   // This calls the presenter's existing saveProject() (the same YAML writer
   // used elsewhere), so it's a different entry point into the existing save
@@ -215,30 +246,16 @@ int filter_command(const FilterOptions& options) {
     // Running in memory tolerates an undetermined video format (the core's
     // own compatibility checks are simply skipped), but a saved .orcprj file
     // is not: the loader requires an explicit NTSC/PAL/PAL-M value and
-    // rejects a project without one. If none of the stages used gave any
-    // format hint (e.g. tbc_source, which reads its own format from its
-    // metadata sidecar rather than the project), --video-format lets the
-    // export succeed anyway.
+    // rejects a project without one. The override above already applied
+    // --video-format if one was given; this only fires when none of the
+    // stages implied a format *and* no override was supplied either.
     if (presenter.getVideoFormat() == orc::presenters::VideoFormat::Unknown) {
-      if (options.export_video_format.empty()) {
-        ORC_LOG_ERROR(
-            "Cannot export: none of the stages used imply a video format "
-            "(NTSC/PAL/PAL-M), so the saved project would fail to reload. "
-            "Pass --video-format NTSC|PAL|PAL-M to set it explicitly for "
-            "the export, or run the pipeline directly instead of "
-            "exporting.");
-        return 1;
-      }
-      orc::presenters::VideoFormat forced =
-          orc::presenters::VideoFormat::Unknown;
-      if (!parse_video_format_name(options.export_video_format, forced)) {
-        ORC_LOG_ERROR(
-            "Unknown --video-format value '{}': expected NTSC, PAL, or "
-            "PAL-M",
-            options.export_video_format);
-        return 1;
-      }
-      presenter.setVideoFormat(forced);
+      ORC_LOG_ERROR(
+          "Cannot export: none of the stages used imply a video format "
+          "(NTSC/PAL/PAL-M), so the saved project would fail to reload. "
+          "Pass --video-format NTSC|PAL|PAL-M, or run the pipeline "
+          "directly instead of exporting.");
+      return 1;
     }
 
     // Mirror the same guard for source signal type: the loader also
@@ -247,23 +264,12 @@ int filter_command(const FilterOptions& options) {
     // source stage's parameters actually reveal it (see
     // filtergraph_import.cpp) — some legitimate graphs give no such hint.
     if (presenter.getSourceFormat() == SourceType::Unknown) {
-      if (options.export_source_type.empty()) {
-        ORC_LOG_ERROR(
-            "Cannot export: none of the stages used imply a source signal "
-            "type (composite/Y-C), so the saved project would fail to "
-            "reload. Pass --source-type composite|yc to set it explicitly "
-            "for the export, or run the pipeline directly instead of "
-            "exporting.");
-        return 1;
-      }
-      SourceType forced_source = SourceType::Unknown;
-      if (!parse_source_type_name(options.export_source_type, forced_source)) {
-        ORC_LOG_ERROR(
-            "Unknown --source-type value '{}': expected composite or yc",
-            options.export_source_type);
-        return 1;
-      }
-      presenter.setSourceType(forced_source);
+      ORC_LOG_ERROR(
+          "Cannot export: none of the stages used imply a source signal "
+          "type (composite/Y-C), so the saved project would fail to "
+          "reload. Pass --source-type composite|yc, or run the pipeline "
+          "directly instead of exporting.");
+      return 1;
     }
 
     // A saved .orcprj resolves relative file-path parameters against the

--- a/orc/cli/command_filter.cpp
+++ b/orc/cli/command_filter.cpp
@@ -1,0 +1,186 @@
+/*
+ * File:        command_filter.cpp
+ * Module:      orc-cli
+ * Purpose:     Build and process a DAG from an ffmpeg-style filtergraph
+ *              (or an input/filters/output triad).
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#include "command_filter.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "filtergraph_import.h"
+#include "filtergraph_parser.h"
+#include "logging.h"
+#include "project_presenter.h"
+#include "project_presenter_types.h"
+#include "stage_category.h"
+
+namespace orc {
+namespace cli {
+
+namespace {
+
+using orc::presenters::ProjectPresenter;
+using orc::presenters::StageInfo;
+
+/**
+ * Validate that every stage named in `segment` belongs to `category`
+ * (input segments must be sources, filters segments must be neither
+ * source nor sink, output segments must be sinks). A stage's category is
+ * never a guess: it comes straight from the same StageInfo the GUI uses, so
+ * this works identically for core stages and for any third-party plugin
+ * stage. Returns true (and leaves `error` untouched) when `segment` is empty
+ * or every stage matches; otherwise returns false with `error` set.
+ */
+bool validate_triad_segment(const std::string& segment, StageCategory category,
+                            const std::map<std::string, StageInfo>& stage_index,
+                            std::string& error) {
+  if (segment.empty()) {
+    return true;
+  }
+  FilterGraphParseResult parsed = parse_filtergraph(segment);
+  if (!parsed.ok) {
+    error = std::string(category_flag(category)) + ": " + parsed.error;
+    return false;
+  }
+  for (const auto& stage : parsed.graph.stages) {
+    auto it = stage_index.find(stage.stage_name);
+    if (it == stage_index.end()) {
+      error = std::string(category_flag(category)) + ": unknown stage '" +
+              stage.stage_name +
+              "'. Run 'orc-cli plugins stages' to see available stages.";
+      return false;
+    }
+    if (!stage_matches_category(it->second, category)) {
+      error = std::string(category_flag(category)) + ": stage '" +
+              stage.stage_name + "' (" + it->second.display_name + ") is " +
+              actual_role_description(it->second) + " — it belongs under " +
+              suggested_flag_for(it->second) + ", not " +
+              category_flag(category) + ".";
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Log runtime plugin diagnostics so stage-loading problems are visible, in the
+/// same spirit as the process command.
+void log_plugin_diagnostics(const ProjectPresenter& presenter) {
+  const auto loaded = presenter.listLoadedPlugins();
+  if (!loaded.empty()) {
+    ORC_LOG_DEBUG("Loaded {} runtime stage plugin(s)", loaded.size());
+  }
+  for (const auto& diagnostic : presenter.listPluginDiagnostics()) {
+    const std::string message =
+        diagnostic.path.empty()
+            ? diagnostic.message
+            : diagnostic.message + " [" + diagnostic.path + "]";
+    switch (diagnostic.severity) {
+      case orc::presenters::PluginDiagnosticSeverity::Info:
+        ORC_LOG_DEBUG("Plugin runtime: {}", message);
+        break;
+      case orc::presenters::PluginDiagnosticSeverity::Warning:
+        ORC_LOG_WARN("Plugin runtime: {}", message);
+        break;
+      case orc::presenters::PluginDiagnosticSeverity::Error:
+        ORC_LOG_ERROR("Plugin runtime: {}", message);
+        break;
+    }
+  }
+}
+
+}  // namespace
+
+int filter_command(const FilterOptions& options) {
+  const bool triad_mode = options.filtergraph.empty();
+
+  std::string combined_graph;
+
+  if (triad_mode) {
+    const auto stage_index = build_stage_index();
+
+    std::string error;
+    if (!validate_triad_segment(options.input_stages, StageCategory::kInput,
+                                stage_index, error) ||
+        !validate_triad_segment(options.filters_stages, StageCategory::kFilters,
+                                stage_index, error) ||
+        !validate_triad_segment(options.output_stages, StageCategory::kOutput,
+                                stage_index, error)) {
+      ORC_LOG_ERROR("{}", error);
+      return 1;
+    }
+
+    std::vector<std::string> segments;
+    for (const auto& segment : {options.input_stages, options.filters_stages,
+                                options.output_stages}) {
+      if (!segment.empty()) {
+        segments.push_back(segment);
+      }
+    }
+    for (size_t i = 0; i < segments.size(); ++i) {
+      if (i > 0) {
+        combined_graph += ",";
+      }
+      combined_graph += segments[i];
+    }
+  } else {
+    combined_graph = options.filtergraph;
+  }
+
+  ProjectPresenter presenter;
+  presenter.setProjectName("filtergraph");
+
+  // Parsing, stage/parameter validation, video-format/source-type
+  // auto-detection, and node/edge construction are all shared with the GUI
+  // (any "paste a CLI command" feature would call the very same function).
+  const orc::presenters::FiltergraphImportResult import_result =
+      orc::presenters::import_filtergraph_into_project(presenter,
+                                                       combined_graph);
+
+  for (const auto& warning : import_result.warnings) {
+    ORC_LOG_WARN("{}", warning);
+  }
+  if (!import_result.ok) {
+    for (const auto& error : import_result.errors) {
+      ORC_LOG_ERROR("{}", error);
+    }
+    return 1;
+  }
+
+  ORC_LOG_INFO("Parsed filtergraph successfully");
+  log_plugin_diagnostics(presenter);
+
+  // Validate the assembled project before running.
+  if (!presenter.validateProject()) {
+    for (const auto& error : presenter.getValidationErrors()) {
+      ORC_LOG_ERROR("Validation: {}", error);
+    }
+    ORC_LOG_ERROR("Filtergraph did not produce a valid project");
+    return 1;
+  }
+
+  // Trigger all sinks with console progress reporting.
+  size_t last_percent = 0;
+  auto progress_callback = [&last_percent](size_t current, size_t total,
+                                           const std::string& message) {
+    if (total > 0) {
+      size_t percent = (current * 100) / total;
+      if (percent >= last_percent + 5 || current == total) {
+        ORC_LOG_INFO("[Progress: {}%] {}", percent, message);
+        last_percent = percent;
+      }
+    }
+  };
+
+  const bool all_success = presenter.triggerAllSinks(progress_callback);
+  return all_success ? 0 : 1;
+}
+
+}  // namespace cli
+}  // namespace orc

--- a/orc/cli/command_filter.h
+++ b/orc/cli/command_filter.h
@@ -46,20 +46,25 @@ struct FilterOptions {
   std::string export_project_path;
 
   /// Optional override for the project's video format ("NTSC", "PAL", or
-  /// "PAL-M"), only consulted when exporting (export_project_path is set)
-  /// and none of the stages used imply a format on their own. Running in
-  /// memory never needs this — the .orcprj file format itself requires an
-  /// explicit format, but the core's own compatibility checks do not, so
-  /// this exists purely to satisfy the save path for stages that are
-  /// legitimately format-agnostic (e.g. tbc_source, which reads its own
-  /// format from its metadata sidecar file rather than from the project).
-  std::string export_video_format;
+  /// "PAL-M"), applied whenever none of the stages used imply a format on
+  /// their own — whether running directly or exporting. Running in memory
+  /// doesn't *need* this (the core's own compatibility checks tolerate an
+  /// undetermined format), but supplying it anyway means the same graph
+  /// behaves identically run directly or exported then reprocessed with
+  /// --process, since format-specific parameter defaults are selected from
+  /// the same video_format either way (see project_to_dag.cpp). Exporting
+  /// specifically *requires* a concrete value one way or another — the
+  /// .orcprj file format itself always requires an explicit format — so a
+  /// stage that is legitimately format-agnostic (e.g. tbc_source, which
+  /// reads its own format from its metadata sidecar file rather than from
+  /// the project) needs this to export at all.
+  std::string video_format_override;
 
   /// Optional override for the project's source signal type ("composite"
-  /// or "yc"), only consulted when exporting and none of the source stages'
-  /// parameters reveal it on their own (e.g. tbc_source with only pcm_path
-  /// set). Same rationale as export_video_format above.
-  std::string export_source_type;
+  /// or "yc"), applied under the same conditions and for the same reasons
+  /// as video_format_override above (e.g. tbc_source with only pcm_path set
+  /// reveals neither on its own).
+  std::string source_type_override;
 };
 
 /**

--- a/orc/cli/command_filter.h
+++ b/orc/cli/command_filter.h
@@ -1,7 +1,7 @@
 /*
  * File:        command_filter.h
  * Module:      orc-cli
- * Purpose:     Build and process a DAG from an input/filters/output triad
+ * Purpose:     Build and process a DAG from a source/filters/sink triad
  *              instead of a .orcprj project file.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -18,21 +18,24 @@ namespace cli {
 /**
  * @brief Options for the filter command.
  *
- * `input_stages` / `filters_stages` / `output_stages` each hold a (possibly
+ * `input_stages` / `filters_stages` / `output_stages` correspond to the CLI's
+ * --source/--filters/--sink flags respectively; each holds a (possibly
  * comma/semicolon-chained) fragment restricted to one stage category —
- * source stages, processing stages, and sink stages respectively — and are
- * validated per category (see filter_command()). Any of the three may be
- * omitted, but at least one must be non-empty.
+ * source stages, processing stages, and sink stages — and is validated per
+ * category (see filter_command()). Any of the three may be omitted, but at
+ * least one must be non-empty.
  *
- * There is no video/source-format option: video format and source type are
- * inherent to the stage modules used (e.g. an NTSC-only source, or the
- * y_path/c_path/input_path parameters actually supplied) and are detected
- * automatically.
+ * There is no video/source-format option for running: video format and
+ * source type are inherent to the stage modules used (e.g. an NTSC-only
+ * source, or the y_path/c_path/input_path parameters actually supplied) and
+ * are detected automatically. The two export_* overrides below exist only
+ * because a saved .orcprj file requires an explicit value even for stages
+ * that are legitimately format-agnostic when run directly.
  */
 struct FilterOptions {
-  std::string input_stages;    ///< Input (source) stage(s).
-  std::string filters_stages;  ///< Processing stage(s).
-  std::string output_stages;   ///< Output (sink) stage(s).
+  std::string input_stages;    ///< --source: input (source) stage(s).
+  std::string filters_stages;  ///< --filters: processing stage(s).
+  std::string output_stages;   ///< --sink: output (sink) stage(s).
 
   /// When non-empty, save the assembled project to this .orcprj path
   /// instead of running it (e.g. for later editing in the GUI, or reuse
@@ -51,12 +54,18 @@ struct FilterOptions {
   /// legitimately format-agnostic (e.g. tbc_source, which reads its own
   /// format from its metadata sidecar file rather than from the project).
   std::string export_video_format;
+
+  /// Optional override for the project's source signal type ("composite"
+  /// or "yc"), only consulted when exporting and none of the source stages'
+  /// parameters reveal it on their own (e.g. tbc_source with only pcm_path
+  /// set). Same rationale as export_video_format above.
+  std::string export_source_type;
 };
 
 /**
  * @brief Execute a filtergraph decode run, or save it instead of running.
  *
- * Parses and composes the input/filters/output triad (validating that each
+ * Parses and composes the source/filters/sink triad (validating that each
  * segment only contains stages of the matching category), auto-detects the
  * project's video format and source type from the stages actually used, and
  * builds an in-memory project via the project presenter.

--- a/orc/cli/command_filter.h
+++ b/orc/cli/command_filter.h
@@ -1,9 +1,8 @@
 /*
  * File:        command_filter.h
  * Module:      orc-cli
- * Purpose:     Build and process a DAG from an ffmpeg-style filtergraph
- *              string (or an input/filters/output triad) instead of a
- *              .orcprj project file.
+ * Purpose:     Build and process a DAG from an input/filters/output triad
+ *              instead of a .orcprj project file.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025-2026 Simon Inns
@@ -19,15 +18,11 @@ namespace cli {
 /**
  * @brief Options for the filter command.
  *
- * Exactly one of the two modes below is used, chosen by which fields are
- * non-empty:
- *
- * - Graph-string mode: `filtergraph` holds a full ffmpeg-style filtergraph.
- * - Triad mode: `input_stages` / `filters_stages` / `output_stages` each hold
- *   a (possibly comma-chained) fragment restricted to one stage category —
- *   source stages, processing stages, and sink stages respectively. This is
- *   friendlier for the common linear pipeline and is validated per category
- *   (see filter_command()).
+ * `input_stages` / `filters_stages` / `output_stages` each hold a (possibly
+ * comma/semicolon-chained) fragment restricted to one stage category —
+ * source stages, processing stages, and sink stages respectively — and are
+ * validated per category (see filter_command()). Any of the three may be
+ * omitted, but at least one must be non-empty.
  *
  * There is no video/source-format option: video format and source type are
  * inherent to the stage modules used (e.g. an NTSC-only source, or the
@@ -35,22 +30,33 @@ namespace cli {
  * automatically.
  */
 struct FilterOptions {
-  std::string filtergraph;     ///< Graph-string mode: full filtergraph.
-  std::string input_stages;    ///< Triad mode: input (source) stage(s).
-  std::string filters_stages;  ///< Triad mode: processing stage(s).
-  std::string output_stages;   ///< Triad mode: output (sink) stage(s).
+  std::string input_stages;    ///< Input (source) stage(s).
+  std::string filters_stages;  ///< Processing stage(s).
+  std::string output_stages;   ///< Output (sink) stage(s).
+
+  /// When non-empty, save the assembled project to this .orcprj path
+  /// instead of running it (e.g. for later editing in the GUI, or reuse
+  /// with --process). No sinks are triggered when this is set. This calls
+  /// the existing ProjectPresenter::saveProject() — the same YAML writer
+  /// used elsewhere — so it is not a new save format, just a different
+  /// entry point into the existing one.
+  std::string export_project_path;
 };
 
 /**
- * @brief Execute a filtergraph decode run.
+ * @brief Execute a filtergraph decode run, or save it instead of running.
  *
- * Parses the filtergraph (or composes and validates the input/filters/output
- * triad), auto-detects the project's video format and source type from the
- * stages actually used, builds an in-memory project via the project
- * presenter, then triggers all sink nodes. No .orcprj file is read or
- * written.
+ * Parses and composes the input/filters/output triad (validating that each
+ * segment only contains stages of the matching category), auto-detects the
+ * project's video format and source type from the stages actually used, and
+ * builds an in-memory project via the project presenter.
  *
- * @param options Filtergraph or triad options.
+ * Normally, triggers all sink nodes and returns their combined result. If
+ * `export_project_path` is set, saves the assembled project as a .orcprj
+ * file instead (for opening in the GUI, or later use with `--process`) and
+ * does not run anything.
+ *
+ * @param options Triad options.
  * @return Exit code (0 = success, non-zero = error).
  */
 int filter_command(const FilterOptions& options);

--- a/orc/cli/command_filter.h
+++ b/orc/cli/command_filter.h
@@ -1,0 +1,59 @@
+/*
+ * File:        command_filter.h
+ * Module:      orc-cli
+ * Purpose:     Build and process a DAG from an ffmpeg-style filtergraph
+ *              string (or an input/filters/output triad) instead of a
+ *              .orcprj project file.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+#include <string>
+
+namespace orc {
+namespace cli {
+
+/**
+ * @brief Options for the filter command.
+ *
+ * Exactly one of the two modes below is used, chosen by which fields are
+ * non-empty:
+ *
+ * - Graph-string mode: `filtergraph` holds a full ffmpeg-style filtergraph.
+ * - Triad mode: `input_stages` / `filters_stages` / `output_stages` each hold
+ *   a (possibly comma-chained) fragment restricted to one stage category —
+ *   source stages, processing stages, and sink stages respectively. This is
+ *   friendlier for the common linear pipeline and is validated per category
+ *   (see filter_command()).
+ *
+ * There is no video/source-format option: video format and source type are
+ * inherent to the stage modules used (e.g. an NTSC-only source, or the
+ * y_path/c_path/input_path parameters actually supplied) and are detected
+ * automatically.
+ */
+struct FilterOptions {
+  std::string filtergraph;     ///< Graph-string mode: full filtergraph.
+  std::string input_stages;    ///< Triad mode: input (source) stage(s).
+  std::string filters_stages;  ///< Triad mode: processing stage(s).
+  std::string output_stages;   ///< Triad mode: output (sink) stage(s).
+};
+
+/**
+ * @brief Execute a filtergraph decode run.
+ *
+ * Parses the filtergraph (or composes and validates the input/filters/output
+ * triad), auto-detects the project's video format and source type from the
+ * stages actually used, builds an in-memory project via the project
+ * presenter, then triggers all sink nodes. No .orcprj file is read or
+ * written.
+ *
+ * @param options Filtergraph or triad options.
+ * @return Exit code (0 = success, non-zero = error).
+ */
+int filter_command(const FilterOptions& options);
+
+}  // namespace cli
+}  // namespace orc

--- a/orc/cli/command_filter.h
+++ b/orc/cli/command_filter.h
@@ -41,6 +41,16 @@ struct FilterOptions {
   /// used elsewhere — so it is not a new save format, just a different
   /// entry point into the existing one.
   std::string export_project_path;
+
+  /// Optional override for the project's video format ("NTSC", "PAL", or
+  /// "PAL-M"), only consulted when exporting (export_project_path is set)
+  /// and none of the stages used imply a format on their own. Running in
+  /// memory never needs this — the .orcprj file format itself requires an
+  /// explicit format, but the core's own compatibility checks do not, so
+  /// this exists purely to satisfy the save path for stages that are
+  /// legitimately format-agnostic (e.g. tbc_source, which reads its own
+  /// format from its metadata sidecar file rather than from the project).
+  std::string export_video_format;
 };
 
 /**

--- a/orc/cli/filtergraph_parser_test.cpp
+++ b/orc/cli/filtergraph_parser_test.cpp
@@ -1,0 +1,284 @@
+/*
+ * File:        filtergraph_parser_test.cpp
+ * Module:      orc-cli-tests
+ * Purpose:     Unit tests for the ffmpeg-style filtergraph parser.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#include "filtergraph_parser.h"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace {
+
+using orc::cli::FilterGraph;
+using orc::cli::parse_filtergraph;
+
+bool HasEdge(const FilterGraph& g, std::size_t from, std::size_t to) {
+  for (const auto& e : g.edges) {
+    if (e.first == from && e.second == to) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path parsing
+// ---------------------------------------------------------------------------
+
+TEST(FiltergraphParser, SimpleAutoChain) {
+  auto r = parse_filtergraph(
+      "NTSC_CVBS_Source=c_path=/a/x.c:y_path=/a/x.y, video_sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  ASSERT_EQ(r.graph.stages.size(), 2u);
+  EXPECT_EQ(r.graph.stages[0].stage_name, "NTSC_CVBS_Source");
+  EXPECT_EQ(r.graph.stages[0].params.at("c_path"), "/a/x.c");
+  EXPECT_EQ(r.graph.stages[0].params.at("y_path"), "/a/x.y");
+  EXPECT_EQ(r.graph.stages[1].stage_name, "video_sink");
+  ASSERT_EQ(r.graph.edges.size(), 1u);
+  EXPECT_TRUE(HasEdge(r.graph, 0, 1));
+}
+
+TEST(FiltergraphParser, ExplicitLabelsAcrossChains) {
+  auto r = parse_filtergraph(
+      "tbc_source=c_path=/a.tbcc:y_path=/a.tbcy [v]; [v] video_sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  ASSERT_EQ(r.graph.stages.size(), 2u);
+  ASSERT_EQ(r.graph.stages[0].output_labels.size(), 1u);
+  EXPECT_EQ(r.graph.stages[0].output_labels[0], "v");
+  ASSERT_EQ(r.graph.stages[1].input_labels.size(), 1u);
+  EXPECT_EQ(r.graph.stages[1].input_labels[0], "v");
+  ASSERT_EQ(r.graph.edges.size(), 1u);
+  EXPECT_TRUE(HasEdge(r.graph, 0, 1));
+}
+
+TEST(FiltergraphParser, MultiInputNode) {
+  auto r = parse_filtergraph(
+      "tbc_source=c_path=/a.tbcc[a]; tbc_source=c_path=/b.tbcc[b]; "
+      "[a][b] stacker [s]; [s] video_sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  ASSERT_EQ(r.graph.stages.size(), 4u);
+  EXPECT_EQ(r.graph.stages[2].stage_name, "stacker");
+  EXPECT_EQ(r.graph.stages[2].input_labels.size(), 2u);
+  ASSERT_EQ(r.graph.edges.size(), 3u);
+  EXPECT_TRUE(HasEdge(r.graph, 0, 2));
+  EXPECT_TRUE(HasEdge(r.graph, 1, 2));
+  EXPECT_TRUE(HasEdge(r.graph, 2, 3));
+}
+
+TEST(FiltergraphParser, QuotedValueWithSpecialChars) {
+  auto r =
+      parse_filtergraph("src=path='/media/My Videos/a:b,c.tbc':gain=1.5, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"), "/media/My Videos/a:b,c.tbc");
+  EXPECT_EQ(r.graph.stages[0].params.at("gain"), "1.5");
+}
+
+TEST(FiltergraphParser, BackslashEscaping) {
+  auto r = parse_filtergraph("src=path=/a\\:b\\,c:k=v, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"), "/a:b,c");
+  EXPECT_EQ(r.graph.stages[0].params.at("k"), "v");
+}
+
+TEST(FiltergraphParser, ValueContainingEquals) {
+  auto r = parse_filtergraph("src=query=a=b=c, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("query"), "a=b=c");
+}
+
+TEST(FiltergraphParser, StageWithoutArgs) {
+  auto r = parse_filtergraph("dropout_correct, video_sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  ASSERT_EQ(r.graph.stages.size(), 2u);
+  EXPECT_TRUE(r.graph.stages[0].params.empty());
+  ASSERT_EQ(r.graph.edges.size(), 1u);
+  EXPECT_TRUE(HasEdge(r.graph, 0, 1));
+}
+
+TEST(FiltergraphParser, FanOutSharedLabel) {
+  auto r = parse_filtergraph("src [x]; [x] sinkA; [x] sinkB");
+  ASSERT_TRUE(r.ok) << r.error;
+  ASSERT_EQ(r.graph.edges.size(), 2u);
+  EXPECT_TRUE(HasEdge(r.graph, 0, 1));
+  EXPECT_TRUE(HasEdge(r.graph, 0, 2));
+}
+
+TEST(FiltergraphParser, ThreeStageChain) {
+  auto r = parse_filtergraph("a, b, c");
+  ASSERT_TRUE(r.ok) << r.error;
+  ASSERT_EQ(r.graph.edges.size(), 2u);
+  EXPECT_TRUE(HasEdge(r.graph, 0, 1));
+  EXPECT_TRUE(HasEdge(r.graph, 1, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Windows path handling
+// ---------------------------------------------------------------------------
+//
+// Windows absolute paths combine two characters that also have syntactic
+// meaning in this grammar: ':' after a drive letter, and '\' as a path
+// separator (which would otherwise be interpreted as an escape character).
+// These tests lock in that unquoted Windows paths survive intact.
+
+TEST(FiltergraphParser, UnquotedWindowsPathWithDriveLetter) {
+  auto r = parse_filtergraph(
+      "tbc_source=input_path=C:\\Users\\superfire\\Documents\\file.tbc, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("input_path"),
+            "C:\\Users\\superfire\\Documents\\file.tbc");
+}
+
+TEST(FiltergraphParser, TwoWindowsPathsInOneStage) {
+  auto r = parse_filtergraph(
+      "hvd_chroma_decoder=input_path=C:\\in\\a.tbc:output_path=D:\\out\\b.rgb, "
+      "sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("input_path"), "C:\\in\\a.tbc");
+  EXPECT_EQ(r.graph.stages[0].params.at("output_path"), "D:\\out\\b.rgb");
+}
+
+TEST(FiltergraphParser, RelativeWindowsStylePathNoDriveLetter) {
+  // The common case: no drive letter, just a bare filename (no colon at all).
+  auto r = parse_filtergraph(
+      "tbc_source=input_path=Santana_smooth_CLV_NTSC.tbc,"
+      "hvd_chroma_decoder=output_path=Santana_smooth_CLV_NTSC.rgb");
+  ASSERT_TRUE(r.ok) << r.error;
+  ASSERT_EQ(r.graph.stages.size(), 2u);
+  ASSERT_EQ(r.graph.edges.size(), 1u);
+  EXPECT_TRUE(HasEdge(r.graph, 0, 1));
+}
+
+TEST(FiltergraphParser, QuotedWindowsPathStillWorks) {
+  auto r = parse_filtergraph("src=path='C:\\Users\\a b\\c.tbc', sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"), "C:\\Users\\a b\\c.tbc");
+}
+
+TEST(FiltergraphParser, DoubledBackslashStillCollapsesToOne) {
+  auto r = parse_filtergraph("src=path=C:\\\\Users\\\\x.tbc, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"), "C:\\Users\\x.tbc");
+}
+
+TEST(FiltergraphParser, RealSeparatorColonStillSplitsNormally) {
+  auto r = parse_filtergraph("src=a=1:b=2, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("a"), "1");
+  EXPECT_EQ(r.graph.stages[0].params.at("b"), "2");
+}
+
+TEST(FiltergraphParser, EscapedLiteralColonStillSupported) {
+  auto r = parse_filtergraph("src=label=ratio\\:16x9, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("label"), "ratio:16x9");
+}
+
+TEST(FiltergraphParser, UncPathNotBrokenByBackslashHandling) {
+  auto r = parse_filtergraph("src=path=\\\\server\\share\\file.tbc, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"), "\\server\\share\\file.tbc");
+}
+
+TEST(FiltergraphParser, ForwardSlashDrivePathAlsoProtected) {
+  auto r = parse_filtergraph("src=path=C:/Users/x/file.tbc, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"), "C:/Users/x/file.tbc");
+}
+
+// ---------------------------------------------------------------------------
+// Double-quote support
+// ---------------------------------------------------------------------------
+//
+// Single quotes and double quotes are fully interchangeable value-quoting
+// styles: whichever one is used, the OTHER quote character may appear
+// literally inside it without ending the quoted span.
+
+TEST(FiltergraphParser, DoubleQuotedWindowsPath) {
+  auto r = parse_filtergraph(
+      "src=path=\"C:\\Users\\superfire\\Documents\\file.tbc\", sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"),
+            "C:\\Users\\superfire\\Documents\\file.tbc");
+}
+
+TEST(FiltergraphParser, DoubleQuotedValueWithSpecialChars) {
+  auto r = parse_filtergraph(
+      "src=path=\"/media/My Videos/a:b,c.tbc\":gain=1.5, sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("path"), "/media/My Videos/a:b,c.tbc");
+  EXPECT_EQ(r.graph.stages[0].params.at("gain"), "1.5");
+}
+
+TEST(FiltergraphParser, DoubleQuotedValueContainingSingleQuote) {
+  auto r = parse_filtergraph("src=label=\"it's a test: ok\", sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("label"), "it's a test: ok");
+}
+
+TEST(FiltergraphParser, SingleQuotedValueContainingDoubleQuote) {
+  auto r = parse_filtergraph("src=label='say \"hi\": ok', sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("label"), "say \"hi\": ok");
+}
+
+TEST(FiltergraphParser, EscapedLiteralDoubleQuoteOutsideQuoting) {
+  auto r = parse_filtergraph("src=label=say \\\"hi\\\", sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("label"), "say \"hi\"");
+}
+
+TEST(FiltergraphParser, RejectsUnterminatedDoubleQuote) {
+  EXPECT_FALSE(parse_filtergraph("src=path=\"/unterminated, sink").ok);
+}
+
+TEST(FiltergraphParser, DoubleQuotedTwoWindowsPathsInOneStage) {
+  auto r = parse_filtergraph(
+      "hvd_chroma_decoder=input_path=\"C:\\in\\a.tbc\":"
+      "output_path=\"D:\\out\\b.rgb\", sink");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ(r.graph.stages[0].params.at("input_path"), "C:\\in\\a.tbc");
+  EXPECT_EQ(r.graph.stages[0].params.at("output_path"), "D:\\out\\b.rgb");
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+TEST(FiltergraphParser, RejectsEmptyGraph) {
+  EXPECT_FALSE(parse_filtergraph("").ok);
+  EXPECT_FALSE(parse_filtergraph("   ").ok);
+}
+
+TEST(FiltergraphParser, RejectsParameterWithoutValue) {
+  EXPECT_FALSE(parse_filtergraph("src=badparam:k=v, sink").ok);
+}
+
+TEST(FiltergraphParser, RejectsEmptyFilter) {
+  EXPECT_FALSE(parse_filtergraph("src, , sink").ok);
+}
+
+TEST(FiltergraphParser, RejectsUnterminatedQuote) {
+  EXPECT_FALSE(parse_filtergraph("src=path='/unterminated, sink").ok);
+}
+
+TEST(FiltergraphParser, RejectsUnterminatedLabel) {
+  EXPECT_FALSE(parse_filtergraph("[a] src [b").ok);
+}
+
+TEST(FiltergraphParser, RejectsTextAfterOutputLabel) {
+  EXPECT_FALSE(parse_filtergraph("src=k=v [out] extra, sink").ok);
+}
+
+TEST(FiltergraphParser, RejectsLoneSeparators) {
+  EXPECT_FALSE(parse_filtergraph(";").ok);
+  EXPECT_FALSE(parse_filtergraph(",").ok);
+}
+
+}  // namespace

--- a/orc/cli/filtergraph_parser_test.cpp
+++ b/orc/cli/filtergraph_parser_test.cpp
@@ -16,8 +16,8 @@
 
 namespace {
 
-using orc::cli::FilterGraph;
-using orc::cli::parse_filtergraph;
+using orc::presenters::FilterGraph;
+using orc::presenters::parse_filtergraph;
 
 bool HasEdge(const FilterGraph& g, std::size_t from, std::size_t to) {
   for (const auto& e : g.edges) {
@@ -137,7 +137,7 @@ TEST(FiltergraphParser, UnquotedWindowsPathWithDriveLetter) {
 
 TEST(FiltergraphParser, TwoWindowsPathsInOneStage) {
   auto r = parse_filtergraph(
-      "hvd_chroma_decoder=input_path=C:\\in\\a.tbc:output_path=D:\\out\\b.rgb, "
+      "dropout_correct=input_path=C:\\in\\a.tbc:output_path=D:\\out\\b.rgb, "
       "sink");
   ASSERT_TRUE(r.ok) << r.error;
   EXPECT_EQ(r.graph.stages[0].params.at("input_path"), "C:\\in\\a.tbc");
@@ -148,7 +148,7 @@ TEST(FiltergraphParser, RelativeWindowsStylePathNoDriveLetter) {
   // The common case: no drive letter, just a bare filename (no colon at all).
   auto r = parse_filtergraph(
       "tbc_source=input_path=Santana_smooth_CLV_NTSC.tbc,"
-      "hvd_chroma_decoder=output_path=Santana_smooth_CLV_NTSC.rgb");
+      "dropout_correct=output_path=Santana_smooth_CLV_NTSC.rgb");
   ASSERT_TRUE(r.ok) << r.error;
   ASSERT_EQ(r.graph.stages.size(), 2u);
   ASSERT_EQ(r.graph.edges.size(), 1u);
@@ -240,7 +240,7 @@ TEST(FiltergraphParser, RejectsUnterminatedDoubleQuote) {
 
 TEST(FiltergraphParser, DoubleQuotedTwoWindowsPathsInOneStage) {
   auto r = parse_filtergraph(
-      "hvd_chroma_decoder=input_path=\"C:\\in\\a.tbc\":"
+      "dropout_correct=input_path=\"C:\\in\\a.tbc\":"
       "output_path=\"D:\\out\\b.rgb\", sink");
   ASSERT_TRUE(r.ok) << r.error;
   EXPECT_EQ(r.graph.stages[0].params.at("input_path"), "C:\\in\\a.tbc");

--- a/orc/cli/orc_cli.cpp
+++ b/orc/cli/orc_cli.cpp
@@ -11,11 +11,13 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "command_filter.h"
 #include "command_plugins.h"
 #include "command_process.h"
 #include "crash_handler.h"
@@ -37,11 +39,31 @@ using namespace orc;  // NOLINT(google-build-using-namespace)
  */
 void print_usage(const char* program_name) {
   std::cerr << "Usage: " << program_name << " <project-file> [options]\n";
+  std::cerr << "       " << program_name
+            << " --filter <graph> | --input/--filters/--output <...>\n";
   std::cerr << "       " << program_name << " plugins <subcommand> [options]\n";
   std::cerr << "\n";
   std::cerr << "Commands:\n";
   std::cerr << "  --process                      Process the whole DAG chain "
                "(trigger all sinks)\n";
+  std::cerr << "  --filter GRAPH                 Build and process a DAG from "
+               "an ffmpeg-style\n";
+  std::cerr << "                                 filtergraph string (no "
+               ".orcprj file)\n";
+  std::cerr << "  --filter-file FILE             Read the filtergraph from "
+               "FILE ('-' for stdin)\n";
+  std::cerr << "  --input GRAPH                  Input (source) stage(s), for "
+               "the input/filters/\n";
+  std::cerr << "                                 output triad — an "
+               "alternative to --filter\n";
+  std::cerr << "  --filters GRAPH                Processing stage(s), for the "
+               "triad\n";
+  std::cerr << "  --output GRAPH                 Output (sink) stage(s), for "
+               "the triad\n";
+  std::cerr << "\n";
+  std::cerr << "Note: video format and source signal type are detected "
+               "automatically\n";
+  std::cerr << "from the stage modules used, and never need to be specified.\n";
   std::cerr << "\n";
   std::cerr << "Plugin Management:\n";
   std::cerr << "  plugins list                   List registry entries and "
@@ -75,6 +97,12 @@ void print_usage(const char* program_name) {
   std::cerr << "  " << program_name << " project.orcprj --process\n";
   std::cerr << "  " << program_name
             << " project.orcprj --process --log-level debug\n";
+  std::cerr << "  " << program_name
+            << " --filter \"tbc_source=input_path=a.tbc, video_sink\"\n";
+  std::cerr << "  " << program_name
+            << " --input tbc_source=input_path=a.tbc \\\n";
+  std::cerr << "      --filters hvd_chroma_decoder --output "
+               "video_sink=output_path=a.mp4\n";
   std::cerr << "  " << program_name << " plugins list\n";
   std::cerr << "  " << program_name
             << " plugins add /path/to/libmyplugin.so --id com.example.my "
@@ -99,6 +127,18 @@ int main(int argc, char* argv[]) {
     std::string log_level = "info";
     std::string log_file;
     bool safe_core_plugins = false;
+
+    // Filtergraph mode: either a full graph string, or the input/filters/
+    // output triad. Mutually exclusive with each other and with a project
+    // file. There is deliberately no video-format/source-format/project-name
+    // option here — those are auto-detected from the stages used.
+    std::string filtergraph;
+    std::string filtergraph_file;
+    std::string input_stages;
+    std::string filters_stages;
+    std::string output_stages;
+    bool graph_string_provided = false;  // --filter / --filter-file
+    bool triad_provided = false;         // --input / --filters / --output
 
     // Command flags
     bool do_process = false;
@@ -179,6 +219,21 @@ int main(int argc, char* argv[]) {
         // Handled before dispatch.
       } else if (arg == "--process") {
         do_process = true;
+      } else if (arg == "--filter" && i + 1 < argc) {
+        filtergraph = argv[++i];
+        graph_string_provided = true;
+      } else if (arg == "--filter-file" && i + 1 < argc) {
+        filtergraph_file = argv[++i];
+        graph_string_provided = true;
+      } else if (arg == "--input" && i + 1 < argc) {
+        input_stages = argv[++i];
+        triad_provided = true;
+      } else if (arg == "--filters" && i + 1 < argc) {
+        filters_stages = argv[++i];
+        triad_provided = true;
+      } else if (arg == "--output" && i + 1 < argc) {
+        output_stages = argv[++i];
+        triad_provided = true;
       } else if (arg[0] != '-') {
         // Positional argument - project file
         if (project_path.empty()) {
@@ -195,18 +250,56 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    // Check if project file was provided
-    if (project_path.empty()) {
-      std::cerr << "Error: No project file specified\n\n";
-      print_usage(argv[0]);
-      return 1;
-    }
+    const bool filtergraph_mode = graph_string_provided || triad_provided;
 
-    // Check if at least one command was specified
-    if (!do_process) {
-      std::cerr << "Error: No command specified. You must use --process\n\n";
-      print_usage(argv[0]);
-      return 1;
+    if (filtergraph_mode) {
+      if (graph_string_provided && triad_provided) {
+        std::cerr << "Error: --filter/--filter-file cannot be combined with "
+                     "--input/--filters/--output\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+      if (!project_path.empty()) {
+        std::cerr << "Error: --filter/--input/--filters/--output cannot be "
+                     "combined with a project file\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+      if (do_process) {
+        std::cerr << "Error: --process is only for a project file and "
+                     "cannot be combined with --filter/--input/--filters/"
+                     "--output\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+      if (graph_string_provided && !filtergraph.empty() &&
+          !filtergraph_file.empty()) {
+        std::cerr
+            << "Error: use either --filter or --filter-file, not both\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+      if (triad_provided && input_stages.empty() && filters_stages.empty() &&
+          output_stages.empty()) {
+        std::cerr
+            << "Error: --input, --filters and --output were all empty\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+    } else {
+      // Check if project file was provided
+      if (project_path.empty()) {
+        std::cerr << "Error: No project file specified\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+
+      // Check if at least one command was specified
+      if (!do_process) {
+        std::cerr << "Error: No command specified. You must use --process\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
     }
 
     // Initialize logging - both app logger and core logger
@@ -231,9 +324,14 @@ int main(int argc, char* argv[]) {
     crash_config.auto_upload_info = true;
 
     // Add callback for custom application state
-    crash_config.custom_info_callback = [&project_path]() -> std::string {
+    crash_config.custom_info_callback = [&project_path,
+                                         filtergraph_mode]() -> std::string {
       std::ostringstream info;
-      info << "Project file: " << project_path << "\n";
+      if (filtergraph_mode) {
+        info << "Mode: filtergraph\n";
+      } else {
+        info << "Project file: " << project_path << "\n";
+      }
       info << "Working directory: " << fs::current_path().string() << "\n";
       return info.str();
     };
@@ -246,10 +344,44 @@ int main(int argc, char* argv[]) {
     int exit_code = 0;
 
     try {
-      cli::ProcessOptions options;
-      options.project_path = project_path;
+      if (filtergraph_mode) {
+        cli::FilterOptions options;
 
-      exit_code = cli::process_command(options);
+        if (graph_string_provided) {
+          // Resolve the filtergraph source (inline string, file, or stdin).
+          std::string graph = filtergraph;
+          if (!filtergraph_file.empty()) {
+            if (filtergraph_file == "-") {
+              std::ostringstream buffer;
+              buffer << std::cin.rdbuf();
+              graph = buffer.str();
+            } else {
+              std::ifstream in(filtergraph_file);
+              if (!in) {
+                ORC_LOG_ERROR("Cannot open filtergraph file: {}",
+                              filtergraph_file);
+                cleanup_crash_handler();
+                return 1;
+              }
+              std::ostringstream buffer;
+              buffer << in.rdbuf();
+              graph = buffer.str();
+            }
+          }
+          options.filtergraph = graph;
+        } else {
+          options.input_stages = input_stages;
+          options.filters_stages = filters_stages;
+          options.output_stages = output_stages;
+        }
+
+        exit_code = cli::filter_command(options);
+      } else {
+        cli::ProcessOptions options;
+        options.project_path = project_path;
+
+        exit_code = cli::process_command(options);
+      }
     } catch (const UserDataError& e) {
       ORC_LOG_WARN("Processing failed: {}", e.what());
       std::cerr << "\nWARNING: " << e.what() << "\n";

--- a/orc/cli/orc_cli.cpp
+++ b/orc/cli/orc_cli.cpp
@@ -39,17 +39,17 @@ using namespace orc;  // NOLINT(google-build-using-namespace)
 void print_usage(const char* program_name) {
   std::cerr << "Usage: " << program_name << " <project-file> [options]\n";
   std::cerr << "       " << program_name
-            << " --input/--filters/--output <...>\n";
+            << " --source/--filters/--sink <...>\n";
   std::cerr << "       " << program_name << " plugins <subcommand> [options]\n";
   std::cerr << "\n";
   std::cerr << "Commands:\n";
   std::cerr << "  --process                      Process the whole DAG chain "
                "(trigger all sinks)\n";
   std::cerr << "\n";
-  std::cerr << "Filtergraph — input/filters/output triad:\n";
-  std::cerr << "  --input GRAPH                  Input (source) stage(s)\n";
-  std::cerr << "  --filters GRAPH                Processing stage(s)\n";
-  std::cerr << "  --output GRAPH                 Output (sink) stage(s)\n";
+  std::cerr << "Filtergraph — source/filters/sink triad:\n";
+  std::cerr << "  --source GRAPH, -i GRAPH       Input (source) stage(s)\n";
+  std::cerr << "  --filters GRAPH, -f GRAPH      Processing stage(s)\n";
+  std::cerr << "  --sink GRAPH, -o GRAPH         Output (sink) stage(s)\n";
   std::cerr << "\n";
   std::cerr << "Filtergraph export:\n";
   std::cerr << "  --export-project FILE          Save the assembled "
@@ -60,16 +60,24 @@ void print_usage(const char* program_name) {
   std::cerr << "  --video-format NTSC|PAL|PAL-M  Only used (and only needed) "
                "with --export-project,\n";
   std::cerr << "                                 if none of the stages used "
-               "imply a format —\n";
-  std::cerr << "                                 e.g. tbc_source reads its "
-               "own format from its\n";
-  std::cerr << "                                 metadata file, so it never "
-               "implies one\n";
+               "imply a video\n";
+  std::cerr << "                                 format — e.g. tbc_source "
+               "reads its own format\n";
+  std::cerr << "                                 from its metadata file, so "
+               "it never implies one\n";
+  std::cerr << "  --source-type composite|yc     Same idea as --video-format, "
+               "but for the source\n";
+  std::cerr << "                                 signal type — needed only "
+               "if no source stage's\n";
+  std::cerr << "                                 parameters reveal it (e.g. "
+               "tbc_source with only\n";
+  std::cerr << "                                 pcm_path set)\n";
   std::cerr << "\n";
   std::cerr << "Note: video format and source signal type are usually "
                "detected automatically\n";
-  std::cerr << "from the stage modules used (see --video-format above for "
-               "the one exception).\n";
+  std::cerr << "from the stage modules used (see --video-format/"
+               "--source-type above for the\n";
+  std::cerr << "rare exception).\n";
   std::cerr << "\n";
   std::cerr << "Plugin Management:\n";
   std::cerr << "  plugins list                   List registry entries and "
@@ -104,11 +112,14 @@ void print_usage(const char* program_name) {
   std::cerr << "  " << program_name
             << " project.orcprj --process --log-level debug\n";
   std::cerr << "  " << program_name
-            << " --input tbc_source=input_path=a.tbc \\\n";
-  std::cerr << "      --filters hvd_chroma_decoder --output "
+            << " --source tbc_source=input_path=a.tbc \\\n";
+  std::cerr << "      --filters dropout_correct --sink "
                "video_sink=output_path=a.mp4\n";
   std::cerr << "  " << program_name
-            << " --input tbc_source=input_path=a.tbc --output video_sink "
+            << " -i \"NTSC_CVBS_Source=input_path=a.composite\" -o video_sink"
+               "=output_path=a.mp4\n";
+  std::cerr << "  " << program_name
+            << " --source tbc_source=input_path=a.tbc --sink video_sink "
                "\\\n";
   std::cerr << "      --export-project a.orcprj\n";
   std::cerr << "  " << program_name << " plugins list\n";
@@ -143,9 +154,10 @@ int main(int argc, char* argv[]) {
     std::string input_stages;
     std::string filters_stages;
     std::string output_stages;
-    bool triad_provided = false;      // --input / --filters / --output
+    bool triad_provided = false;      // --source / --filters / --sink
     std::string export_project_path;  // --export-project
     std::string export_video_format;  // --video-format (export-only override)
+    std::string export_source_type;   // --source-type (export-only override)
 
     // Command flags
     bool do_process = false;
@@ -226,19 +238,21 @@ int main(int argc, char* argv[]) {
         // Handled before dispatch.
       } else if (arg == "--process") {
         do_process = true;
-      } else if (arg == "--input" && i + 1 < argc) {
+      } else if ((arg == "--source" || arg == "-i") && i + 1 < argc) {
         input_stages = argv[++i];
         triad_provided = true;
-      } else if (arg == "--filters" && i + 1 < argc) {
+      } else if ((arg == "--filters" || arg == "-f") && i + 1 < argc) {
         filters_stages = argv[++i];
         triad_provided = true;
-      } else if (arg == "--output" && i + 1 < argc) {
+      } else if ((arg == "--sink" || arg == "-o") && i + 1 < argc) {
         output_stages = argv[++i];
         triad_provided = true;
       } else if (arg == "--export-project" && i + 1 < argc) {
         export_project_path = argv[++i];
       } else if (arg == "--video-format" && i + 1 < argc) {
         export_video_format = argv[++i];
+      } else if (arg == "--source-type" && i + 1 < argc) {
+        export_source_type = argv[++i];
       } else if (arg[0] != '-') {
         // Positional argument - project file
         if (project_path.empty()) {
@@ -263,24 +277,29 @@ int main(int argc, char* argv[]) {
       print_usage(argv[0]);
       return 1;
     }
+    if (!export_source_type.empty() && export_project_path.empty()) {
+      std::cerr << "Error: --source-type only makes sense with "
+                   "--export-project\n\n";
+      print_usage(argv[0]);
+      return 1;
+    }
 
     if (filtergraph_mode) {
       if (!project_path.empty()) {
-        std::cerr << "Error: --input/--filters/--output cannot be "
+        std::cerr << "Error: --source/--filters/--sink cannot be "
                      "combined with a project file\n\n";
         print_usage(argv[0]);
         return 1;
       }
       if (do_process) {
         std::cerr << "Error: --process is only for a project file and "
-                     "cannot be combined with --input/--filters/--output\n\n";
+                     "cannot be combined with --source/--filters/--sink\n\n";
         print_usage(argv[0]);
         return 1;
       }
       if (input_stages.empty() && filters_stages.empty() &&
           output_stages.empty()) {
-        std::cerr
-            << "Error: --input, --filters and --output were all empty\n\n";
+        std::cerr << "Error: --source, --filters and --sink were all empty\n\n";
         print_usage(argv[0]);
         return 1;
       }
@@ -293,7 +312,7 @@ int main(int argc, char* argv[]) {
       }
       if (!export_project_path.empty()) {
         std::cerr << "Error: --export-project only makes sense with "
-                     "--input/--filters/--output (a project file is "
+                     "--source/--filters/--sink (a project file is "
                      "already a project)\n\n";
         print_usage(argv[0]);
         return 1;
@@ -356,6 +375,7 @@ int main(int argc, char* argv[]) {
         options.output_stages = output_stages;
         options.export_project_path = export_project_path;
         options.export_video_format = export_video_format;
+        options.export_source_type = export_source_type;
 
         exit_code = cli::filter_command(options);
       } else {

--- a/orc/cli/orc_cli.cpp
+++ b/orc/cli/orc_cli.cpp
@@ -11,7 +11,6 @@
 
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -40,26 +39,24 @@ using namespace orc;  // NOLINT(google-build-using-namespace)
 void print_usage(const char* program_name) {
   std::cerr << "Usage: " << program_name << " <project-file> [options]\n";
   std::cerr << "       " << program_name
-            << " --filter <graph> | --input/--filters/--output <...>\n";
+            << " --input/--filters/--output <...>\n";
   std::cerr << "       " << program_name << " plugins <subcommand> [options]\n";
   std::cerr << "\n";
   std::cerr << "Commands:\n";
   std::cerr << "  --process                      Process the whole DAG chain "
                "(trigger all sinks)\n";
-  std::cerr << "  --filter GRAPH                 Build and process a DAG from "
-               "an ffmpeg-style\n";
-  std::cerr << "                                 filtergraph string (no "
-               ".orcprj file)\n";
-  std::cerr << "  --filter-file FILE             Read the filtergraph from "
-               "FILE ('-' for stdin)\n";
-  std::cerr << "  --input GRAPH                  Input (source) stage(s), for "
-               "the input/filters/\n";
-  std::cerr << "                                 output triad — an "
-               "alternative to --filter\n";
-  std::cerr << "  --filters GRAPH                Processing stage(s), for the "
-               "triad\n";
-  std::cerr << "  --output GRAPH                 Output (sink) stage(s), for "
-               "the triad\n";
+  std::cerr << "\n";
+  std::cerr << "Filtergraph — input/filters/output triad:\n";
+  std::cerr << "  --input GRAPH                  Input (source) stage(s)\n";
+  std::cerr << "  --filters GRAPH                Processing stage(s)\n";
+  std::cerr << "  --output GRAPH                 Output (sink) stage(s)\n";
+  std::cerr << "\n";
+  std::cerr << "Filtergraph export:\n";
+  std::cerr << "  --export-project FILE          Save the assembled "
+               "filtergraph as a .orcprj file\n";
+  std::cerr << "                                 instead of running it (for "
+               "the GUI, or later\n";
+  std::cerr << "                                 reuse with --process)\n";
   std::cerr << "\n";
   std::cerr << "Note: video format and source signal type are detected "
                "automatically\n";
@@ -98,11 +95,13 @@ void print_usage(const char* program_name) {
   std::cerr << "  " << program_name
             << " project.orcprj --process --log-level debug\n";
   std::cerr << "  " << program_name
-            << " --filter \"tbc_source=input_path=a.tbc, video_sink\"\n";
-  std::cerr << "  " << program_name
             << " --input tbc_source=input_path=a.tbc \\\n";
   std::cerr << "      --filters hvd_chroma_decoder --output "
                "video_sink=output_path=a.mp4\n";
+  std::cerr << "  " << program_name
+            << " --input tbc_source=input_path=a.tbc --output video_sink "
+               "\\\n";
+  std::cerr << "      --export-project a.orcprj\n";
   std::cerr << "  " << program_name << " plugins list\n";
   std::cerr << "  " << program_name
             << " plugins add /path/to/libmyplugin.so --id com.example.my "
@@ -128,17 +127,15 @@ int main(int argc, char* argv[]) {
     std::string log_file;
     bool safe_core_plugins = false;
 
-    // Filtergraph mode: either a full graph string, or the input/filters/
-    // output triad. Mutually exclusive with each other and with a project
-    // file. There is deliberately no video-format/source-format/project-name
-    // option here — those are auto-detected from the stages used.
-    std::string filtergraph;
-    std::string filtergraph_file;
+    // Filtergraph mode: the input/filters/output triad. Mutually exclusive
+    // with a project file. There is deliberately no video-format/source-
+    // format/project-name option here — those are auto-detected from the
+    // stages used.
     std::string input_stages;
     std::string filters_stages;
     std::string output_stages;
-    bool graph_string_provided = false;  // --filter / --filter-file
-    bool triad_provided = false;         // --input / --filters / --output
+    bool triad_provided = false;      // --input / --filters / --output
+    std::string export_project_path;  // --export-project
 
     // Command flags
     bool do_process = false;
@@ -219,12 +216,6 @@ int main(int argc, char* argv[]) {
         // Handled before dispatch.
       } else if (arg == "--process") {
         do_process = true;
-      } else if (arg == "--filter" && i + 1 < argc) {
-        filtergraph = argv[++i];
-        graph_string_provided = true;
-      } else if (arg == "--filter-file" && i + 1 < argc) {
-        filtergraph_file = argv[++i];
-        graph_string_provided = true;
       } else if (arg == "--input" && i + 1 < argc) {
         input_stages = argv[++i];
         triad_provided = true;
@@ -234,6 +225,8 @@ int main(int argc, char* argv[]) {
       } else if (arg == "--output" && i + 1 < argc) {
         output_stages = argv[++i];
         triad_provided = true;
+      } else if (arg == "--export-project" && i + 1 < argc) {
+        export_project_path = argv[++i];
       } else if (arg[0] != '-') {
         // Positional argument - project file
         if (project_path.empty()) {
@@ -250,36 +243,22 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    const bool filtergraph_mode = graph_string_provided || triad_provided;
+    const bool filtergraph_mode = triad_provided;
 
     if (filtergraph_mode) {
-      if (graph_string_provided && triad_provided) {
-        std::cerr << "Error: --filter/--filter-file cannot be combined with "
-                     "--input/--filters/--output\n\n";
-        print_usage(argv[0]);
-        return 1;
-      }
       if (!project_path.empty()) {
-        std::cerr << "Error: --filter/--input/--filters/--output cannot be "
+        std::cerr << "Error: --input/--filters/--output cannot be "
                      "combined with a project file\n\n";
         print_usage(argv[0]);
         return 1;
       }
       if (do_process) {
         std::cerr << "Error: --process is only for a project file and "
-                     "cannot be combined with --filter/--input/--filters/"
-                     "--output\n\n";
+                     "cannot be combined with --input/--filters/--output\n\n";
         print_usage(argv[0]);
         return 1;
       }
-      if (graph_string_provided && !filtergraph.empty() &&
-          !filtergraph_file.empty()) {
-        std::cerr
-            << "Error: use either --filter or --filter-file, not both\n\n";
-        print_usage(argv[0]);
-        return 1;
-      }
-      if (triad_provided && input_stages.empty() && filters_stages.empty() &&
+      if (input_stages.empty() && filters_stages.empty() &&
           output_stages.empty()) {
         std::cerr
             << "Error: --input, --filters and --output were all empty\n\n";
@@ -290,6 +269,13 @@ int main(int argc, char* argv[]) {
       // Check if project file was provided
       if (project_path.empty()) {
         std::cerr << "Error: No project file specified\n\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+      if (!export_project_path.empty()) {
+        std::cerr << "Error: --export-project only makes sense with "
+                     "--input/--filters/--output (a project file is "
+                     "already a project)\n\n";
         print_usage(argv[0]);
         return 1;
       }
@@ -346,34 +332,10 @@ int main(int argc, char* argv[]) {
     try {
       if (filtergraph_mode) {
         cli::FilterOptions options;
-
-        if (graph_string_provided) {
-          // Resolve the filtergraph source (inline string, file, or stdin).
-          std::string graph = filtergraph;
-          if (!filtergraph_file.empty()) {
-            if (filtergraph_file == "-") {
-              std::ostringstream buffer;
-              buffer << std::cin.rdbuf();
-              graph = buffer.str();
-            } else {
-              std::ifstream in(filtergraph_file);
-              if (!in) {
-                ORC_LOG_ERROR("Cannot open filtergraph file: {}",
-                              filtergraph_file);
-                cleanup_crash_handler();
-                return 1;
-              }
-              std::ostringstream buffer;
-              buffer << in.rdbuf();
-              graph = buffer.str();
-            }
-          }
-          options.filtergraph = graph;
-        } else {
-          options.input_stages = input_stages;
-          options.filters_stages = filters_stages;
-          options.output_stages = output_stages;
-        }
+        options.input_stages = input_stages;
+        options.filters_stages = filters_stages;
+        options.output_stages = output_stages;
+        options.export_project_path = export_project_path;
 
         exit_code = cli::filter_command(options);
       } else {

--- a/orc/cli/orc_cli.cpp
+++ b/orc/cli/orc_cli.cpp
@@ -56,15 +56,24 @@ void print_usage(const char* program_name) {
                "filtergraph as a .orcprj file\n";
   std::cerr << "                                 instead of running it (for "
                "the GUI, or later\n";
-  std::cerr << "                                 reuse with --process)\n";
-  std::cerr << "  --video-format NTSC|PAL|PAL-M  Only used (and only needed) "
-               "with --export-project,\n";
-  std::cerr << "                                 if none of the stages used "
-               "imply a video\n";
-  std::cerr << "                                 format — e.g. tbc_source "
-               "reads its own format\n";
-  std::cerr << "                                 from its metadata file, so "
-               "it never implies one\n";
+  std::cerr << "                                 reuse with --process). "
+               "Requires a video format\n";
+  std::cerr << "                                 and source signal type — "
+               "see --video-format/\n";
+  std::cerr << "                                 --source-type below if no "
+               "stage implies one.\n";
+  std::cerr << "  --video-format NTSC|PAL|PAL-M  Set the video format if "
+               "none of the stages used\n";
+  std::cerr << "                                 imply one — e.g. "
+               "tbc_source reads its own\n";
+  std::cerr << "                                 format from its metadata "
+               "file, so it never\n";
+  std::cerr << "                                 implies one. Works when "
+               "running directly too\n";
+  std::cerr << "                                 (so the same graph "
+               "behaves identically either\n";
+  std::cerr << "                                 way); only --export-project "
+               "actually requires it.\n";
   std::cerr << "  --source-type composite|yc     Same idea as --video-format, "
                "but for the source\n";
   std::cerr << "                                 signal type — needed only "
@@ -154,10 +163,10 @@ int main(int argc, char* argv[]) {
     std::string input_stages;
     std::string filters_stages;
     std::string output_stages;
-    bool triad_provided = false;      // --source / --filters / --sink
-    std::string export_project_path;  // --export-project
-    std::string export_video_format;  // --video-format (export-only override)
-    std::string export_source_type;   // --source-type (export-only override)
+    bool triad_provided = false;        // --source / --filters / --sink
+    std::string export_project_path;    // --export-project
+    std::string video_format_override;  // --video-format (export-only override)
+    std::string source_type_override;   // --source-type (export-only override)
 
     // Command flags
     bool do_process = false;
@@ -250,9 +259,9 @@ int main(int argc, char* argv[]) {
       } else if (arg == "--export-project" && i + 1 < argc) {
         export_project_path = argv[++i];
       } else if (arg == "--video-format" && i + 1 < argc) {
-        export_video_format = argv[++i];
+        video_format_override = argv[++i];
       } else if (arg == "--source-type" && i + 1 < argc) {
-        export_source_type = argv[++i];
+        source_type_override = argv[++i];
       } else if (arg[0] != '-') {
         // Positional argument - project file
         if (project_path.empty()) {
@@ -271,15 +280,20 @@ int main(int argc, char* argv[]) {
 
     const bool filtergraph_mode = triad_provided;
 
-    if (!export_video_format.empty() && export_project_path.empty()) {
+    // --video-format/--source-type apply to the source/filters/sink triad
+    // (with or without --export-project — see filter_command()) but have
+    // nowhere to go with a plain .orcprj file, which already carries its
+    // own video_format/source_format from the YAML; reject rather than
+    // silently ignore.
+    if (!video_format_override.empty() && !filtergraph_mode) {
       std::cerr << "Error: --video-format only makes sense with "
-                   "--export-project\n\n";
+                   "--source/--filters/--sink\n\n";
       print_usage(argv[0]);
       return 1;
     }
-    if (!export_source_type.empty() && export_project_path.empty()) {
+    if (!source_type_override.empty() && !filtergraph_mode) {
       std::cerr << "Error: --source-type only makes sense with "
-                   "--export-project\n\n";
+                   "--source/--filters/--sink\n\n";
       print_usage(argv[0]);
       return 1;
     }
@@ -374,8 +388,8 @@ int main(int argc, char* argv[]) {
         options.filters_stages = filters_stages;
         options.output_stages = output_stages;
         options.export_project_path = export_project_path;
-        options.export_video_format = export_video_format;
-        options.export_source_type = export_source_type;
+        options.video_format_override = video_format_override;
+        options.source_type_override = source_type_override;
 
         exit_code = cli::filter_command(options);
       } else {

--- a/orc/cli/orc_cli.cpp
+++ b/orc/cli/orc_cli.cpp
@@ -57,10 +57,19 @@ void print_usage(const char* program_name) {
   std::cerr << "                                 instead of running it (for "
                "the GUI, or later\n";
   std::cerr << "                                 reuse with --process)\n";
+  std::cerr << "  --video-format NTSC|PAL|PAL-M  Only used (and only needed) "
+               "with --export-project,\n";
+  std::cerr << "                                 if none of the stages used "
+               "imply a format —\n";
+  std::cerr << "                                 e.g. tbc_source reads its "
+               "own format from its\n";
+  std::cerr << "                                 metadata file, so it never "
+               "implies one\n";
   std::cerr << "\n";
-  std::cerr << "Note: video format and source signal type are detected "
-               "automatically\n";
-  std::cerr << "from the stage modules used, and never need to be specified.\n";
+  std::cerr << "Note: video format and source signal type are usually "
+               "detected automatically\n";
+  std::cerr << "from the stage modules used (see --video-format above for "
+               "the one exception).\n";
   std::cerr << "\n";
   std::cerr << "Plugin Management:\n";
   std::cerr << "  plugins list                   List registry entries and "
@@ -136,6 +145,7 @@ int main(int argc, char* argv[]) {
     std::string output_stages;
     bool triad_provided = false;      // --input / --filters / --output
     std::string export_project_path;  // --export-project
+    std::string export_video_format;  // --video-format (export-only override)
 
     // Command flags
     bool do_process = false;
@@ -227,6 +237,8 @@ int main(int argc, char* argv[]) {
         triad_provided = true;
       } else if (arg == "--export-project" && i + 1 < argc) {
         export_project_path = argv[++i];
+      } else if (arg == "--video-format" && i + 1 < argc) {
+        export_video_format = argv[++i];
       } else if (arg[0] != '-') {
         // Positional argument - project file
         if (project_path.empty()) {
@@ -244,6 +256,13 @@ int main(int argc, char* argv[]) {
     }
 
     const bool filtergraph_mode = triad_provided;
+
+    if (!export_video_format.empty() && export_project_path.empty()) {
+      std::cerr << "Error: --video-format only makes sense with "
+                   "--export-project\n\n";
+      print_usage(argv[0]);
+      return 1;
+    }
 
     if (filtergraph_mode) {
       if (!project_path.empty()) {
@@ -336,6 +355,7 @@ int main(int argc, char* argv[]) {
         options.filters_stages = filters_stages;
         options.output_stages = output_stages;
         options.export_project_path = export_project_path;
+        options.export_video_format = export_video_format;
 
         exit_code = cli::filter_command(options);
       } else {

--- a/orc/cli/stage_category.cpp
+++ b/orc/cli/stage_category.cpp
@@ -1,0 +1,83 @@
+/*
+ * File:        stage_category.cpp
+ * Module:      orc-cli
+ * Purpose:     Implementation of shared stage-category classification.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#include "stage_category.h"
+
+#include "project_presenter.h"
+
+namespace orc {
+namespace cli {
+
+using orc::presenters::ProjectPresenter;
+using orc::presenters::StageInfo;
+
+const char* category_flag(StageCategory category) {
+  switch (category) {
+    case StageCategory::kInput:
+      return "--input";
+    case StageCategory::kFilters:
+      return "--filters";
+    case StageCategory::kOutput:
+      return "--output";
+  }
+  return "?";
+}
+
+const char* category_label(StageCategory category) {
+  switch (category) {
+    case StageCategory::kInput:
+      return "input (source)";
+    case StageCategory::kFilters:
+      return "processing";
+    case StageCategory::kOutput:
+      return "output (sink)";
+  }
+  return "?";
+}
+
+StageCategory category_of(const StageInfo& info) {
+  if (info.is_source) return StageCategory::kInput;
+  if (info.is_sink) return StageCategory::kOutput;
+  return StageCategory::kFilters;
+}
+
+const char* actual_role_description(const StageInfo& info) {
+  if (info.is_source) return "an input (source) stage";
+  if (info.is_sink) return "an output (sink) stage";
+  return "a processing stage";
+}
+
+const char* suggested_flag_for(const StageInfo& info) {
+  if (info.is_source) return "--input";
+  if (info.is_sink) return "--output";
+  return "--filters";
+}
+
+bool stage_matches_category(const StageInfo& info, StageCategory category) {
+  switch (category) {
+    case StageCategory::kInput:
+      return info.is_source;
+    case StageCategory::kFilters:
+      return !info.is_source && !info.is_sink;
+    case StageCategory::kOutput:
+      return info.is_sink;
+  }
+  return false;
+}
+
+std::map<std::string, StageInfo> build_stage_index() {
+  std::map<std::string, StageInfo> index;
+  for (auto& info : ProjectPresenter::getAllStages()) {
+    index.emplace(info.name, info);
+  }
+  return index;
+}
+
+}  // namespace cli
+}  // namespace orc

--- a/orc/cli/stage_category.cpp
+++ b/orc/cli/stage_category.cpp
@@ -20,23 +20,11 @@ using orc::presenters::StageInfo;
 const char* category_flag(StageCategory category) {
   switch (category) {
     case StageCategory::kInput:
-      return "--input";
+      return "--source";
     case StageCategory::kFilters:
       return "--filters";
     case StageCategory::kOutput:
-      return "--output";
-  }
-  return "?";
-}
-
-const char* category_label(StageCategory category) {
-  switch (category) {
-    case StageCategory::kInput:
-      return "input (source)";
-    case StageCategory::kFilters:
-      return "processing";
-    case StageCategory::kOutput:
-      return "output (sink)";
+      return "--sink";
   }
   return "?";
 }
@@ -54,21 +42,11 @@ const char* actual_role_description(const StageInfo& info) {
 }
 
 const char* suggested_flag_for(const StageInfo& info) {
-  if (info.is_source) return "--input";
-  if (info.is_sink) return "--output";
-  return "--filters";
+  return category_flag(category_of(info));
 }
 
 bool stage_matches_category(const StageInfo& info, StageCategory category) {
-  switch (category) {
-    case StageCategory::kInput:
-      return info.is_source;
-    case StageCategory::kFilters:
-      return !info.is_source && !info.is_sink;
-    case StageCategory::kOutput:
-      return info.is_sink;
-  }
-  return false;
+  return category_of(info) == category;
 }
 
 std::map<std::string, StageInfo> build_stage_index() {

--- a/orc/cli/stage_category.h
+++ b/orc/cli/stage_category.h
@@ -1,0 +1,56 @@
+/*
+ * File:        stage_category.h
+ * Module:      orc-cli
+ * Purpose:     Shared classification of stages into the three categories
+ *              the CLI presents them under (input/filters/output), used by
+ *              both the filtergraph triad validator and the plugin/stage
+ *              listing commands.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "project_presenter_types.h"
+
+namespace orc {
+namespace cli {
+
+/// The three stage categories the CLI classifies every stage into. This
+/// mirrors the --input/--filters/--output triad, and is also used to group
+/// `orc-cli plugins stages`/`inputs`/`outputs`/`filters` output.
+enum class StageCategory { kInput, kFilters, kOutput };
+
+/// The CLI flag associated with a category (e.g. "--input").
+const char* category_flag(StageCategory category);
+
+/// Human-readable label for a category (e.g. "input (source)"), used as a
+/// role tag in listings and error messages.
+const char* category_label(StageCategory category);
+
+/// A stage's category is never guessed from its name: it comes straight
+/// from the same is_source/is_sink metadata the GUI uses, so this works
+/// identically for core stages and for any third-party plugin stage.
+StageCategory category_of(const orc::presenters::StageInfo& info);
+
+/// Human-readable description of the category a stage actually belongs to,
+/// for error messages ("X is <this>, not <expected>").
+const char* actual_role_description(const orc::presenters::StageInfo& info);
+
+/// Which CLI flag a stage's actual role belongs under (e.g. "--output").
+const char* suggested_flag_for(const orc::presenters::StageInfo& info);
+
+/// Whether `info` belongs to `category`.
+bool stage_matches_category(const orc::presenters::StageInfo& info,
+                            StageCategory category);
+
+/// Stage name -> StageInfo, built once per run (core stages + loaded
+/// plugins).
+std::map<std::string, orc::presenters::StageInfo> build_stage_index();
+
+}  // namespace cli
+}  // namespace orc

--- a/orc/cli/stage_category.h
+++ b/orc/cli/stage_category.h
@@ -2,9 +2,9 @@
  * File:        stage_category.h
  * Module:      orc-cli
  * Purpose:     Shared classification of stages into the three categories
- *              the CLI presents them under (input/filters/output), used by
- *              both the filtergraph triad validator and the plugin/stage
- *              listing commands.
+ *              the CLI presents them under (source/filters/sink), used by
+ *              the filtergraph triad validator to enforce that each flag
+ *              only accepts stages of the matching role.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025-2026 Simon Inns
@@ -21,16 +21,11 @@ namespace orc {
 namespace cli {
 
 /// The three stage categories the CLI classifies every stage into. This
-/// mirrors the --input/--filters/--output triad, and is also used to group
-/// `orc-cli plugins stages`/`inputs`/`outputs`/`filters` output.
+/// mirrors the --source/--filters/--sink triad.
 enum class StageCategory { kInput, kFilters, kOutput };
 
-/// The CLI flag associated with a category (e.g. "--input").
+/// The CLI flag associated with a category (e.g. "--source"/"-i").
 const char* category_flag(StageCategory category);
-
-/// Human-readable label for a category (e.g. "input (source)"), used as a
-/// role tag in listings and error messages.
-const char* category_label(StageCategory category);
 
 /// A stage's category is never guessed from its name: it comes straight
 /// from the same is_source/is_sink metadata the GUI uses, so this works
@@ -41,7 +36,7 @@ StageCategory category_of(const orc::presenters::StageInfo& info);
 /// for error messages ("X is <this>, not <expected>").
 const char* actual_role_description(const orc::presenters::StageInfo& info);
 
-/// Which CLI flag a stage's actual role belongs under (e.g. "--output").
+/// Which CLI flag a stage's actual role belongs under (e.g. "--sink"/"-o").
 const char* suggested_flag_for(const orc::presenters::StageInfo& info);
 
 /// Whether `info` belongs to `category`.

--- a/orc/presenters/CMakeLists.txt
+++ b/orc/presenters/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 add_library(orc-presenters STATIC
     src/project_presenter.cpp
+    src/filtergraph_parser.cpp
+    src/filtergraph_import.cpp
     src/render_presenter.cpp
     src/analysis_presenter.cpp
     src/analysis_tool_presenter.cpp

--- a/orc/presenters/include/filtergraph_import.h
+++ b/orc/presenters/include/filtergraph_import.h
@@ -1,0 +1,68 @@
+/*
+ * File:        filtergraph_import.h
+ * Module:      orc-presenters
+ * Purpose:     Parse an ffmpeg-style filtergraph string and build it into a
+ *              project via the presenter — shared between orc-cli
+ *              (--filter/--input/--filters/--output) and any GUI feature
+ *              that lets a person paste a CLI command to build a project.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace orc {
+namespace presenters {
+
+class IProjectPresenter;
+
+/**
+ * @brief Outcome of importing a filtergraph string into a project.
+ *
+ * `ok` is false if parsing failed, a stage name was unrecognised, a
+ * required parameter was missing, or building the DAG raised a core-side
+ * validation error (e.g. a source/format incompatibility) — in every case
+ * `errors` holds one or more human-readable messages and nothing was added
+ * to the project. `warnings` holds non-fatal issues (currently: parameter
+ * names not recognised by a stage, which may be a typo) even when `ok` is
+ * true — the project is still built in that case.
+ */
+struct FiltergraphImportResult {
+  bool ok = false;
+  std::vector<std::string> errors;
+  std::vector<std::string> warnings;
+};
+
+/**
+ * @brief Parse `filtergraph` and build it into `presenter`.
+ *
+ * Performs, in order: parsing, stage-name validation, video-format/source-
+ * type auto-detection from the stages used (see the CLI's Filtergraph Mode
+ * documentation for the exact rules — the same logic applies here), stage
+ * parameter validation (missing required / unrecognised names), and finally
+ * adds every node, sets its parameters, and wires every edge.
+ *
+ * Does not call `validateProject()` or trigger anything — that decision is
+ * left to the caller (the CLI runs the pipeline immediately; a GUI "paste
+ * command" feature would more likely leave the person to review the
+ * resulting graph first).
+ *
+ * On failure, `presenter` is left exactly as it was: nodes are only added
+ * once the input passes every validation step, so a bad paste cannot leave
+ * a partially-built graph behind.
+ *
+ * @param presenter Project to build into. Any existing nodes are left
+ * alone; the new nodes are added alongside them.
+ * @param filtergraph The filtergraph string (same grammar as orc-cli's
+ * `--filter`).
+ * @return Result; check `.ok` before assuming the project changed.
+ */
+FiltergraphImportResult import_filtergraph_into_project(
+    IProjectPresenter& presenter, const std::string& filtergraph);
+
+}  // namespace presenters
+}  // namespace orc

--- a/orc/presenters/include/filtergraph_import.h
+++ b/orc/presenters/include/filtergraph_import.h
@@ -3,7 +3,7 @@
  * Module:      orc-presenters
  * Purpose:     Parse an ffmpeg-style filtergraph string and build it into a
  *              project via the presenter — shared between orc-cli
- *              (--filter/--input/--filters/--output) and any GUI feature
+ *              (--source/--filters/--sink) and any GUI feature
  *              that lets a person paste a CLI command to build a project.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -58,7 +58,7 @@ struct FiltergraphImportResult {
  * @param presenter Project to build into. Any existing nodes are left
  * alone; the new nodes are added alongside them.
  * @param filtergraph The filtergraph string (same grammar as the composed
- * --input/--filters/--output triad).
+ * --source/--filters/--sink triad).
  * @return Result; check `.ok` before assuming the project changed.
  */
 FiltergraphImportResult import_filtergraph_into_project(

--- a/orc/presenters/include/filtergraph_import.h
+++ b/orc/presenters/include/filtergraph_import.h
@@ -57,8 +57,8 @@ struct FiltergraphImportResult {
  *
  * @param presenter Project to build into. Any existing nodes are left
  * alone; the new nodes are added alongside them.
- * @param filtergraph The filtergraph string (same grammar as orc-cli's
- * `--filter`).
+ * @param filtergraph The filtergraph string (same grammar as the composed
+ * --input/--filters/--output triad).
  * @return Result; check `.ok` before assuming the project changed.
  */
 FiltergraphImportResult import_filtergraph_into_project(

--- a/orc/presenters/include/filtergraph_parser.h
+++ b/orc/presenters/include/filtergraph_parser.h
@@ -1,0 +1,92 @@
+/*
+ * File:        filtergraph_parser.h
+ * Module:      orc-cli
+ * Purpose:     Parse an ffmpeg-style complex filtergraph string into a
+ *              stage/edge description that can drive the project presenter.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace orc {
+namespace cli {
+
+/**
+ * @brief A single stage instance parsed from a filtergraph.
+ *
+ * Mirrors one ffmpeg "filter": an optional set of input link labels, a stage
+ * name, its key=value parameters, and an optional set of output link labels.
+ */
+struct FilterStage {
+  std::string stage_name;                     ///< e.g. "tbc_source"
+  std::map<std::string, std::string> params;  ///< key -> value
+  std::vector<std::string> input_labels;      ///< leading [labels]
+  std::vector<std::string> output_labels;     ///< trailing [labels]
+};
+
+/**
+ * @brief Fully parsed filtergraph.
+ *
+ * `stages` are listed in the order they appear. `edges` are resolved
+ * connections expressed as (from_stage_index, to_stage_index) pairs, combining
+ * both implicit comma-chain adjacency and explicit shared-label links.
+ */
+struct FilterGraph {
+  std::vector<FilterStage> stages;
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+};
+
+/**
+ * @brief Result of parsing a filtergraph string.
+ *
+ * On failure, `ok` is false and `error` contains a human-readable description
+ * (with the approximate character offset where parsing failed).
+ */
+struct FilterGraphParseResult {
+  bool ok = false;
+  std::string error;
+  FilterGraph graph;
+};
+
+/**
+ * @brief Parse an ffmpeg-style complex filtergraph.
+ *
+ * Grammar (informal):
+ * @code
+ *   graph       := filterchain (';' filterchain)*
+ *   filterchain := filter (',' filter)*
+ *   filter      := inlabels? stagespec outlabels?
+ *   inlabels    := ('[' label ']')+
+ *   outlabels   := ('[' label ']')+
+ *   stagespec   := stage_name ('=' args)?
+ *   args        := arg (':' arg)*
+ *   arg         := key '=' value
+ * @endcode
+ *
+ * Connection rules:
+ * - Within a filterchain, a filter that has no explicit input labels is
+ *   auto-connected to the immediately preceding filter in the same chain.
+ * - Any output label is connected to every filter that lists the same name as
+ *   an input label, anywhere in the graph (ffmpeg-style shared labels).
+ *
+ * Quoting: values may be wrapped in single OR double quotes ('...' or "...")
+ * to include ':' '[' ']' ',' ';' and whitespace literally; the two quote
+ * styles are interchangeable and a value quoted with one may freely contain
+ * the other character. A backslash escapes the next character anywhere
+ * outside quotes. Leading/trailing unquoted whitespace is trimmed.
+ *
+ * @param input Filtergraph string.
+ * @return Parse result; check `.ok` before using `.graph`.
+ */
+FilterGraphParseResult parse_filtergraph(const std::string& input);
+
+}  // namespace cli
+}  // namespace orc

--- a/orc/presenters/include/filtergraph_parser.h
+++ b/orc/presenters/include/filtergraph_parser.h
@@ -1,6 +1,6 @@
 /*
  * File:        filtergraph_parser.h
- * Module:      orc-cli
+ * Module:      orc-presenters
  * Purpose:     Parse an ffmpeg-style complex filtergraph string into a
  *              stage/edge description that can drive the project presenter.
  *
@@ -17,7 +17,7 @@
 #include <vector>
 
 namespace orc {
-namespace cli {
+namespace presenters {
 
 /**
  * @brief A single stage instance parsed from a filtergraph.
@@ -88,5 +88,5 @@ struct FilterGraphParseResult {
  */
 FilterGraphParseResult parse_filtergraph(const std::string& input);
 
-}  // namespace cli
+}  // namespace presenters
 }  // namespace orc

--- a/orc/presenters/src/filtergraph_import.cpp
+++ b/orc/presenters/src/filtergraph_import.cpp
@@ -24,8 +24,6 @@ namespace presenters {
 
 namespace {
 
-using orc::cli::FilterStage;
-
 /// Result of auto-detecting the project's video format from its stages.
 struct VideoFormatInference {
   VideoFormat format = VideoFormat::Unknown;
@@ -92,12 +90,21 @@ struct SourceFormatInference {
 
 /**
  * Auto-detect the project's source signal type (composite vs Y/C) from the
- * parameters actually supplied to source stages: y_path/c_path implies Y/C,
- * input_path implies composite — the same convention every dual-mode source
- * stage (tbc_source, the CVBS sources) already follows, so this works
- * without hardcoding any specific stage name. A stage name containing "YC"
- * is used as a fallback hint, mirroring the core's own heuristic.
+ * parameters actually supplied to source stages: y_path AND c_path both
+ * present and non-empty implies Y/C; input_path present and non-empty
+ * implies composite — the same convention, and the same presence-and-
+ * non-empty check, the core's own set_node_parameters() uses (project.cpp),
+ * so this works without hardcoding any specific stage name.
  */
+/// True if `stage` has a non-empty string value for parameter `key`. A key
+/// that is merely *present* with an empty value (e.g. a composite source
+/// that still lists `y_path=''` for symmetry) must not count — matching
+/// the core's own `has_nonempty_str()` check exactly (project.cpp).
+bool has_nonempty_param(const FilterStage& stage, const std::string& key) {
+  const auto it = stage.params.find(key);
+  return it != stage.params.end() && !it->second.empty();
+}
+
 SourceFormatInference infer_source_format(
     const std::vector<FilterStage>& stages,
     const std::map<std::string, StageInfo>& stage_index) {
@@ -111,14 +118,15 @@ SourceFormatInference infer_source_format(
     }
 
     SourceType this_format = SourceType::Unknown;
-    const bool has_yc_path =
-        stage.params.count("y_path") != 0 || stage.params.count("c_path") != 0;
-    const bool has_input_path = stage.params.count("input_path") != 0;
-    const bool name_implies_yc =
-        stage.stage_name.find("YC") != std::string::npos && !has_input_path;
-    if (has_yc_path || name_implies_yc) {
+    // Y/C requires *both* y_path and c_path — matching the core's own
+    // has_nonempty_str("y_path") && has_nonempty_str("c_path") exactly.
+    // Either alone is not enough: a composite source may still carry an
+    // empty y_path/c_path key for parameter symmetry, and that must not be
+    // mistaken for Y/C.
+    if (has_nonempty_param(stage, "y_path") &&
+        has_nonempty_param(stage, "c_path")) {
       this_format = SourceType::YC;
-    } else if (has_input_path) {
+    } else if (has_nonempty_param(stage, "input_path")) {
       this_format = SourceType::Composite;
     }
     if (this_format == SourceType::Unknown) {
@@ -145,8 +153,7 @@ FiltergraphImportResult import_filtergraph_into_project(
     IProjectPresenter& presenter, const std::string& filtergraph) {
   FiltergraphImportResult result;
 
-  orc::cli::FilterGraphParseResult parsed =
-      orc::cli::parse_filtergraph(filtergraph);
+  FilterGraphParseResult parsed = parse_filtergraph(filtergraph);
   if (!parsed.ok) {
     result.errors.push_back("Failed to parse filtergraph: " + parsed.error);
     return result;
@@ -189,6 +196,18 @@ FiltergraphImportResult import_filtergraph_into_project(
     return result;
   }
 
+  // Set the detected format/source-type *before* fetching parameter
+  // descriptors below: some stages narrow their descriptor set by format or
+  // source type (see FixedFormatCVBSSourceStage::get_parameter_descriptors),
+  // so descriptors must be fetched with the real context already in place,
+  // not with Unknown.
+  if (video_inference.format != VideoFormat::Unknown) {
+    presenter.setVideoFormat(video_inference.format);
+  }
+  if (source_inference.format != SourceType::Unknown) {
+    presenter.setSourceType(source_inference.format);
+  }
+
   // Validate parameters against each stage's descriptors. This uses only
   // the generic getStageParameters() API, so it works identically for core
   // stages and for third-party plugin stages: missing required parameters
@@ -224,14 +243,17 @@ FiltergraphImportResult import_filtergraph_into_project(
     }
   }
   if (!result.errors.empty()) {
+    // Parameter validation failed after all: undo the format/source-type
+    // set above, so a failed import leaves the presenter completely
+    // unchanged either way (see the contract documented in
+    // filtergraph_import.h).
+    if (video_inference.format != VideoFormat::Unknown) {
+      presenter.setVideoFormat(VideoFormat::Unknown);
+    }
+    if (source_inference.format != SourceType::Unknown) {
+      presenter.setSourceType(SourceType::Unknown);
+    }
     return result;
-  }
-
-  if (video_inference.format != VideoFormat::Unknown) {
-    presenter.setVideoFormat(video_inference.format);
-  }
-  if (source_inference.format != SourceType::Unknown) {
-    presenter.setSourceType(source_inference.format);
   }
 
   // Add nodes (auto-layout left to right) and their parameters, then wire up
@@ -257,6 +279,13 @@ FiltergraphImportResult import_filtergraph_into_project(
   } catch (const std::exception& e) {
     result.errors.push_back(std::string("Failed to build filtergraph: ") +
                             e.what());
+    // Same rollback as the parameter-validation failure above.
+    if (video_inference.format != VideoFormat::Unknown) {
+      presenter.setVideoFormat(VideoFormat::Unknown);
+    }
+    if (source_inference.format != SourceType::Unknown) {
+      presenter.setSourceType(SourceType::Unknown);
+    }
     return result;
   }
 

--- a/orc/presenters/src/filtergraph_import.cpp
+++ b/orc/presenters/src/filtergraph_import.cpp
@@ -1,0 +1,268 @@
+/*
+ * File:        filtergraph_import.cpp
+ * Module:      orc-presenters
+ * Purpose:     Implementation of the shared filtergraph-to-project builder.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#include "filtergraph_import.h"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "filtergraph_parser.h"
+#include "i_project_presenter.h"
+#include "project_presenter_types.h"
+
+namespace orc {
+namespace presenters {
+
+namespace {
+
+using orc::cli::FilterStage;
+
+/// Result of auto-detecting the project's video format from its stages.
+struct VideoFormatInference {
+  VideoFormat format = VideoFormat::Unknown;
+  bool conflict = false;
+  std::string conflict_detail;
+};
+
+/**
+ * Auto-detect the project's video format from the stages actually used,
+ * with no naming assumptions: a stage's format exclusivity comes from its
+ * formally declared VideoFormatCompatibility (NTSC_ONLY / PAL_ONLY /
+ * PAL_M_ONLY), the same metadata the GUI uses to filter its "Add Stage"
+ * menu. Stages compatible with every format (the common case: transforms,
+ * sinks, and dual-mode sources like tbc_source) contribute no signal.
+ */
+VideoFormatInference infer_video_format(
+    IProjectPresenter& presenter, const std::vector<FilterStage>& stages) {
+  VideoFormatInference result;
+
+  std::set<std::string> ntsc_names, pal_names, pal_m_names;
+  for (auto& s : presenter.listAvailableStagesForFormat(VideoFormat::NTSC)) {
+    ntsc_names.insert(s.name);
+  }
+  for (auto& s : presenter.listAvailableStagesForFormat(VideoFormat::PAL)) {
+    pal_names.insert(s.name);
+  }
+  for (auto& s : presenter.listAvailableStagesForFormat(VideoFormat::PAL_M)) {
+    pal_m_names.insert(s.name);
+  }
+
+  std::string detected_from;
+  for (const auto& stage : stages) {
+    const bool in_ntsc = ntsc_names.count(stage.stage_name) != 0;
+    const bool in_pal = pal_names.count(stage.stage_name) != 0;
+    const bool in_pal_m = pal_m_names.count(stage.stage_name) != 0;
+    const int membership =
+        (in_ntsc ? 1 : 0) + (in_pal ? 1 : 0) + (in_pal_m ? 1 : 0);
+    if (membership == 0 || membership == 3) {
+      continue;  // Not a registered stage, or compatible with every format.
+    }
+    const VideoFormat this_format =
+        in_ntsc ? VideoFormat::NTSC
+                : (in_pal ? VideoFormat::PAL : VideoFormat::PAL_M);
+    if (result.format == VideoFormat::Unknown) {
+      result.format = this_format;
+      detected_from = stage.stage_name;
+    } else if (result.format != this_format) {
+      result.conflict = true;
+      result.conflict_detail = "stage '" + detected_from +
+                               "' requires one video format but '" +
+                               stage.stage_name + "' requires another";
+      return result;
+    }
+  }
+  return result;
+}
+
+/// Result of auto-detecting the project's source signal type from its stages.
+struct SourceFormatInference {
+  SourceType format = SourceType::Unknown;
+  bool conflict = false;
+  std::string conflict_detail;
+};
+
+/**
+ * Auto-detect the project's source signal type (composite vs Y/C) from the
+ * parameters actually supplied to source stages: y_path/c_path implies Y/C,
+ * input_path implies composite — the same convention every dual-mode source
+ * stage (tbc_source, the CVBS sources) already follows, so this works
+ * without hardcoding any specific stage name. A stage name containing "YC"
+ * is used as a fallback hint, mirroring the core's own heuristic.
+ */
+SourceFormatInference infer_source_format(
+    const std::vector<FilterStage>& stages,
+    const std::map<std::string, StageInfo>& stage_index) {
+  SourceFormatInference result;
+
+  std::string detected_from;
+  for (const auto& stage : stages) {
+    auto it = stage_index.find(stage.stage_name);
+    if (it == stage_index.end() || !it->second.is_source) {
+      continue;
+    }
+
+    SourceType this_format = SourceType::Unknown;
+    const bool has_yc_path =
+        stage.params.count("y_path") != 0 || stage.params.count("c_path") != 0;
+    const bool has_input_path = stage.params.count("input_path") != 0;
+    const bool name_implies_yc =
+        stage.stage_name.find("YC") != std::string::npos && !has_input_path;
+    if (has_yc_path || name_implies_yc) {
+      this_format = SourceType::YC;
+    } else if (has_input_path) {
+      this_format = SourceType::Composite;
+    }
+    if (this_format == SourceType::Unknown) {
+      continue;
+    }
+
+    if (result.format == SourceType::Unknown) {
+      result.format = this_format;
+      detected_from = stage.stage_name;
+    } else if (result.format != this_format) {
+      result.conflict = true;
+      result.conflict_detail = "source '" + detected_from +
+                               "' looks like one signal type but '" +
+                               stage.stage_name + "' looks like another";
+      return result;
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+FiltergraphImportResult import_filtergraph_into_project(
+    IProjectPresenter& presenter, const std::string& filtergraph) {
+  FiltergraphImportResult result;
+
+  orc::cli::FilterGraphParseResult parsed =
+      orc::cli::parse_filtergraph(filtergraph);
+  if (!parsed.ok) {
+    result.errors.push_back("Failed to parse filtergraph: " + parsed.error);
+    return result;
+  }
+
+  // Validate stage names up front so callers get a clear message rather
+  // than an opaque failure deep in DAG construction.
+  for (const auto& stage : parsed.graph.stages) {
+    if (!presenter.stageExists(stage.stage_name)) {
+      result.errors.push_back("Unknown stage '" + stage.stage_name + "'.");
+    }
+  }
+  if (!result.errors.empty()) {
+    return result;
+  }
+
+  // Build a stage-name -> StageInfo index once, reused for source-format
+  // inference and parameter validation below.
+  std::map<std::string, StageInfo> stage_index;
+  for (auto& info : presenter.listAllStages()) {
+    stage_index.emplace(info.name, info);
+  }
+
+  // Auto-detect video format and source signal type from the stages
+  // actually used — these are properties of the modules, not something the
+  // caller should have to state separately.
+  const VideoFormatInference video_inference =
+      infer_video_format(presenter, parsed.graph.stages);
+  if (video_inference.conflict) {
+    result.errors.push_back("Conflicting video formats between stages: " +
+                            video_inference.conflict_detail);
+  }
+  const SourceFormatInference source_inference =
+      infer_source_format(parsed.graph.stages, stage_index);
+  if (source_inference.conflict) {
+    result.errors.push_back("Conflicting source signal types between stages: " +
+                            source_inference.conflict_detail);
+  }
+  if (!result.errors.empty()) {
+    return result;
+  }
+
+  // Validate parameters against each stage's descriptors. This uses only
+  // the generic getStageParameters() API, so it works identically for core
+  // stages and for third-party plugin stages: missing required parameters
+  // are reported as errors (instead of an opaque failure later inside the
+  // stage's trigger()), and unrecognised parameter names are reported as
+  // warnings (likely typos) without blocking the build.
+  for (const auto& stage : parsed.graph.stages) {
+    const auto descriptors = presenter.getStageParameters(stage.stage_name);
+    if (descriptors.empty()) {
+      continue;
+    }
+
+    for (const auto& descriptor : descriptors) {
+      const bool supplied =
+          stage.params.find(descriptor.name) != stage.params.end();
+      if (descriptor.constraints.required && !supplied) {
+        result.errors.push_back("Stage '" + stage.stage_name +
+                                "': missing required parameter '" +
+                                descriptor.name + "'.");
+      }
+    }
+
+    for (const auto& [key, value] : stage.params) {
+      (void)value;
+      const bool known =
+          std::any_of(descriptors.begin(), descriptors.end(),
+                      [&key](const auto& d) { return d.name == key; });
+      if (!known) {
+        result.warnings.push_back(
+            "Stage '" + stage.stage_name + "': parameter '" + key +
+            "' is not recognised by this stage (check for typos).");
+      }
+    }
+  }
+  if (!result.errors.empty()) {
+    return result;
+  }
+
+  if (video_inference.format != VideoFormat::Unknown) {
+    presenter.setVideoFormat(video_inference.format);
+  }
+  if (source_inference.format != SourceType::Unknown) {
+    presenter.setSourceType(source_inference.format);
+  }
+
+  // Add nodes (auto-layout left to right) and their parameters, then wire up
+  // edges. Core-side validation (e.g. source format compatibility) can throw
+  // for any stage, including third-party plugin stages, so surface those as
+  // a clean error rather than letting the exception propagate.
+  try {
+    std::vector<orc::NodeID> node_ids;
+    node_ids.reserve(parsed.graph.stages.size());
+    double x = 0.0;
+    for (const auto& stage : parsed.graph.stages) {
+      orc::NodeID id = presenter.addNode(stage.stage_name, x, 0.0);
+      node_ids.push_back(id);
+      if (!stage.params.empty()) {
+        presenter.setNodeParameters(id, stage.params);
+      }
+      x += 200.0;
+    }
+
+    for (const auto& edge : parsed.graph.edges) {
+      presenter.addEdge(node_ids[edge.first], node_ids[edge.second]);
+    }
+  } catch (const std::exception& e) {
+    result.errors.push_back(std::string("Failed to build filtergraph: ") +
+                            e.what());
+    return result;
+  }
+
+  result.ok = true;
+  return result;
+}
+
+}  // namespace presenters
+}  // namespace orc

--- a/orc/presenters/src/filtergraph_parser.cpp
+++ b/orc/presenters/src/filtergraph_parser.cpp
@@ -1,0 +1,481 @@
+/*
+ * File:        filtergraph_parser.cpp
+ * Module:      orc-cli
+ * Purpose:     Implementation of the ffmpeg-style filtergraph parser.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ *
+ * This translation unit deliberately depends only on the C++ standard library
+ * so the parser can be unit-tested in isolation from orc-core/presenters.
+ */
+
+#include "filtergraph_parser.h"
+
+#include <cctype>
+#include <cstddef>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace orc {
+namespace cli {
+
+namespace {
+
+using std::size_t;
+
+bool is_ws(char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+         c == '\v';
+}
+
+/**
+ * Detect a Windows drive-letter colon such as the one in "C:\Users\..." or
+ * "D:/data". Such a colon must never be treated as a top-level ':' argument
+ * separator, or an unquoted Windows absolute path silently corrupts parsing.
+ *
+ * Matches when: s[i] == ':', the preceding character is a single ASCII
+ * letter that starts a token (i.e. is at the very start of the string or is
+ * preceded by a non-alphanumeric, non-underscore character), and the
+ * following character is '\' or '/'.
+ */
+bool is_drive_letter_colon(const std::string& s, size_t i) {
+  if (s[i] != ':' || i == 0 || i + 1 >= s.size()) {
+    return false;
+  }
+  unsigned char prev = static_cast<unsigned char>(s[i - 1]);
+  if (!std::isalpha(prev)) {
+    return false;
+  }
+  if (i >= 2) {
+    unsigned char before_prev = static_cast<unsigned char>(s[i - 2]);
+    if (std::isalnum(before_prev) || before_prev == '_') {
+      return false;  // e.g. "abc:" - not a standalone drive letter
+    }
+  }
+  return s[i + 1] == '\\' || s[i + 1] == '/';
+}
+
+/// A half-open [begin, end) slice of the source string.
+struct Range {
+  size_t begin = 0;
+  size_t end = 0;
+  bool empty() const { return begin >= end; }
+};
+
+/// Error carrier used throughout parsing.
+struct ParseError {
+  bool set = false;
+  std::string message;
+  size_t offset = 0;
+
+  void fail(const std::string& msg, size_t off) {
+    if (!set) {  // keep first error
+      set = true;
+      message = msg;
+      offset = off;
+    }
+  }
+};
+
+/**
+ * Split [begin, end) of `s` at top-level occurrences of any separator in
+ * `seps`. "Top level" means not inside a quoted span (single OR double
+ * quotes), not escaped by a preceding backslash, and not nested inside
+ * square brackets. Returns the list of sub-ranges (raw, not unescaped, not
+ * trimmed). Empty ranges are preserved so callers can diagnose things like
+ * "a,,b".
+ */
+std::vector<Range> split_top_level(const std::string& s, size_t begin,
+                                   size_t end, const std::string& seps,
+                                   ParseError& err) {
+  std::vector<Range> out;
+  size_t seg_start = begin;
+  size_t i = begin;
+  int depth = 0;
+  char quote_char = '\0';  // '\0' = not currently inside a quoted span
+
+  while (i < end) {
+    char c = s[i];
+
+    if (quote_char != '\0') {
+      if (c == quote_char) {
+        quote_char = '\0';
+      }
+      ++i;
+      continue;
+    }
+
+    if (c == '\\') {  // escape: skip next char literally
+      i += 2;
+      continue;
+    }
+    if (c == '\'' || c == '"') {
+      quote_char = c;
+      ++i;
+      continue;
+    }
+    if (c == '[') {
+      ++depth;
+      ++i;
+      continue;
+    }
+    if (c == ']') {
+      if (depth > 0) {
+        --depth;
+      }
+      ++i;
+      continue;
+    }
+
+    if (depth == 0 && seps.find(c) != std::string::npos) {
+      if (c == ':' && is_drive_letter_colon(s, i)) {
+        ++i;
+        continue;
+      }
+      out.push_back(Range{seg_start, i});
+      seg_start = i + 1;
+      ++i;
+      continue;
+    }
+    ++i;
+  }
+
+  if (quote_char != '\0') {
+    err.fail(std::string("Unterminated ") +
+                 (quote_char == '\'' ? "single" : "double") + " quote",
+             begin);
+  }
+  if (depth > 0) {
+    err.fail("Unbalanced '[' in filtergraph", begin);
+  }
+
+  out.push_back(Range{seg_start, end});
+  return out;
+}
+
+/// Trim leading/trailing unquoted ASCII whitespace from a range in place.
+Range trim(const std::string& s, Range r) {
+  while (r.begin < r.end && is_ws(s[r.begin])) {
+    ++r.begin;
+  }
+  while (r.end > r.begin && is_ws(s[r.end - 1])) {
+    --r.end;
+  }
+  return r;
+}
+
+/**
+ * Produce the literal value of a token, resolving quoting (single OR double
+ * quotes) and backslash escaping. Backslash outside quotes escapes the
+ * following character when it is one of the syntax-special characters;
+ * inside a quoted span everything is literal until the matching closing
+ * quote (the other quote character is not special inside it, so a value can
+ * freely contain the other kind of quote character).
+ */
+std::string resolve_token(const std::string& s, Range r) {
+  std::string out;
+  size_t i = r.begin;
+  while (i < r.end) {
+    char c = s[i];
+    if (c == '\\' && i + 1 < r.end) {
+      char next = s[i + 1];
+      static const std::string kEscapable = ":,;[]'\" \t\\";
+      if (kEscapable.find(next) != std::string::npos) {
+        out.push_back(next);
+        i += 2;
+        continue;
+      }
+      // Not a recognised escape (e.g. a Windows path like "C:\Users\..."):
+      // keep the backslash literally and let the following character be
+      // processed normally on the next iteration.
+      out.push_back(c);
+      ++i;
+      continue;
+    }
+    if (c == '\'' || c == '"') {
+      const char quote_char = c;
+      ++i;
+      while (i < r.end && s[i] != quote_char) {
+        out.push_back(s[i]);
+        ++i;
+      }
+      if (i < r.end) {
+        ++i;  // consume closing quote
+      }
+      continue;
+    }
+    out.push_back(c);
+    ++i;
+  }
+  return out;
+}
+
+/**
+ * Consume a run of `[label]` groups starting at r.begin (whitespace allowed
+ * between groups). Appends resolved labels to `labels` and returns the offset
+ * just past the last consumed group. Stops as soon as the next non-whitespace
+ * character is not '['.
+ */
+size_t consume_label_groups(const std::string& s, Range r,
+                            std::vector<std::string>& labels, ParseError& err) {
+  size_t i = r.begin;
+  while (true) {
+    while (i < r.end && is_ws(s[i])) {
+      ++i;
+    }
+    if (i >= r.end || s[i] != '[') {
+      return i;
+    }
+    size_t label_start = i + 1;
+    size_t j = label_start;
+    while (j < r.end && s[j] != ']') {
+      ++j;
+    }
+    if (j >= r.end) {
+      err.fail("Unterminated '[' label", i);
+      return r.end;
+    }
+    Range inner = trim(s, Range{label_start, j});
+    if (inner.empty()) {
+      err.fail("Empty link label '[]'", i);
+      return r.end;
+    }
+    labels.push_back(resolve_token(s, inner));
+    i = j + 1;  // past ']'
+  }
+}
+
+/// Find the first top-level '[' in [begin, end) (unquoted, unescaped). Returns
+/// `end` if none is found.
+size_t find_top_level_open_bracket(const std::string& s, size_t begin,
+                                   size_t end) {
+  size_t i = begin;
+  char quote_char = '\0';
+  while (i < end) {
+    char c = s[i];
+    if (quote_char != '\0') {
+      if (c == quote_char) {
+        quote_char = '\0';
+      }
+      ++i;
+      continue;
+    }
+    if (c == '\\') {
+      i += 2;
+      continue;
+    }
+    if (c == '\'' || c == '"') {
+      quote_char = c;
+      ++i;
+      continue;
+    }
+    if (c == '[') {
+      return i;
+    }
+    ++i;
+  }
+  return end;
+}
+
+/// Parse the "key=value:key=value" argument list of a stage.
+void parse_args(const std::string& s, Range r, FilterStage& stage,
+                ParseError& err) {
+  r = trim(s, r);
+  if (r.empty()) {
+    return;
+  }
+  std::vector<Range> args = split_top_level(s, r.begin, r.end, ":", err);
+  for (const Range& raw : args) {
+    Range arg = trim(s, raw);
+    if (arg.empty()) {
+      err.fail("Empty parameter (stray ':')", raw.begin);
+      continue;
+    }
+    // Split on the first top-level '='.
+    std::vector<Range> kv = split_top_level(s, arg.begin, arg.end, "=", err);
+    if (kv.size() < 2) {
+      err.fail("Parameter '" + resolve_token(s, arg) +
+                   "' must be of the form key=value",
+               arg.begin);
+      continue;
+    }
+    Range key_r = trim(s, kv[0]);
+    // Re-join everything after the first '=' as the value (values may contain
+    // '=', e.g. base64 or query strings).
+    Range val_r{kv[1].begin, arg.end};
+    val_r = trim(s, val_r);
+    std::string key = resolve_token(s, key_r);
+    if (key.empty()) {
+      err.fail("Empty parameter name before '='", arg.begin);
+      continue;
+    }
+    stage.params[key] = resolve_token(s, val_r);
+  }
+}
+
+/// Parse a single filter: [in]... stage=args [out]...
+void parse_filter(const std::string& s, Range r, FilterStage& stage,
+                  ParseError& err) {
+  r = trim(s, r);
+  if (r.empty()) {
+    err.fail("Empty filter (stray ',' or ';')", r.begin);
+    return;
+  }
+
+  // 1. Leading input labels.
+  size_t after_inputs = consume_label_groups(s, r, stage.input_labels, err);
+  if (err.set) {
+    return;
+  }
+
+  // 2. Stage spec runs until the first top-level '[' (start of output labels)
+  //    or the end of the range.
+  size_t out_start = find_top_level_open_bracket(s, after_inputs, r.end);
+  Range spec = trim(s, Range{after_inputs, out_start});
+  if (spec.empty()) {
+    err.fail("Missing stage name", after_inputs);
+    return;
+  }
+
+  // 3. Trailing output labels (if any).
+  if (out_start < r.end) {
+    size_t after_outputs = consume_label_groups(s, Range{out_start, r.end},
+                                                stage.output_labels, err);
+    if (err.set) {
+      return;
+    }
+    Range leftover = trim(s, Range{after_outputs, r.end});
+    if (!leftover.empty()) {
+      err.fail("Unexpected text after output labels: '" +
+                   resolve_token(s, leftover) + "'",
+               after_outputs);
+      return;
+    }
+  }
+
+  // 4. Split stage spec into name and optional args on first top-level '='.
+  std::vector<Range> name_args =
+      split_top_level(s, spec.begin, spec.end, "=", err);
+  if (err.set) {
+    return;
+  }
+  Range name_r = trim(s, name_args[0]);
+  stage.stage_name = resolve_token(s, name_r);
+  if (stage.stage_name.empty()) {
+    err.fail("Empty stage name", spec.begin);
+    return;
+  }
+  if (name_args.size() >= 2) {
+    Range args_r{name_args[1].begin, spec.end};
+    parse_args(s, args_r, stage, err);
+  }
+}
+
+/// Resolve edges from parsed chains: implicit comma adjacency + shared labels.
+void resolve_edges(FilterGraph& graph,
+                   const std::vector<std::vector<size_t>>& chains) {
+  std::set<std::pair<size_t, size_t>> seen;
+  auto add_edge = [&](size_t from, size_t to) {
+    if (from == to) {
+      return;
+    }
+    if (seen.insert({from, to}).second) {
+      graph.edges.emplace_back(from, to);
+    }
+  };
+
+  // Implicit adjacency: within a chain, connect consecutive filters when the
+  // downstream filter has no explicit input labels.
+  for (const auto& chain : chains) {
+    for (size_t k = 1; k < chain.size(); ++k) {
+      size_t prev = chain[k - 1];
+      size_t cur = chain[k];
+      if (graph.stages[cur].input_labels.empty()) {
+        add_edge(prev, cur);
+      }
+    }
+  }
+
+  // Explicit shared labels: an output label connects to any filter that lists
+  // the same name as an input label.
+  for (size_t producer = 0; producer < graph.stages.size(); ++producer) {
+    for (const std::string& out_label : graph.stages[producer].output_labels) {
+      for (size_t consumer = 0; consumer < graph.stages.size(); ++consumer) {
+        const auto& in = graph.stages[consumer].input_labels;
+        for (const std::string& in_label : in) {
+          if (in_label == out_label) {
+            add_edge(producer, consumer);
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+
+FilterGraphParseResult parse_filtergraph(const std::string& input) {
+  FilterGraphParseResult result;
+  ParseError err;
+
+  Range whole = trim(input, Range{0, input.size()});
+  if (whole.empty()) {
+    result.error = "Empty filtergraph";
+    return result;
+  }
+
+  // Split into filterchains on ';'.
+  std::vector<Range> chain_ranges =
+      split_top_level(input, whole.begin, whole.end, ";", err);
+  if (err.set) {
+    result.error =
+        err.message + " (at offset " + std::to_string(err.offset) + ")";
+    return result;
+  }
+
+  std::vector<std::vector<size_t>> chains;
+  for (const Range& chain_raw : chain_ranges) {
+    Range chain_r = trim(input, chain_raw);
+    if (chain_r.empty()) {
+      err.fail("Empty filterchain (stray ';')", chain_raw.begin);
+      break;
+    }
+
+    std::vector<Range> filter_ranges =
+        split_top_level(input, chain_r.begin, chain_r.end, ",", err);
+    if (err.set) {
+      break;
+    }
+
+    std::vector<size_t> chain_indices;
+    for (const Range& filter_raw : filter_ranges) {
+      FilterStage stage;
+      parse_filter(input, filter_raw, stage, err);
+      if (err.set) {
+        break;
+      }
+      chain_indices.push_back(result.graph.stages.size());
+      result.graph.stages.push_back(std::move(stage));
+    }
+    if (err.set) {
+      break;
+    }
+    chains.push_back(std::move(chain_indices));
+  }
+
+  if (err.set) {
+    result.error =
+        err.message + " (at offset " + std::to_string(err.offset) + ")";
+    return result;
+  }
+
+  resolve_edges(result.graph, chains);
+  result.ok = true;
+  return result;
+}
+
+}  // namespace cli
+}  // namespace orc

--- a/orc/presenters/src/filtergraph_parser.cpp
+++ b/orc/presenters/src/filtergraph_parser.cpp
@@ -1,6 +1,6 @@
 /*
  * File:        filtergraph_parser.cpp
- * Module:      orc-cli
+ * Module:      orc-presenters
  * Purpose:     Implementation of the ffmpeg-style filtergraph parser.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -20,7 +20,7 @@
 #include <vector>
 
 namespace orc {
-namespace cli {
+namespace presenters {
 
 namespace {
 
@@ -477,5 +477,5 @@ FilterGraphParseResult parse_filtergraph(const std::string& input) {
   return result;
 }
 
-}  // namespace cli
+}  // namespace presenters
 }  // namespace orc

--- a/orc/presenters/src/project_presenter.cpp
+++ b/orc/presenters/src/project_presenter.cpp
@@ -1346,6 +1346,13 @@ bool ProjectPresenter::triggerNode(orc::NodeID node_id,
 
   if (success) {
     is_modified_ = true;
+  } else if (!status.empty()) {
+    // `status` carries the stage's own failure reason (from
+    // TriggerableStage::get_trigger_status()); without logging it here the
+    // caller only ever sees a generic "failed to trigger" message with no
+    // indication of *why* (e.g. a missing input file, an invalid parameter
+    // value reported by a third-party plugin, etc.).
+    ORC_LOG_ERROR("Trigger failed for node {}: {}", node_id, status);
   }
 
   return success;


### PR DESCRIPTION
## Summary

Briefly describe what this PR changes and why.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

i openend the GUI without issue and the CLI was able to digest the filtergraph and run it
example off command used : `orc-cli --input "tbc_source=input_path='D:/Santana_smooth_CLV_NTSC_Laserjuke_2023-02-07_16-12-45.tbc':pcm_path='D:/Santana_smooth_CLV_NTSC_Laserjuke_2023-02-07_16-12-45.pcm'[n0]" --output [n0]hvd_chroma_decoder=fast=true:output_path='D:/santanadecode.mkv'`

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [ ] Related docs were updated if needed
- [#227] Linked issue (if applicable)

## Related issue
#226
Closes #