### PR TITLE
Add audio preview to Decode-Orc

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -153,6 +153,9 @@ jobs:
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
+          # Qt Multimedia is an add-on module in the online installer; the
+          # preview dialogue's audio output (QAudioSink) needs it.
+          modules: 'qtmultimedia'
           cache: true
 
       - name: Fetch ezpwd-reed-solomon headers

--- a/cmake/sdk_header_allowlist.txt
+++ b/cmake/sdk_header_allowlist.txt
@@ -17,6 +17,7 @@ orc/plugin/orc_stage_tooling.h
 orc/stage/analysis_sink_results.h
 orc/stage/artifact.h
 orc/stage/audio/audio_channel_pair.h
+orc/stage/audio/audio_sample_feed.h
 orc/stage/audio_channel_pair.h
 orc/stage/colour_preview_conversion.h
 orc/stage/colour_preview_provider.h

--- a/docs/gui-user-guide/dialogues/preview.md
+++ b/docs/gui-user-guide/dialogues/preview.md
@@ -37,6 +37,43 @@ Field indices always refer to the **post-stage output**, not the original source
 
 ---
 
+### Audio playback
+
+When the previewed stage's output carries audio channel pairs, the preview
+dialogue offers an **Audio** selector listing them (plus **Mute/None**),
+together with a volume slider. Selecting a pair and pressing play sounds that
+pair alongside the advancing preview; choosing **Mute/None** silences it.
+
+Playback is **audio-mastered**: the audio plays continuously at normal speed
+and the video chases it. Preview rendering cannot be relied on to reach real
+time — a 3D chroma decoder or a neural stage may need seconds per frame — so
+the preview shows whichever frame the audio has reached and skips the frames
+the renderer could not deliver in time. The sound is always continuous; on a
+heavy pipeline the picture simply refreshes at a lower rate.
+
+Points to be aware of:
+
+* Some sources decode their whole audio stream on first access (a TBC source,
+  an imported WAV, or an EFM disc decode, which can take minutes). A progress
+  window appears when the wait is long enough to notice, and the prepared audio
+  is retained so that pausing and resuming is immediate. CVBS containers read
+  audio per frame and need no preparation.
+* Preparing audio for a TBC, imported or EFM source holds the decoded stream in
+  memory, which can reach hundreds of megabytes on a feature-length title.
+* Channel-pair numbering belongs to the stage's output, so the selector is
+  re-read and reset to **Mute/None** whenever the previewed stage changes.
+* Editing parameters or the graph invalidates the prepared audio and stops
+  playback; press play again to restart.
+* Scrubbing during playback restarts the audio from the new position.
+* Choosing **Mute/None** during playback ends the audio session, so the preview
+  reverts to its timer-paced video-only playback rather than chasing an audio
+  clock. Picking a pair again resumes audio-mastered playback from the position
+  reached.
+* Projects with no audio are the normal case. The audio controls are then
+  disabled and playback behaves exactly as it does without the feature.
+
+---
+
 ### Field parity display
 
 The preview UI indicates whether the currently displayed field is:

--- a/docs/technical/plugin-sdk.md
+++ b/docs/technical/plugin-sdk.md
@@ -117,6 +117,7 @@ grouped by domain. A layout change here bumps the host ABI version.
 | Header | Provides |
 |--------|----------|
 | `<orc/stage/audio/audio_channel_pair.h>` | Audio channel-pair model shared by all |
+| `<orc/stage/audio/audio_sample_feed.h>` | Pure conversions from the 24-bit-in-int32 pipeline audio |
 
 **dropout**
 

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,13 @@
           ps."mkdocs-awesome-nav"
         ]);
 
+        # Qt Multimedia dlopens libpipewire-0.3.so.0 at runtime (PipeWire capture
+        # support) but nixpkgs' qtmultimedia carries no RPATH entry for it, so
+        # anything linking Qt6::Multimedia logs
+        #   qt.multimedia.symbolsresolver: Couldn't load pipewire-0.3 library
+        # unless PipeWire is on the library search path. Used on Linux only.
+        pipewireLibPath = "${pkgs.pipewire}/lib";
+
         # Build the decode-orc package (primary output).
         mkDecodeOrc = {}: stdenv.mkDerivation {
           pname = "decode-orc";
@@ -140,6 +147,11 @@
               "--set"
               "GIO_EXTRA_MODULES"
               "${pkgs.glib-networking}/lib/gio/modules"
+              # Let Qt Multimedia resolve libpipewire-0.3 (see pipewireLibPath).
+              "--prefix"
+              "LD_LIBRARY_PATH"
+              ":"
+              pipewireLibPath
             ];
 
           preFixup = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
@@ -166,6 +178,9 @@
             # Qt6 for GUI
             qt6.qtbase
             qt6.qttools
+
+            # Audio output device for preview playback (QAudioSink)
+            qt6.qtmultimedia
 
             # QtNodes built from flake input
             qtNodes
@@ -224,6 +239,7 @@
                     --set-rpath "$out/lib:$out/lib/orc-stage-plugins:${pkgs.lib.makeLibraryPath [
                       pkgs.stdenv.cc.cc
                       pkgs.qt6.qtbase
+                      pkgs.qt6.qtmultimedia
                       pkgs.curl
                       pkgs.ffmpeg
                       pkgs.soxr
@@ -426,6 +442,10 @@
             # Build CMAKE_PREFIX_PATH from all build inputs so that IDEs (e.g. CLion)
             # launched from this shell can run cmake without extra configuration.
             export CMAKE_PREFIX_PATH="$(echo $buildInputs $nativeBuildInputs | tr ' ' '\n' | tr '\n' ':')"
+            ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            # Qt Multimedia dlopens libpipewire-0.3 (see pipewireLibPath).
+            export LD_LIBRARY_PATH="${pipewireLibPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            ''}
 
             # Ensure build directory exists
             mkdir -p build
@@ -454,6 +474,10 @@
           shellHook = ''
             export EZPWD_INCLUDE_DIR=${ezpwd-headers}
             export CMAKE_PREFIX_PATH="$(echo $buildInputs $nativeBuildInputs | tr ' ' '\n' | tr '\n' ':')"
+            ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            # Qt Multimedia dlopens libpipewire-0.3 (see pipewireLibPath).
+            export LD_LIBRARY_PATH="${pipewireLibPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            ''}
             mkdir -p build
           '';
 

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -201,6 +201,7 @@ orc_add_core_unit_tests(
         presenters/plugin_load_state_test.cpp
         presenters/plugin_selector_test.cpp
         presenters/stage_details_test.cpp
+        presenters/representation_audio_stream_reader_test.cpp
 )
 target_link_libraries(orc-core-unit-tests-presenters orc-presenters)
 
@@ -454,5 +455,6 @@ orc_add_core_unit_tests(
                 preview_types/preview_carrier_conversion_test.cpp
                 preview_types/preview_frame_layout_test.cpp
                 preview_types/preview_helpers_test.cpp
+                preview_types/preview_navigation_hint_test.cpp
                 preview_types/preview_view_registry_test.cpp
         )

--- a/orc-tests/core/unit/mocks/mock_video_frame_representation.h
+++ b/orc-tests/core/unit/mocks/mock_video_frame_representation.h
@@ -57,6 +57,8 @@ class MockVideoFrameRepresentation : public orc::VideoFrameRepresentation {
               get_audio_channel_pair_descriptor, (size_t), (const, override));
   MOCK_METHOD((std::vector<int32_t>), get_audio_samples, (size_t, orc::FrameID),
               (const, override));
+  MOCK_METHOD(void, prime_audio_decode, (const orc::AudioDecodeProgressFn&),
+              (const, override));
 
   // EFM
   MOCK_METHOD(bool, has_efm, (), (const, override));

--- a/orc-tests/core/unit/presenters/representation_audio_stream_reader_test.cpp
+++ b/orc-tests/core/unit/presenters/representation_audio_stream_reader_test.cpp
@@ -1,0 +1,410 @@
+/*
+ * File:        representation_audio_stream_reader_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Unit tests for the presenter audio access surface: pair
+ *              enumeration, reader creation, carrier→float conversion and
+ *              SMPTE 272M frame ↔ stream-position mapping
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "../../../../orc/presenters/src/representation_audio_stream_reader.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <orc/stage/audio/audio_sample_feed.h>
+
+#include <memory>
+
+#include "../mocks/mock_video_frame_representation.h"
+
+namespace orc_unit_test {
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace {
+
+// SMPTE 272M-1994 §14.3 Table 1: PAL is a constant 1920 stereo pairs per frame.
+constexpr uint32_t kPalPairsPerFrame = 1920;
+
+std::optional<orc::SourceParameters> params_for(orc::VideoSystem system) {
+  orc::SourceParameters params{};
+  params.system = system;
+  return params;
+}
+
+orc::AudioChannelPairDescriptor descriptor(std::string name,
+                                           orc::AudioOrigin origin) {
+  orc::AudioChannelPairDescriptor desc;
+  desc.name = std::move(name);
+  desc.origin = origin;
+  return desc;
+}
+
+// A representation carrying |pair_count| pairs over frames [0, last_frame].
+std::shared_ptr<NiceMock<MockVideoFrameRepresentation>> make_representation(
+    orc::VideoSystem system, size_t pair_count, orc::FrameID last_frame = 99) {
+  auto repr = std::make_shared<NiceMock<MockVideoFrameRepresentation>>();
+  ON_CALL(*repr, get_video_parameters())
+      .WillByDefault(Return(params_for(system)));
+  ON_CALL(*repr, audio_channel_pair_count()).WillByDefault(Return(pair_count));
+  ON_CALL(*repr, frame_range())
+      .WillByDefault(Return(orc::FrameIDRange{0, last_frame}));
+  return repr;
+}
+
+// Ramp of distinct carrier values so conversion and ordering are both visible:
+// sample s of frame f is (f + 1) * 1000 + s.
+std::vector<int32_t> ramp_samples(orc::FrameID frame, uint32_t pairs) {
+  std::vector<int32_t> out(static_cast<size_t>(pairs) * 2);
+  for (size_t s = 0; s < out.size(); ++s) {
+    out[s] = static_cast<int32_t>((frame + 1) * 1000 + s);
+  }
+  return out;
+}
+
+}  // namespace
+
+// === Pair enumeration =====================================================
+
+TEST(RepresentationAudioPairEnumerationTest,
+     EnumeratesEveryPairWithIndexNameAndOrigin) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 2);
+  ON_CALL(*repr, get_audio_channel_pair_descriptor(0))
+      .WillByDefault(
+          Return(descriptor("Analogue", orc::AudioOrigin::ANALOGUE)));
+  ON_CALL(*repr, get_audio_channel_pair_descriptor(1))
+      .WillByDefault(
+          Return(descriptor("EFM digital audio", orc::AudioOrigin::EFM)));
+
+  const auto pairs = orc::presenters::enumerate_audio_channel_pairs(*repr);
+
+  ASSERT_EQ(pairs.size(), 2u);
+  EXPECT_EQ(pairs[0].index, 0u);
+  EXPECT_EQ(pairs[0].name, "Analogue");
+  EXPECT_EQ(pairs[0].origin, "analogue");
+  EXPECT_EQ(pairs[1].index, 1u);
+  EXPECT_EQ(pairs[1].name, "EFM digital audio");
+  EXPECT_EQ(pairs[1].origin, "efm");
+}
+
+TEST(RepresentationAudioPairEnumerationTest,
+     ReturnsEmptyList_WhenRepresentationHasNoAudio) {
+  // The normal case for most projects — audio is optional end to end.
+  auto repr = make_representation(orc::VideoSystem::PAL, 0);
+
+  EXPECT_TRUE(orc::presenters::enumerate_audio_channel_pairs(*repr).empty());
+}
+
+TEST(RepresentationAudioPairEnumerationTest,
+     ReturnsEmptyList_WhenVideoSystemIsUnknown) {
+  // Without a video system the SMPTE 272M cadence is undefined, so nominally
+  // present pairs cannot be addressed by frame and are reported as absent.
+  auto repr = make_representation(orc::VideoSystem::Unknown, 2);
+
+  EXPECT_TRUE(orc::presenters::enumerate_audio_channel_pairs(*repr).empty());
+}
+
+TEST(RepresentationAudioPairEnumerationTest,
+     ReturnsEmptyList_WhenVideoParametersAreAbsent) {
+  auto repr = std::make_shared<NiceMock<MockVideoFrameRepresentation>>();
+  ON_CALL(*repr, get_video_parameters()).WillByDefault(Return(std::nullopt));
+  ON_CALL(*repr, audio_channel_pair_count()).WillByDefault(Return(1));
+
+  EXPECT_TRUE(orc::presenters::enumerate_audio_channel_pairs(*repr).empty());
+}
+
+TEST(RepresentationAudioPairEnumerationTest,
+     ReportsUnknownOrigin_WhenDescriptorIsAbsent) {
+  auto repr = make_representation(orc::VideoSystem::NTSC, 1);
+  ON_CALL(*repr, get_audio_channel_pair_descriptor(0))
+      .WillByDefault(Return(std::nullopt));
+
+  const auto pairs = orc::presenters::enumerate_audio_channel_pairs(*repr);
+
+  ASSERT_EQ(pairs.size(), 1u);
+  EXPECT_TRUE(pairs[0].name.empty());
+  EXPECT_EQ(pairs[0].origin, "unknown");
+}
+
+// === Reader creation ======================================================
+
+TEST(RepresentationAudioStreamReaderCreationTest, CreatesReader_ForUsablePair) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+
+  EXPECT_NE(orc::presenters::make_audio_stream_reader(repr, 0), nullptr);
+}
+
+TEST(RepresentationAudioStreamReaderCreationTest,
+     ReturnsNull_WhenPairIsOutOfRange) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+
+  EXPECT_EQ(orc::presenters::make_audio_stream_reader(repr, 1), nullptr);
+}
+
+TEST(RepresentationAudioStreamReaderCreationTest,
+     ReturnsNull_WhenVideoSystemIsUnknown) {
+  auto repr = make_representation(orc::VideoSystem::Unknown, 1);
+
+  EXPECT_EQ(orc::presenters::make_audio_stream_reader(repr, 0), nullptr);
+}
+
+TEST(RepresentationAudioStreamReaderCreationTest,
+     ReturnsNull_WhenRepresentationIsNull) {
+  EXPECT_EQ(orc::presenters::make_audio_stream_reader(nullptr, 0), nullptr);
+}
+
+TEST(RepresentationAudioStreamReaderCreationTest,
+     KeepsRepresentationAliveForTheReadersLifetime) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+  std::weak_ptr<const orc::VideoFrameRepresentation> observer = repr;
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  repr.reset();
+
+  // The playback session must not read through a freed representation.
+  EXPECT_FALSE(observer.expired());
+  reader.reset();
+  EXPECT_TRUE(observer.expired());
+}
+
+// === Frame ↔ stream-position mapping ======================================
+
+TEST(RepresentationAudioStreamReaderMappingTest, PalUsesConstant1920Stride) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  EXPECT_EQ(reader->pairPositionForFrame(0), 0u);
+  EXPECT_EQ(reader->pairPositionForFrame(1), kPalPairsPerFrame);
+  EXPECT_EQ(reader->pairPositionForFrame(100), 100u * kPalPairsPerFrame);
+
+  EXPECT_EQ(reader->frameForPairPosition(0), 0u);
+  EXPECT_EQ(reader->frameForPairPosition(kPalPairsPerFrame - 1), 0u);
+  EXPECT_EQ(reader->frameForPairPosition(kPalPairsPerFrame), 1u);
+}
+
+TEST(RepresentationAudioStreamReaderMappingTest,
+     NtscFollowsTheFiveFrameCadence) {
+  auto repr = make_representation(orc::VideoSystem::NTSC, 1);
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  // SMPTE 272M-1994 §14.3 Table 1: 1602/1601/1602/1601/1602 per frame gives
+  // cumulative in-sequence offsets 0, 1602, 3203, 4805, 6406, 8008.
+  const uint64_t expected[] = {0, 1602, 3203, 4805, 6406, 8008};
+  for (uint64_t frame = 0; frame < 6; ++frame) {
+    EXPECT_EQ(reader->pairPositionForFrame(frame), expected[frame])
+        << "frame " << frame;
+  }
+
+  // No drift accumulates: five frames per sequence, exactly 8008 pairs.
+  EXPECT_EQ(reader->pairPositionForFrame(5 * 100), 8008u * 100u);
+}
+
+TEST(RepresentationAudioStreamReaderMappingTest,
+     NtscPositionMapsBackToItsOwnFrame) {
+  auto repr = make_representation(orc::VideoSystem::NTSC, 1);
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  // Round-trip every frame of two full audio-frame sequences plus the last
+  // position inside each frame — the boundary the naive pos*5/8008 estimate
+  // gets wrong.
+  for (orc::FrameID frame = 0; frame < 10; ++frame) {
+    const uint64_t start = reader->pairPositionForFrame(frame);
+    const uint64_t last = reader->pairPositionForFrame(frame + 1) - 1;
+    EXPECT_EQ(reader->frameForPairPosition(start), frame) << "start " << frame;
+    EXPECT_EQ(reader->frameForPairPosition(last), frame) << "last " << frame;
+  }
+}
+
+TEST(RepresentationAudioStreamReaderMappingTest,
+     FrameRangeMirrorsTheRepresentation) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1, /*last_frame=*/41);
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  EXPECT_EQ(reader->frameRange().first, 0u);
+  EXPECT_EQ(reader->frameRange().last, 41u);
+  EXPECT_EQ(reader->frameRange().count(), 42u);
+}
+
+// === Sample reads =========================================================
+
+TEST(RepresentationAudioStreamReaderReadTest,
+     ConvertsCarrierToFloatAtFullScale) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+  // One PAL frame of samples whose first four values probe the carrier extremes
+  // (SMPTE 272M-1994 §1.3: −8388608 … 8388607 in int32_t).
+  std::vector<int32_t> block(kPalPairsPerFrame * 2, 0);
+  block[0] = 0;
+  block[1] = 8388607;
+  block[2] = -8388608;
+  block[3] = 4194304;
+  ON_CALL(*repr, get_audio_samples(0, 0)).WillByDefault(Return(block));
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  const auto samples = reader->readFrames(0, 1);
+
+  ASSERT_EQ(samples.size(), kPalPairsPerFrame * 2u);
+  EXPECT_FLOAT_EQ(samples[0], 0.0f);
+  EXPECT_FLOAT_EQ(samples[1], 8388607.0f / 8388608.0f);
+  EXPECT_FLOAT_EQ(samples[2], -1.0f);
+  EXPECT_FLOAT_EQ(samples[3], 0.5f);
+}
+
+TEST(RepresentationAudioStreamReaderReadTest,
+     ConcatenatesFramesInTemporalOrder) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+  ON_CALL(*repr, get_audio_samples(0, _))
+      .WillByDefault(Invoke([](size_t, orc::FrameID frame) {
+        return ramp_samples(frame, kPalPairsPerFrame);
+      }));
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  const auto samples = reader->readFrames(3, 2);
+
+  ASSERT_EQ(samples.size(), kPalPairsPerFrame * 2u * 2u);
+  // First sample of frame 3, then first sample of frame 4.
+  EXPECT_FLOAT_EQ(samples[0], orc::audio_carrier_to_float(4000));
+  EXPECT_FLOAT_EQ(samples[kPalPairsPerFrame * 2],
+                  orc::audio_carrier_to_float(5000));
+}
+
+TEST(RepresentationAudioStreamReaderReadTest,
+     SizesNtscReadsFromTheCadenceNotAConstantStride) {
+  auto repr = make_representation(orc::VideoSystem::NTSC, 1);
+  ON_CALL(*repr, get_audio_samples(0, _))
+      .WillByDefault(Invoke([](size_t, orc::FrameID frame) {
+        return ramp_samples(
+            frame, orc::audio_pairs_in_frame(frame, orc::VideoSystem::NTSC));
+      }));
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  // Frames 0..4 are one complete audio frame sequence: 8008 pairs total.
+  EXPECT_EQ(reader->readFrames(0, 5).size(), 8008u * 2u);
+  // Frames 1..2 are 1601 + 1602 pairs — not 2 × any constant.
+  EXPECT_EQ(reader->readFrames(1, 2).size(), (1601u + 1602u) * 2u);
+}
+
+TEST(RepresentationAudioStreamReaderReadTest,
+     SubstitutesCadenceExactSilence_WhenAFrameHasNoSamples) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+  ON_CALL(*repr, get_audio_samples(0, 0))
+      .WillByDefault(Return(std::vector<int32_t>(kPalPairsPerFrame * 2, 7)));
+  // A legal response: e.g. a CVBS placeholder pair with nothing for this frame.
+  ON_CALL(*repr, get_audio_samples(0, 1))
+      .WillByDefault(Return(std::vector<int32_t>{}));
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  const auto samples = reader->readFrames(0, 2);
+
+  // The gap must not shorten the buffer, or the audio clock would slip against
+  // the frame timeline.
+  ASSERT_EQ(samples.size(), kPalPairsPerFrame * 2u * 2u);
+  EXPECT_FLOAT_EQ(samples[0], orc::audio_carrier_to_float(7));
+  EXPECT_FLOAT_EQ(samples[kPalPairsPerFrame * 2], 0.0f);
+  EXPECT_FLOAT_EQ(samples.back(), 0.0f);
+}
+
+TEST(RepresentationAudioStreamReaderReadTest,
+     PadsShortBlocksAndTruncatesLongOnes) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+  ON_CALL(*repr, get_audio_samples(0, 0))
+      .WillByDefault(Return(std::vector<int32_t>{11, 22}));  // one pair only
+  ON_CALL(*repr, get_audio_samples(0, 1))
+      .WillByDefault(
+          Return(std::vector<int32_t>(kPalPairsPerFrame * 4, 33)));  // too long
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  const auto samples = reader->readFrames(0, 2);
+
+  ASSERT_EQ(samples.size(), kPalPairsPerFrame * 2u * 2u);
+  EXPECT_FLOAT_EQ(samples[0], orc::audio_carrier_to_float(11));
+  EXPECT_FLOAT_EQ(samples[1], orc::audio_carrier_to_float(22));
+  EXPECT_FLOAT_EQ(samples[2], 0.0f);  // short block padded with silence
+  EXPECT_FLOAT_EQ(samples[kPalPairsPerFrame * 2],
+                  orc::audio_carrier_to_float(33));
+  EXPECT_FLOAT_EQ(samples.back(), orc::audio_carrier_to_float(33));
+}
+
+TEST(RepresentationAudioStreamReaderReadTest, ClampsReadsToTheFrameRange) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1, /*last_frame=*/4);
+  ON_CALL(*repr, get_audio_samples(0, _))
+      .WillByDefault(Invoke([](size_t, orc::FrameID frame) {
+        return ramp_samples(frame, kPalPairsPerFrame);
+      }));
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  // Overruns the end: frames 3 and 4 only.
+  EXPECT_EQ(reader->readFrames(3, 10).size(), kPalPairsPerFrame * 2u * 2u);
+  // Entirely past the end.
+  EXPECT_TRUE(reader->readFrames(5, 4).empty());
+  // Zero-length request.
+  EXPECT_TRUE(reader->readFrames(0, 0).empty());
+}
+
+TEST(RepresentationAudioStreamReaderReadTest,
+     ReadsTheRequestedPairOnly_WhenSeveralArePresent) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 3);
+  EXPECT_CALL(*repr, get_audio_samples(2, 0))
+      .WillOnce(Return(std::vector<int32_t>(kPalPairsPerFrame * 2, 5)));
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 2);
+  ASSERT_NE(reader, nullptr);
+
+  const auto samples = reader->readFrames(0, 1);
+
+  ASSERT_FALSE(samples.empty());
+  EXPECT_FLOAT_EQ(samples[0], orc::audio_carrier_to_float(5));
+}
+
+// === Priming ==============================================================
+
+TEST(RepresentationAudioStreamReaderPrimeTest,
+     ForwardsProgressToTheRepresentation) {
+  auto repr = make_representation(orc::VideoSystem::PAL, 1);
+  uint64_t seen_done = 0;
+  uint64_t seen_total = 0;
+  std::string seen_message;
+  EXPECT_CALL(*repr, prime_audio_decode(_))
+      .WillOnce(Invoke([](const orc::AudioDecodeProgressFn& progress) {
+        // Producers report through the callback they were handed; EFM decode is
+        // the one that reports real progress.
+        if (progress) {
+          progress(3, 10, "Decoding EFM audio");
+        }
+      }));
+
+  auto reader = orc::presenters::make_audio_stream_reader(repr, 0);
+  ASSERT_NE(reader, nullptr);
+
+  reader->prime([&](uint64_t done, uint64_t total, const std::string& message) {
+    seen_done = done;
+    seen_total = total;
+    seen_message = message;
+  });
+
+  EXPECT_EQ(seen_done, 3u);
+  EXPECT_EQ(seen_total, 10u);
+  EXPECT_EQ(seen_message, "Decoding EFM audio");
+}
+
+}  // namespace orc_unit_test

--- a/orc-tests/core/unit/preview_types/preview_carrier_conversion_test.cpp
+++ b/orc-tests/core/unit/preview_types/preview_carrier_conversion_test.cpp
@@ -11,6 +11,12 @@
 #include <orc/stage/preview/orc_preview_carriers.h>
 #include <orc/support/colour_preview_conversion.h>
 
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
 namespace orc_unit_test {
 
 TEST(ColourFrameCarrierTest, InvalidWhenPlaneSizesDoNot_MatchDimensions) {
@@ -221,6 +227,163 @@ TEST(ColourCarrierConversionTest, Bt1886Transfer_ProducesValidImage) {
   ASSERT_TRUE(image.is_valid());
   ASSERT_EQ(image.width, 1u);
   ASSERT_EQ(image.height, 1u);
+}
+
+// =============================================================================
+// Transfer-function lookup tables
+//
+// The conversion evaluates the transfer decode and the sRGB encode through an
+// interpolated table rather than std::pow per component. These tests pin the
+// table's output against the transfer formulae computed directly, so a change
+// to the table resolution or the interpolation cannot silently shift the
+// rendered image.
+// =============================================================================
+
+namespace {
+
+// The reference conversion, written straight from the specifications rather
+// than from the implementation: ITU-R BT.470/BT.709 opto-electronic transfer
+// decode to linear light, then the IEC 61966-2-1 (sRGB) encode.
+double referenceDecodeToLinear(
+    double value, orc::ColorimetricTransferCharacteristics transfer) {
+  value = std::clamp(value, 0.0, 1.0);
+
+  switch (transfer) {
+    case orc::ColorimetricTransferCharacteristics::Gamma28:
+      return std::pow(value, 2.8);
+    case orc::ColorimetricTransferCharacteristics::BT709:
+      // ITU-R BT.709-6 Section 1.2: linear below 0.081, power law above.
+      if (value < 0.081) {
+        return value / 4.5;
+      }
+      return std::pow((value + 0.099) / 1.099, 1.0 / 0.45);
+    case orc::ColorimetricTransferCharacteristics::BT1886:
+    case orc::ColorimetricTransferCharacteristics::BT1886App1:
+      return std::pow(value, 2.4);
+    case orc::ColorimetricTransferCharacteristics::Gamma22:
+    case orc::ColorimetricTransferCharacteristics::Unspecified:
+    default:
+      return std::pow(value, 2.2);
+  }
+}
+
+// IEC 61966-2-1: sRGB opto-electronic transfer function.
+double referenceEncodeToSrgb(double linear) {
+  linear = std::clamp(linear, 0.0, 1.0);
+  if (linear <= 0.0031308) {
+    return 12.92 * linear;
+  }
+  return 1.055 * std::pow(linear, 1.0 / 2.4) - 0.055;
+}
+
+uint8_t referenceCode(double non_linear,
+                      orc::ColorimetricTransferCharacteristics transfer) {
+  const double srgb =
+      referenceEncodeToSrgb(referenceDecodeToLinear(non_linear, transfer));
+  return static_cast<uint8_t>(std::clamp(srgb, 0.0, 1.0) * 255.0 + 0.5);
+}
+
+// A single-row carrier whose luma sweeps [0, 1] of the black→white range with
+// neutral chroma, so every output byte is the transfer function of a known
+// non-linear input.
+orc::ColourFrameCarrier makeLumaRamp(
+    uint32_t samples, orc::ColorimetricTransferCharacteristics transfer) {
+  constexpr double kWhite = 65535.0;
+
+  orc::ColourFrameCarrier carrier{};
+  carrier.width = samples;
+  carrier.height = 1;
+  carrier.cvbs_blanking = 0.0;
+  carrier.cvbs_black = 0.0;
+  carrier.cvbs_white = kWhite;
+  carrier.colorimetry = orc::ColorimetricMetadata::default_ntsc();
+  carrier.colorimetry.transfer_characteristics = transfer;
+
+  carrier.y_plane.resize(samples);
+  carrier.u_plane.assign(samples, 0.0);
+  carrier.v_plane.assign(samples, 0.0);
+  for (uint32_t i = 0; i < samples; ++i) {
+    carrier.y_plane[i] =
+        kWhite * static_cast<double>(i) / static_cast<double>(samples - 1);
+  }
+  return carrier;
+}
+
+}  // namespace
+
+TEST(ColourCarrierConversionTest, TransferTable_MatchesDirectEvaluation) {
+  // Every supported characteristic, swept densely enough to cross every table
+  // interval many times over.
+  const orc::ColorimetricTransferCharacteristics transfers[] = {
+      orc::ColorimetricTransferCharacteristics::Unspecified,
+      orc::ColorimetricTransferCharacteristics::Gamma22,
+      orc::ColorimetricTransferCharacteristics::Gamma28,
+      orc::ColorimetricTransferCharacteristics::BT709,
+      orc::ColorimetricTransferCharacteristics::BT1886,
+      orc::ColorimetricTransferCharacteristics::BT1886App1,
+  };
+  constexpr uint32_t kSamples = 20000;
+
+  for (const auto transfer : transfers) {
+    const auto carrier = makeLumaRamp(kSamples, transfer);
+    const auto image = orc::render_preview_from_colour_carrier(carrier);
+    ASSERT_TRUE(image.is_valid());
+
+    size_t off_by_one = 0;
+    for (uint32_t i = 0; i < kSamples; ++i) {
+      const double non_linear =
+          static_cast<double>(i) / static_cast<double>(kSamples - 1);
+      const int expected = referenceCode(non_linear, transfer);
+      const int actual = image.rgb_data[static_cast<size_t>(i) * 3];
+
+      // Never more than one 8-bit code away from the directly evaluated
+      // transfer function, for any input.
+      ASSERT_LE(std::abs(actual - expected), 1)
+          << "transfer=" << static_cast<int>(transfer) << " sample=" << i
+          << " expected=" << expected << " actual=" << actual;
+      if (actual != expected) {
+        ++off_by_one;
+      }
+    }
+
+    // Only inputs landing within the table's reconstruction error of a
+    // rounding boundary may differ at all; that is a small fraction of a
+    // percent, not a systematic shift.
+    EXPECT_LT(off_by_one, kSamples / 100)
+        << "transfer=" << static_cast<int>(transfer) << " differed on "
+        << off_by_one << " of " << kSamples << " samples";
+  }
+}
+
+TEST(ColourCarrierConversionTest, TransferTable_IsExactAtTheRangeEndpoints) {
+  // Black and white must not drift: the top endpoint in particular is the one
+  // input that falls outside every interpolation interval.
+  const auto carrier =
+      makeLumaRamp(2, orc::ColorimetricTransferCharacteristics::Gamma22);
+  const auto image = orc::render_preview_from_colour_carrier(carrier);
+  ASSERT_TRUE(image.is_valid());
+
+  EXPECT_EQ(image.rgb_data[0], 0);
+  EXPECT_EQ(image.rgb_data[1], 0);
+  EXPECT_EQ(image.rgb_data[2], 0);
+  EXPECT_EQ(image.rgb_data[3], 255);
+  EXPECT_EQ(image.rgb_data[4], 255);
+  EXPECT_EQ(image.rgb_data[5], 255);
+}
+
+TEST(ColourCarrierConversionTest, TransferTable_StaysMonotonicAcrossTheRamp) {
+  // A table lookup must not introduce a local dip; banding in a preview ramp
+  // is exactly what a badly interpolated table looks like.
+  const auto carrier =
+      makeLumaRamp(4096, orc::ColorimetricTransferCharacteristics::BT709);
+  const auto image = orc::render_preview_from_colour_carrier(carrier);
+  ASSERT_TRUE(image.is_valid());
+
+  for (uint32_t i = 1; i < carrier.width; ++i) {
+    EXPECT_LE(image.rgb_data[static_cast<size_t>(i - 1) * 3],
+              image.rgb_data[static_cast<size_t>(i) * 3])
+        << "output fell at sample " << i;
+  }
 }
 
 namespace {

--- a/orc-tests/core/unit/preview_types/preview_navigation_hint_test.cpp
+++ b/orc-tests/core/unit/preview_types/preview_navigation_hint_test.cpp
@@ -1,0 +1,230 @@
+/*
+ * File:        preview_navigation_hint_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     PreviewRenderer forwards the caller's navigation hint to stages
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include <gtest/gtest.h>
+#include <orc/stage/artifact.h>
+#include <orc/stage/observation/observation_context.h>
+#include <orc/stage/preview/colour_preview_provider.h>
+#include <orc/stage/preview/stage_custom_preview_renderer.h>
+#include <orc/stage/stage.h>
+#include <orc/stage/video_frame_representation.h>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "preview_renderer.h"
+
+namespace orc {
+namespace {
+
+// Minimal VFR so a source node has something to hand downstream. The preview
+// under test never reads it — the stages below render their own images.
+class EmptyVfr final : public VideoFrameRepresentation, public Artifact {
+ public:
+  EmptyVfr() : Artifact(ArtifactID("hint_probe"), Provenance{}) {}
+
+  std::string type_name() const override { return "VideoFrameRepresentation"; }
+
+  FrameIDRange frame_range() const override { return {0, 0}; }
+  size_t frame_count() const override { return 1; }
+  bool has_frame(FrameID id) const override { return id == 0; }
+  std::optional<FrameDescriptor> get_frame_descriptor(
+      FrameID /*id*/) const override {
+    return std::nullopt;
+  }
+  const sample_type* get_frame(FrameID /*id*/) const override {
+    return nullptr;
+  }
+  std::vector<sample_type> get_frame_copy(FrameID /*id*/) const override {
+    return {};
+  }
+};
+
+PreviewImage make_solid_image() {
+  PreviewImage image{};
+  image.width = 2;
+  image.height = 2;
+  image.rgb_data.assign(2 * 2 * 3, 64);
+  return image;
+}
+
+// A stage on the custom-preview path (the SourceAlignStage shape): it renders
+// its own images and receives the hint directly.
+class CustomPreviewProbeStage final : public DAGStage,
+                                      public IStageCustomPreviewRenderer {
+ public:
+  std::string version() const override { return "1.0.0"; }
+
+  NodeTypeInfo get_node_type_info() const override {
+    return NodeTypeInfo(NodeType::SOURCE, "custom_preview_probe",
+                        "Custom Preview Probe", "", 0, 0, 1, 1,
+                        VideoFormatCompatibility::ALL);
+  }
+
+  std::vector<ArtifactPtr> execute(
+      const std::vector<ArtifactPtr>& /*inputs*/,
+      const std::map<std::string, ParameterValue>& /*parameters*/,
+      ObservationContext& /*ctx*/) override {
+    return {std::make_shared<EmptyVfr>()};
+  }
+
+  size_t required_input_count() const override { return 0; }
+  size_t output_count() const override { return 1; }
+
+  std::vector<PreviewOption> get_preview_options() const override {
+    return {PreviewOption{"probe", "Probe", true, 2, 2, 1, 1.0}};
+  }
+
+  PreviewImage render_preview(const std::string& /*option_id*/,
+                              uint64_t /*index*/,
+                              PreviewNavigationHint hint) const override {
+    observed_hint = hint;
+    return make_solid_image();
+  }
+
+  mutable std::optional<PreviewNavigationHint> observed_hint;
+};
+
+// A stage on the colour-carrier path: the hint reaches it through
+// IColourPreviewProvider instead.
+class ColourPreviewProbeStage final : public DAGStage,
+                                      public IStagePreviewCapability,
+                                      public IColourPreviewProvider {
+ public:
+  std::string version() const override { return "1.0.0"; }
+
+  NodeTypeInfo get_node_type_info() const override {
+    return NodeTypeInfo(NodeType::SOURCE, "colour_preview_probe",
+                        "Colour Preview Probe", "", 0, 0, 1, 1,
+                        VideoFormatCompatibility::ALL);
+  }
+
+  std::vector<ArtifactPtr> execute(
+      const std::vector<ArtifactPtr>& /*inputs*/,
+      const std::map<std::string, ParameterValue>& /*parameters*/,
+      ObservationContext& /*ctx*/) override {
+    return {std::make_shared<EmptyVfr>()};
+  }
+
+  size_t required_input_count() const override { return 0; }
+  size_t output_count() const override { return 1; }
+
+  StagePreviewCapability get_preview_capability() const override {
+    StagePreviewCapability capability{};
+    capability.supported_data_types = {VideoDataType::ColourNTSC};
+    capability.navigation_extent = {1, 1, "frame"};
+    capability.geometry = {2, 2, 4.0 / 3.0, 1.0};
+    return capability;
+  }
+
+  std::optional<ColourFrameCarrier> get_colour_preview_carrier(
+      uint64_t frame_index, PreviewNavigationHint hint) const override {
+    observed_hint = hint;
+
+    ColourFrameCarrier carrier{};
+    carrier.data_type = VideoDataType::ColourNTSC;
+    carrier.colorimetry = ColorimetricMetadata::default_ntsc();
+    carrier.frame_index = frame_index;
+    carrier.width = 2;
+    carrier.height = 2;
+    carrier.y_plane = {0.25, 0.5, 0.75, 1.0};
+    carrier.u_plane = {0.0, 0.0, 0.0, 0.0};
+    carrier.v_plane = {0.0, 0.0, 0.0, 0.0};
+    carrier.cvbs_white = 65535.0;
+    carrier.cvbs_blanking = 0.0;
+    return carrier;
+  }
+
+  mutable std::optional<PreviewNavigationHint> observed_hint;
+};
+
+template <typename StageT>
+std::shared_ptr<DAG> build_single_node_dag(std::shared_ptr<StageT> stage) {
+  DAGNode node;
+  node.node_id = NodeID(1);
+  node.stage = std::move(stage);
+
+  auto dag = std::make_shared<DAG>();
+  dag->add_node(std::move(node));
+  return dag;
+}
+
+// Playback renders a run of adjacent frames, and the SDK contract lets a stage
+// pre-fetch around the requested one when it is told so. The hint was declared
+// end to end but never sent — every render arrived as Random.
+TEST(PreviewNavigationHintTest, CustomPreviewStage_ReceivesSequentialHint) {
+  auto stage = std::make_shared<CustomPreviewProbeStage>();
+  PreviewRenderer renderer(build_single_node_dag(stage));
+
+  const auto result =
+      renderer.render_output(NodeID(1), PreviewOutputType::Frame_Field1_First,
+                             0, "probe", PreviewNavigationHint::Sequential);
+
+  ASSERT_TRUE(result.success) << result.error_message;
+  ASSERT_TRUE(stage->observed_hint.has_value());
+  EXPECT_EQ(*stage->observed_hint, PreviewNavigationHint::Sequential);
+}
+
+TEST(PreviewNavigationHintTest, CustomPreviewStage_ReceivesRandomHint) {
+  auto stage = std::make_shared<CustomPreviewProbeStage>();
+  PreviewRenderer renderer(build_single_node_dag(stage));
+
+  const auto result =
+      renderer.render_output(NodeID(1), PreviewOutputType::Frame_Field1_First,
+                             0, "probe", PreviewNavigationHint::Random);
+
+  ASSERT_TRUE(result.success) << result.error_message;
+  ASSERT_TRUE(stage->observed_hint.has_value());
+  EXPECT_EQ(*stage->observed_hint, PreviewNavigationHint::Random);
+}
+
+// Scrubbing and one-off navigations must keep the old behaviour, so an
+// unspecified hint stays Random rather than inheriting the playback value.
+TEST(PreviewNavigationHintTest, DefaultsToRandomWhenTheCallerSaysNothing) {
+  auto stage = std::make_shared<CustomPreviewProbeStage>();
+  PreviewRenderer renderer(build_single_node_dag(stage));
+
+  const auto result = renderer.render_output(
+      NodeID(1), PreviewOutputType::Frame_Field1_First, 0, "probe");
+
+  ASSERT_TRUE(result.success) << result.error_message;
+  ASSERT_TRUE(stage->observed_hint.has_value());
+  EXPECT_EQ(*stage->observed_hint, PreviewNavigationHint::Random);
+}
+
+TEST(PreviewNavigationHintTest, ColourCarrierStage_ReceivesSequentialHint) {
+  auto stage = std::make_shared<ColourPreviewProbeStage>();
+  PreviewRenderer renderer(build_single_node_dag(stage));
+
+  const auto result =
+      renderer.render_output(NodeID(1), PreviewOutputType::Frame_Field1_First,
+                             0, "", PreviewNavigationHint::Sequential);
+
+  ASSERT_TRUE(result.success) << result.error_message;
+  ASSERT_TRUE(stage->observed_hint.has_value());
+  EXPECT_EQ(*stage->observed_hint, PreviewNavigationHint::Sequential);
+}
+
+TEST(PreviewNavigationHintTest, ColourCarrierStage_DefaultsToRandom) {
+  auto stage = std::make_shared<ColourPreviewProbeStage>();
+  PreviewRenderer renderer(build_single_node_dag(stage));
+
+  const auto result = renderer.render_output(
+      NodeID(1), PreviewOutputType::Frame_Field1_First, 0, "");
+
+  ASSERT_TRUE(result.success) << result.error_message;
+  ASSERT_TRUE(stage->observed_hint.has_value());
+  EXPECT_EQ(*stage->observed_hint, PreviewNavigationHint::Random);
+}
+
+}  // namespace
+}  // namespace orc

--- a/orc-tests/core/unit/stages/audio_align/audio_align_stage_test.cpp
+++ b/orc-tests/core/unit/stages/audio_align/audio_align_stage_test.cpp
@@ -133,14 +133,36 @@ TEST(AudioAlignStageTest, Descriptors_DefaultsRoundTripThroughSetGet) {
   EXPECT_EQ(std::get<double>(params.at("offset_ms")), -12.5);
 }
 
-TEST(AudioAlignStageTest, Execute_ThrowsWhenChannelPairOutOfRange) {
+TEST(AudioAlignStageTest, ChannelPairOutOfRange_PassesInputThrough) {
+  // A pair the input does not carry must not fail the DAG: an audio-only
+  // misconfiguration cannot be allowed to blank a downstream video preview.
   orc::AudioAlignStage stage;
   auto vfr = std::make_shared<NiceMock<MockVideoFrameRepresentationArtifact>>();
   ON_CALL(*vfr, audio_channel_pair_count()).WillByDefault(Return(1u));
 
   orc::ObservationContext ctx;
-  EXPECT_THROW(stage.execute({vfr}, {{"channel_pair", std::string("1")}}, ctx),
-               orc::DAGExecutionError);
+  std::vector<orc::ArtifactPtr> outputs;
+  ASSERT_NO_THROW(outputs = stage.execute(
+                      {vfr},
+                      {{"channel_pair", std::string("1")}, {"offset_ms", 40.0}},
+                      ctx));
+  ASSERT_EQ(outputs.size(), 1u);
+  EXPECT_EQ(outputs[0].get(), vfr.get());
+}
+
+TEST(AudioAlignStageTest, NoAudioPairs_PassesInputThrough) {
+  orc::AudioAlignStage stage;
+  auto vfr = std::make_shared<NiceMock<MockVideoFrameRepresentationArtifact>>();
+  ON_CALL(*vfr, audio_channel_pair_count()).WillByDefault(Return(0u));
+
+  orc::ObservationContext ctx;
+  std::vector<orc::ArtifactPtr> outputs;
+  ASSERT_NO_THROW(outputs = stage.execute(
+                      {vfr},
+                      {{"channel_pair", std::string("0")}, {"offset_ms", 40.0}},
+                      ctx));
+  ASSERT_EQ(outputs.size(), 1u);
+  EXPECT_EQ(outputs[0].get(), vfr.get());
 }
 
 TEST(AudioAlignStageTest, Execute_ZeroOffsetPassesInputThrough) {

--- a/orc-tests/core/unit/stages/audio_channel_map/audio_channel_map_stage_test.cpp
+++ b/orc-tests/core/unit/stages/audio_channel_map/audio_channel_map_stage_test.cpp
@@ -228,14 +228,34 @@ TEST(AudioChannelMapStageTest, Execute_ThrowsOnMissingInput) {
   EXPECT_THROW(stage.execute({}, {}, ctx), orc::DAGExecutionError);
 }
 
-TEST(AudioChannelMapStageTest, Execute_ThrowsWhenSourcePairOutOfRange) {
+TEST(AudioChannelMapStageTest, SourcePairOutOfRange_PassesInputThrough) {
+  // A pair the input does not carry must not fail the DAG: video (and the
+  // untouched audio) has to keep reaching downstream sinks and the preview.
+  orc::AudioChannelMapStage stage;
+  auto vfr = make_two_pair_source();
+  auto output = run(stage, vfr,
+                    {{"channel_pair", std::string("5")},
+                     {"operation", std::string("left_to_mono")}});
+
+  EXPECT_EQ(output.get(),
+            static_cast<const orc::VideoFrameRepresentation*>(vfr.get()));
+  EXPECT_EQ(output->audio_channel_pair_count(), 2u);
+  EXPECT_EQ(output->get_audio_samples(0, orc::FrameID(0)),
+            (std::vector<int32_t>{100000, 200000, -300000, 400000}));
+}
+
+TEST(AudioChannelMapStageTest, NoAudioPairs_PassesInputThrough) {
+  // The reported case: a TBC source carrying no audio at all.
   orc::AudioChannelMapStage stage;
   auto vfr = std::make_shared<NiceMock<MockVideoFrameRepresentationArtifact>>();
-  ON_CALL(*vfr, audio_channel_pair_count()).WillByDefault(Return(1u));
+  ON_CALL(*vfr, audio_channel_pair_count()).WillByDefault(Return(0u));
 
   orc::ObservationContext ctx;
-  EXPECT_THROW(stage.execute({vfr}, {{"channel_pair", std::string("1")}}, ctx),
-               orc::DAGExecutionError);
+  std::vector<orc::ArtifactPtr> outputs;
+  ASSERT_NO_THROW(outputs = stage.execute(
+                      {vfr}, {{"channel_pair", std::string("0")}}, ctx));
+  ASSERT_EQ(outputs.size(), 1u);
+  EXPECT_EQ(outputs[0].get(), static_cast<orc::Artifact*>(vfr.get()));
 }
 
 TEST(AudioChannelMapStageTest, LeftToMono_KeepsLeftAndSilencesRight) {
@@ -330,31 +350,34 @@ TEST(AudioChannelMapStageTest, CopyLeftToExistingTarget_OverwritesTargetOnly) {
   EXPECT_EQ(target->origin, orc::AudioOrigin::DERIVED);
 }
 
-TEST(AudioChannelMapStageTest, CopyToTarget_ThrowsWhenTargetOutOfRange) {
+TEST(AudioChannelMapStageTest, CopyToTarget_PassesThroughWhenTargetOutOfRange) {
   orc::AudioChannelMapStage stage;
   auto vfr = make_two_pair_source();
-  orc::ObservationContext ctx;
-  EXPECT_THROW(stage.execute({vfr},
-                             {{"channel_pair", std::string("0")},
-                              {"operation", std::string("copy_left_to_target")},
-                              {"target_pair", std::string("5")}},
-                             ctx),
-               orc::DAGExecutionError);
+  auto output = run(stage, vfr,
+                    {{"channel_pair", std::string("0")},
+                     {"operation", std::string("copy_left_to_target")},
+                     {"target_pair", std::string("5")}});
+
+  // Nothing is appended or overwritten; the input reaches the output as-is.
+  EXPECT_EQ(output->audio_channel_pair_count(), 2u);
+  EXPECT_EQ(output->get_audio_samples(1, orc::FrameID(0)),
+            (std::vector<int32_t>{5000, 6000, 7000, 8000}));
 }
 
-TEST(AudioChannelMapStageTest, CopyToNewTarget_ThrowsWhenPairCapExceeded) {
+TEST(AudioChannelMapStageTest,
+     CopyToNewTarget_PassesThroughWhenPairCapReached) {
   orc::AudioChannelMapStage stage;
   auto vfr = std::make_shared<NiceMock<MockVideoFrameRepresentationArtifact>>();
   ON_CALL(*vfr, audio_channel_pair_count())
       .WillByDefault(Return(orc::kMaxAudioChannelPairs));
 
-  orc::ObservationContext ctx;
-  EXPECT_THROW(stage.execute({vfr},
-                             {{"channel_pair", std::string("0")},
-                              {"operation", std::string("copy_left_to_target")},
-                              {"target_pair", std::string("new")}},
-                             ctx),
-               orc::DAGExecutionError);
+  auto output = run(stage, vfr,
+                    {{"channel_pair", std::string("0")},
+                     {"operation", std::string("copy_left_to_target")},
+                     {"target_pair", std::string("new")}});
+
+  // The cap still holds: no ninth pair appears.
+  EXPECT_EQ(output->audio_channel_pair_count(), orc::kMaxAudioChannelPairs);
 }
 
 TEST(AudioChannelMapStageTest, Delete_RemovesTargetAndShiftsLaterPairsDown) {

--- a/orc-tests/core/unit/stages/video_sink/audio_sample_feed_test.cpp
+++ b/orc-tests/core/unit/stages/video_sink/audio_sample_feed_test.cpp
@@ -1,16 +1,15 @@
 /*
  * File:        audio_sample_feed_test.cpp
  * Module:      orc-core-tests
- * Purpose:     Unit tests for the video sink's carrier-to-encoder sample
- *              conversions and gain application
+ * Purpose:     Unit tests for the SDK carrier-to-consumer sample conversions
+ *              and gain application
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2026 decode-orc contributors
  */
 
-#include "../../../../orc/plugins/stages/sinks/common/audio_sample_feed.h"
-
 #include <gtest/gtest.h>
+#include <orc/stage/audio/audio_sample_feed.h>
 
 namespace orc_unit_test {
 

--- a/orc-tests/gui/unit/CMakeLists.txt
+++ b/orc-tests/gui/unit/CMakeLists.txt
@@ -85,6 +85,7 @@ orc_add_gui_unit_tests(
         "unit;gui-logic"
         OFFSCREEN
         SOURCES
+            audio_channel_pair_notice_test.cpp
             field_frame_presentation_test.cpp
             frame_view_geometry_test.cpp
             framescopedialog_test.cpp
@@ -93,6 +94,7 @@ orc_add_gui_unit_tests(
             theme_manager_test.cpp
             node_type_helper_port_test.cpp
             observation_status_formatter_test.cpp
+            preview_audio_chase_test.cpp
             project_load_status_formatter_test.cpp
             quick_project_planner_test.cpp
             closed_caption_assembler_test.cpp
@@ -109,6 +111,7 @@ orc_add_gui_unit_tests(
     SOURCES
         gui_project_test.cpp
         orc_graph_model_test.cpp
+        preview_audio_controller_test.cpp
         render_coordinator_test.cpp
         plugin_discovery_model_test.cpp
 )
@@ -131,6 +134,7 @@ orc_add_gui_unit_tests(
         dropout_editor_dialog_test.cpp
         field_preview_crosshair_test.cpp
         preview_dialog_playback_test.cpp
+        preview_dialog_audio_test.cpp
         preview_dialog_observer_availability_test.cpp
         preview_dialog_subwindow_lifecycle_test.cpp
         theme_controller_test.cpp

--- a/orc-tests/gui/unit/audio_channel_pair_notice_test.cpp
+++ b/orc-tests/gui/unit/audio_channel_pair_notice_test.cpp
@@ -1,0 +1,54 @@
+/*
+ * File:        audio_channel_pair_notice_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Tier 1 (gui-logic) tests for the audio-stage "input carries no
+ *              channel pairs" dialog notice helper
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "audio_channel_pair_notice.h"
+
+#include <gtest/gtest.h>
+
+namespace orc::gui {
+namespace {
+
+TEST(AudioChannelPairNotice, InputWithPairsNeedsNoNotice) {
+  EXPECT_EQ(audioChannelPairNotice(1), "");
+  EXPECT_EQ(audioChannelPairNotice(8), "");
+}
+
+TEST(AudioChannelPairNotice, InputWithoutPairsExplainsPassThrough) {
+  const std::string note = audioChannelPairNotice(0);
+  EXPECT_NE(note.find("no audio channel pairs"), std::string::npos);
+  EXPECT_NE(note.find("pass its input through unchanged"), std::string::npos);
+}
+
+TEST(AudioChannelPairNotice, NoticeIsAppendedBelowTheStageDescription) {
+  EXPECT_EQ(withAudioChannelPairNotice("Route audio channel pairs", 2),
+            "Route audio channel pairs");
+
+  const std::string combined =
+      withAudioChannelPairNotice("Route audio channel pairs", 0);
+  EXPECT_EQ(combined.rfind("Route audio channel pairs\n\n", 0), 0u);
+  EXPECT_NE(combined.find(audioChannelPairNotice(0)), std::string::npos);
+}
+
+TEST(AudioChannelPairNotice, PreviewNoticeDescribesNothingToPlay) {
+  // The preview is not passing anything through, so it must not borrow the
+  // stage wording — it simply has no audio to offer.
+  const std::string note = audioChannelPairPreviewNotice();
+  EXPECT_NE(note.find("no audio channel pairs"), std::string::npos);
+  EXPECT_NE(note.find("nothing to play"), std::string::npos);
+  EXPECT_EQ(note.find("pass its input through unchanged"), std::string::npos);
+}
+
+TEST(AudioChannelPairNotice, EmptyDescriptionYieldsTheNoticeAlone) {
+  EXPECT_EQ(withAudioChannelPairNotice("", 0), audioChannelPairNotice(0));
+  EXPECT_EQ(withAudioChannelPairNotice("", 3), "");
+}
+
+}  // namespace
+}  // namespace orc::gui

--- a/orc-tests/gui/unit/dropout_editor_dialog_test.cpp
+++ b/orc-tests/gui/unit/dropout_editor_dialog_test.cpp
@@ -104,7 +104,8 @@ class FakeRenderPresenter : public orc::presenters::IRenderPresenter {
   orc::PreviewRenderResult renderPreview(orc::NodeID node_id,
                                          orc::PreviewOutputType output_type,
                                          uint64_t output_index,
-                                         const std::string&) override {
+                                         const std::string&,
+                                         orc::PreviewNavigationHint) override {
     orc::PreviewRenderResult result;
     result.node_id = node_id;
     result.output_type = output_type;
@@ -124,6 +125,13 @@ class FakeRenderPresenter : public orc::presenters::IRenderPresenter {
   }
 
   // Unused interface surface: inert stubs.
+  std::vector<orc::AudioPairView> getAudioChannelPairs(orc::NodeID) override {
+    return {};
+  }
+  std::shared_ptr<orc::presenters::IAudioStreamReader> createAudioStreamReader(
+      orc::NodeID, size_t) override {
+    return nullptr;
+  }
   std::optional<orc::presenters::DropoutDisplaySeries> getDropoutAnalysisData(
       orc::NodeID) override {
     return std::nullopt;

--- a/orc-tests/gui/unit/mocks/fake_audio_output.h
+++ b/orc-tests/gui/unit/mocks/fake_audio_output.h
@@ -1,0 +1,132 @@
+/*
+ * File:        fake_audio_output.h
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Scripted, device-free IAudioOutput for playback controller tests
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "audio_output.h"
+
+namespace orc::gui::test {
+
+/**
+ * @brief Simulated audio device: a fixed-depth queue the test drains by hand.
+ *
+ * Models exactly what the controller relies on — bounded free space, partial
+ * accepts, and a clock that only advances as queued audio is consumed — with
+ * no real device, no timers and no wall clock anywhere.
+ */
+class FakeAudioOutput final : public IAudioOutput {
+ public:
+  // Default depth is the 200 ms the Qt implementation asks for at 48 kHz.
+  explicit FakeAudioOutput(size_t capacity_pairs = 9600)
+      : capacity_pairs_(capacity_pairs) {}
+
+  bool start(uint32_t sample_rate_hz, uint32_t channels) override {
+    ++start_calls_;
+    requested_sample_rate_hz_ = sample_rate_hz;
+    requested_channels_ = channels;
+    if (!start_succeeds_) {
+      return false;
+    }
+    started_ = true;
+    queued_pairs_ = 0;
+    played_pairs_ = 0;
+    written_.clear();
+    return true;
+  }
+
+  void stop() override {
+    if (started_) {
+      ++stop_calls_;
+    }
+    started_ = false;
+    queued_pairs_ = 0;
+  }
+
+  size_t stereoPairsFree() const override {
+    return started_ ? capacity_pairs_ - queued_pairs_ : 0;
+  }
+
+  size_t write(const float* interleaved, size_t stereo_pairs) override {
+    if (!started_ || interleaved == nullptr) {
+      return 0;
+    }
+    const size_t accepted =
+        std::min(stereo_pairs, capacity_pairs_ - queued_pairs_);
+    written_.insert(written_.end(), interleaved, interleaved + accepted * 2);
+    queued_pairs_ += accepted;
+    return accepted;
+  }
+
+  uint64_t playedMicroseconds() const override {
+    if (requested_sample_rate_hz_ == 0) {
+      return 0;
+    }
+    // The earliest microsecond at which played_pairs_ have finished, i.e. the
+    // ceiling. Rounding down instead would make the caller's microseconds →
+    // pairs conversion report one pair fewer than has actually played at pair
+    // counts that are not a whole number of microseconds.
+    return (played_pairs_ * 1000000ULL + requested_sample_rate_hz_ - 1) /
+           requested_sample_rate_hz_;
+  }
+
+  void setVolume(double linear) override {
+    volume_ = linear;
+    volume_history_.push_back(linear);
+  }
+
+  // ---- Test drivers -------------------------------------------------------
+
+  /// Consume up to @p stereo_pairs of queued audio, advancing the clock.
+  void playPairs(uint64_t stereo_pairs) {
+    const uint64_t consumed = std::min<uint64_t>(stereo_pairs, queued_pairs_);
+    queued_pairs_ -= consumed;
+    played_pairs_ += consumed;
+  }
+
+  /// Consume everything queued — what a device does when nobody feeds it.
+  void playAllQueued() { playPairs(queued_pairs_); }
+
+  /// Make the next start() fail, as a machine with no usable device would.
+  void setStartSucceeds(bool succeeds) { start_succeeds_ = succeeds; }
+
+  // ---- Observations -------------------------------------------------------
+
+  bool isStarted() const { return started_; }
+  int startCalls() const { return start_calls_; }
+  int stopCalls() const { return stop_calls_; }
+  uint32_t requestedSampleRateHz() const { return requested_sample_rate_hz_; }
+  uint32_t requestedChannels() const { return requested_channels_; }
+  uint64_t queuedPairs() const { return queued_pairs_; }
+  uint64_t playedPairs() const { return played_pairs_; }
+  double volume() const { return volume_; }
+  const std::vector<double>& volumeHistory() const { return volume_history_; }
+  /// Every sample handed to the device since the last start(), interleaved.
+  const std::vector<float>& written() const { return written_; }
+  uint64_t writtenPairs() const { return written_.size() / 2; }
+
+ private:
+  size_t capacity_pairs_;
+  bool started_ = false;
+  bool start_succeeds_ = true;
+  int start_calls_ = 0;
+  int stop_calls_ = 0;
+  uint32_t requested_sample_rate_hz_ = 0;
+  uint32_t requested_channels_ = 0;
+  uint64_t queued_pairs_ = 0;
+  uint64_t played_pairs_ = 0;
+  double volume_ = 1.0;
+  std::vector<double> volume_history_;
+  std::vector<float> written_;
+};
+
+}  // namespace orc::gui::test

--- a/orc-tests/gui/unit/mocks/fake_audio_stream_reader.h
+++ b/orc-tests/gui/unit/mocks/fake_audio_stream_reader.h
@@ -1,0 +1,104 @@
+/*
+ * File:        fake_audio_stream_reader.h
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Cadence-accurate IAudioStreamReader stand-in for playback tests
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <audio_stream_reader.h>
+#include <orc/stage/audio/audio_channel_pair.h>  // audio_pair_offset
+#include <orc/stage/common_types.h>              // VideoSystem
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace orc::gui::test {
+
+/**
+ * @brief In-memory reader following the real SMPTE 272M-1994 §14.3 cadence.
+ *
+ * Uses the SDK's own audio_pair_offset()/audio_pairs_in_frame(), so the
+ * NTSC 1602/1601 sequence a controller test exercises is the pipeline's, not a
+ * test-local approximation. Every sample carries its absolute stereo-pair
+ * stream position, which lets a test assert that what reached the device is
+ * contiguous from the frame playback started at.
+ */
+class FakeAudioStreamReader final : public orc::presenters::IAudioStreamReader {
+ public:
+  FakeAudioStreamReader(orc::FrameIDRange range, orc::VideoSystem system)
+      : range_(range), system_(system) {}
+
+  void prime(
+      const orc::presenters::AudioPrimeProgressCallback& progress) override {
+    ++prime_calls_;
+    if (progress) {
+      progress(1, 1, "primed");
+    }
+  }
+
+  std::vector<float> readFrames(orc::FrameID first_frame,
+                                uint64_t frame_count) override {
+    read_requests_.emplace_back(first_frame, frame_count);
+
+    std::vector<float> out;
+    if (frame_count == 0 || range_.empty()) {
+      return out;
+    }
+    const orc::FrameID first = std::max(first_frame, range_.first);
+    if (first > range_.last || first_frame + frame_count <= first) {
+      return out;
+    }
+    const orc::FrameID last =
+        std::min(first_frame + frame_count - 1, range_.last);
+
+    const uint64_t begin = orc::audio_pair_offset(first, system_);
+    const uint64_t end = orc::audio_pair_offset(last + 1, system_);
+    out.reserve((end - begin) * 2);
+    for (uint64_t position = begin; position < end; ++position) {
+      out.push_back(static_cast<float>(position));  // Left
+      out.push_back(static_cast<float>(position));  // Right
+    }
+    return out;
+  }
+
+  uint64_t frameForPairPosition(uint64_t pair_position) const override {
+    if (range_.empty()) {
+      return 0;
+    }
+    // Estimate then correct, exactly as the presenter's reader does, so the
+    // NTSC cadence stays exact at every position.
+    uint64_t frame = 0;
+    while (orc::audio_pair_offset(frame + 1, system_) <= pair_position) {
+      ++frame;
+    }
+    return frame;
+  }
+
+  uint64_t pairPositionForFrame(orc::FrameID frame) const override {
+    return orc::audio_pair_offset(frame, system_);
+  }
+
+  orc::FrameIDRange frameRange() const override { return range_; }
+
+  // ---- Observations -------------------------------------------------------
+
+  int primeCalls() const { return prime_calls_; }
+  const std::vector<std::pair<orc::FrameID, uint64_t>>& readRequests() const {
+    return read_requests_;
+  }
+  void clearReadRequests() { read_requests_.clear(); }
+
+ private:
+  orc::FrameIDRange range_;
+  orc::VideoSystem system_;
+  int prime_calls_ = 0;
+  std::vector<std::pair<orc::FrameID, uint64_t>> read_requests_;
+};
+
+}  // namespace orc::gui::test

--- a/orc-tests/gui/unit/mocks/mock_render_presenter.h
+++ b/orc-tests/gui/unit/mocks/mock_render_presenter.h
@@ -191,7 +191,8 @@ class MockRenderPresenter : public IRenderPresenter {
 
   MOCK_METHOD(orc::PreviewRenderResult, renderPreview,
               (NodeID node_id, orc::PreviewOutputType output_type,
-               uint64_t output_index, const std::string& option_id),
+               uint64_t output_index, const std::string& option_id,
+               orc::PreviewNavigationHint hint),
               (override));
 
   MOCK_METHOD((std::optional<orc::presenters::DropoutDisplaySeries>),
@@ -202,6 +203,12 @@ class MockRenderPresenter : public IRenderPresenter {
               getBurstLevelAnalysisData, (NodeID node_id), (override));
   MOCK_METHOD((std::vector<orc::PreviewOutputInfo>), getAvailableOutputs,
               (NodeID node_id), (override));
+
+  MOCK_METHOD((std::vector<orc::AudioPairView>), getAudioChannelPairs,
+              (NodeID node_id), (override));
+  MOCK_METHOD((std::shared_ptr<orc::presenters::IAudioStreamReader>),
+              createAudioStreamReader, (NodeID node_id, size_t pair),
+              (override));
 
   MOCK_METHOD(LineSampleData, getLineSamplesWithYC,
               (NodeID node_id, orc::PreviewOutputType output_type,

--- a/orc-tests/gui/unit/preview_audio_chase_test.cpp
+++ b/orc-tests/gui/unit/preview_audio_chase_test.cpp
@@ -1,0 +1,128 @@
+/*
+ * File:        preview_audio_chase_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Tier 1 coverage of the preview audio clock arithmetic
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "preview_audio_chase.h"
+
+#include <gtest/gtest.h>
+#include <orc/stage/audio/audio_channel_pair.h>
+
+namespace {
+
+using namespace orc::gui::preview_audio;
+
+constexpr uint32_t kRate = orc::kAudioSampleRateHz;
+
+TEST(PreviewAudioChase, StereoPairsPlayed_IsZero_AtTheStartOfPlayback) {
+  EXPECT_EQ(stereoPairsPlayed(0, kRate), 0u);
+}
+
+TEST(PreviewAudioChase, StereoPairsPlayed_MatchesSampleRate_AfterOneSecond) {
+  EXPECT_EQ(stereoPairsPlayed(1000000, kRate), 48000u);
+}
+
+TEST(PreviewAudioChase, StereoPairsPlayed_MatchesPalFrame_AfterFortyMs) {
+  // ITU-R BT.1700 Annex 1 Part B (625-line PAL): 1920 stereo pairs per frame.
+  EXPECT_EQ(stereoPairsPlayed(40000, kRate), 1920u);
+}
+
+TEST(PreviewAudioChase, StereoPairsPlayed_TruncatesToTheLastCompletedPair) {
+  // 20 us is 0.96 of a pair: nothing has finished playing yet.
+  EXPECT_EQ(stereoPairsPlayed(20, kRate), 0u);
+  EXPECT_EQ(stereoPairsPlayed(21, kRate), 1u);
+}
+
+TEST(PreviewAudioChase, StereoPairsPlayed_StaysExact_OverAFeatureLengthRun) {
+  // Three hours of audio must not overflow or lose a pair.
+  constexpr uint64_t kThreeHoursUs = 3ULL * 60 * 60 * 1000000ULL;
+  EXPECT_EQ(stereoPairsPlayed(kThreeHoursUs, kRate), 3ULL * 60 * 60 * kRate);
+}
+
+TEST(PreviewAudioChase, MicrosecondsForStereoPairs_InvertsPlayedPairs) {
+  EXPECT_EQ(microsecondsForStereoPairs(1920, kRate), 40000u);
+  EXPECT_EQ(microsecondsForStereoPairs(kRate, kRate), 1000000u);
+}
+
+TEST(PreviewAudioChase, MicrosecondsForStereoPairs_IsZero_ForAZeroSampleRate) {
+  EXPECT_EQ(microsecondsForStereoPairs(1920, 0), 0u);
+}
+
+TEST(PreviewAudioChase, StereoPairsForMilliseconds_MatchesTheFeedLead) {
+  EXPECT_EQ(stereoPairsForMilliseconds(kFeedLeadMs, kRate), 24000u);
+  EXPECT_EQ(stereoPairsForMilliseconds(0, kRate), 0u);
+}
+
+TEST(PreviewAudioChase,
+     PreviewIndexForFrame_IsTheFrame_ForFrameIndexedOutputs) {
+  EXPECT_EQ(previewIndexForFrame(0, 1), 0u);
+  EXPECT_EQ(previewIndexForFrame(7, 1), 7u);
+}
+
+TEST(PreviewAudioChase,
+     PreviewIndexForFrame_SelectsTheFirstField_ForFieldIndexedOutputs) {
+  // Audio for a frame starts with its first field, so the chase must land
+  // there rather than half a frame ahead on the second.
+  EXPECT_EQ(previewIndexForFrame(0, 2), 0u);
+  EXPECT_EQ(previewIndexForFrame(7, 2), 14u);
+}
+
+TEST(PreviewAudioChase, PreviewIndexForFrame_TreatsZeroItemsPerFrameAsOne) {
+  EXPECT_EQ(previewIndexForFrame(7, 0), 7u);
+}
+
+TEST(PreviewAudioChase, FrameForPreviewIndex_MapsBothFieldsToTheSameFrame) {
+  EXPECT_EQ(frameForPreviewIndex(14, 2), 7u);
+  EXPECT_EQ(frameForPreviewIndex(15, 2), 7u);
+  EXPECT_EQ(frameForPreviewIndex(16, 2), 8u);
+}
+
+TEST(PreviewAudioChase, FrameForPreviewIndex_InvertsPreviewIndexForFrame) {
+  for (uint32_t items : {1u, 2u}) {
+    for (uint64_t frame = 0; frame < 50; ++frame) {
+      EXPECT_EQ(frameForPreviewIndex(previewIndexForFrame(frame, items), items),
+                frame)
+          << "items_per_frame=" << items << " frame=" << frame;
+    }
+  }
+}
+
+TEST(PreviewAudioChase, FrameForPreviewIndex_TreatsZeroItemsPerFrameAsOne) {
+  EXPECT_EQ(frameForPreviewIndex(7, 0), 7u);
+}
+
+TEST(PreviewAudioChase, ItemsPerFrame_IsTwoForFieldIndexedOutputs) {
+  // A field-indexed output steps a field per preview index, so one frame's
+  // audio spans two of them.
+  EXPECT_EQ(itemsPerFrameForOutputType(orc::PreviewOutputType::Frame_Field1),
+            2u);
+  EXPECT_EQ(itemsPerFrameForOutputType(orc::PreviewOutputType::Frame_Field2),
+            2u);
+  EXPECT_EQ(itemsPerFrameForOutputType(orc::PreviewOutputType::Luma), 2u);
+}
+
+TEST(PreviewAudioChase, ItemsPerFrame_IsOneForFrameIndexedOutputs) {
+  EXPECT_EQ(
+      itemsPerFrameForOutputType(orc::PreviewOutputType::Frame_Field1_First),
+      1u);
+  EXPECT_EQ(itemsPerFrameForOutputType(orc::PreviewOutputType::Frame_Reversed),
+            1u);
+  EXPECT_EQ(itemsPerFrameForOutputType(orc::PreviewOutputType::Split), 1u);
+  EXPECT_EQ(itemsPerFrameForOutputType(orc::PreviewOutputType::Chroma), 1u);
+  EXPECT_EQ(itemsPerFrameForOutputType(orc::PreviewOutputType::Composite), 1u);
+}
+
+TEST(PreviewAudioChase, FeedChunk_IsShorterThanTheFeedLead) {
+  // A chunk read must be small next to the lead, otherwise a single read
+  // decides whether the device starves.
+  const uint64_t chunk_pairs_pal = kFeedChunkFrames * 1920;
+  EXPECT_LT(chunk_pairs_pal, stereoPairsForMilliseconds(kFeedLeadMs, kRate));
+  EXPECT_GT(microsecondsForStereoPairs(chunk_pairs_pal, kRate),
+            kFeedIntervalMs * 1000ULL);
+}
+
+}  // namespace

--- a/orc-tests/gui/unit/preview_audio_controller_test.cpp
+++ b/orc-tests/gui/unit/preview_audio_controller_test.cpp
@@ -1,0 +1,510 @@
+/*
+ * File:        preview_audio_controller_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Tier 2 coverage of the audio-mastered preview playback session
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "preview_audio_controller.h"
+
+#include <gtest/gtest.h>
+#include <orc/stage/audio/audio_channel_pair.h>
+
+#include <QSignalSpy>
+#include <memory>
+
+#include "mocks/fake_audio_output.h"
+#include "mocks/fake_audio_stream_reader.h"
+#include "preview_audio_chase.h"
+
+namespace {
+
+using orc::gui::PreviewAudioController;
+using orc::gui::preview_audio::kFeedChunkFrames;
+using orc::gui::test::FakeAudioOutput;
+using orc::gui::test::FakeAudioStreamReader;
+
+constexpr uint32_t kRate = orc::kAudioSampleRateHz;
+constexpr uint64_t kPalPairsPerFrame = 1920;
+
+// A range long enough that the feeder never reaches the end mid-test.
+constexpr orc::FrameIDRange kLongRange{0, 999};
+
+class PreviewAudioControllerTest : public ::testing::Test {
+ protected:
+  void build(orc::FrameIDRange range = kLongRange,
+             orc::VideoSystem system = orc::VideoSystem::PAL,
+             size_t device_capacity_pairs = 9600) {
+    controller_ = std::make_unique<PreviewAudioController>();
+    auto output = std::make_unique<FakeAudioOutput>(device_capacity_pairs);
+    output_ = output.get();
+    controller_->setAudioOutput(std::move(output));
+    reader_ = std::make_shared<FakeAudioStreamReader>(range, system);
+    controller_->setReader(reader_);
+  }
+
+  // Play |pairs| of queued audio, topping the device back up as a running
+  // feed timer would. Mirrors steady-state playback.
+  void playPairsWithFeed(uint64_t pairs) {
+    constexpr uint64_t kStep = 480;  // 10 ms
+    for (uint64_t done = 0; done < pairs; done += kStep) {
+      output_->playPairs(std::min(kStep, pairs - done));
+      controller_->feed();
+    }
+  }
+
+  std::unique_ptr<PreviewAudioController> controller_;
+  FakeAudioOutput* output_ = nullptr;
+  std::shared_ptr<FakeAudioStreamReader> reader_;
+};
+
+// ---------------------------------------------------------------------------
+// Session start
+// ---------------------------------------------------------------------------
+
+TEST_F(PreviewAudioControllerTest, Start_Fails_WhenNoAudioOutputIsInstalled) {
+  PreviewAudioController controller;
+  controller.setReader(std::make_shared<FakeAudioStreamReader>(
+      kLongRange, orc::VideoSystem::PAL));
+
+  EXPECT_FALSE(controller.hasAudioOutput());
+  EXPECT_FALSE(controller.start(0));
+  EXPECT_FALSE(controller.isPlaying());
+}
+
+TEST_F(PreviewAudioControllerTest, Start_Fails_WhenNoReaderIsInstalled) {
+  PreviewAudioController controller;
+  controller.setAudioOutput(std::make_unique<FakeAudioOutput>());
+
+  EXPECT_FALSE(controller.hasReader());
+  EXPECT_FALSE(controller.start(0));
+  EXPECT_FALSE(controller.isPlaying());
+}
+
+TEST_F(PreviewAudioControllerTest, Start_Fails_WhenTheFrameIsOutsideTheRange) {
+  build(orc::FrameIDRange{10, 20});
+
+  EXPECT_FALSE(controller_->start(9));
+  EXPECT_FALSE(controller_->start(21));
+  EXPECT_EQ(output_->startCalls(), 0);
+  EXPECT_TRUE(controller_->start(10));
+}
+
+TEST_F(PreviewAudioControllerTest, Start_Fails_WhenTheDeviceRefusesToOpen) {
+  build();
+  output_->setStartSucceeds(false);
+
+  EXPECT_FALSE(controller_->start(0));
+  EXPECT_FALSE(controller_->isPlaying());
+}
+
+TEST_F(PreviewAudioControllerTest,
+       Start_OpensTheDeviceAtTheStereoPipelineFormat) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+
+  EXPECT_TRUE(output_->isStarted());
+  EXPECT_EQ(output_->requestedSampleRateHz(), kRate);
+  EXPECT_EQ(output_->requestedChannels(), 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Feeding
+// ---------------------------------------------------------------------------
+
+TEST_F(PreviewAudioControllerTest, Start_FillsTheDeviceBeforeTheFirstTick) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+
+  // Playback must begin immediately, not one feed interval later.
+  EXPECT_EQ(output_->queuedPairs(), 9600u);
+}
+
+TEST_F(PreviewAudioControllerTest,
+       Feed_ReadsNoFurtherAhead_ThanOneChunkPastAFullDevice) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+  const uint64_t after_start = output_->writtenPairs();
+
+  controller_->feed();
+  controller_->feed();
+
+  // Nothing has played, so the device is still full: the feeder must not have
+  // read more of the stream into its own buffer.
+  EXPECT_EQ(output_->writtenPairs(), after_start);
+  EXPECT_EQ(output_->queuedPairs(), 9600u);
+}
+
+TEST_F(PreviewAudioControllerTest, Feed_TopsTheDeviceBackUp_AsAudioPlays) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+
+  output_->playPairs(4800);
+  ASSERT_EQ(output_->queuedPairs(), 4800u);
+  controller_->feed();
+
+  EXPECT_EQ(output_->queuedPairs(), 9600u);
+}
+
+TEST_F(PreviewAudioControllerTest, Feed_ReadsInChunks_FromTheStartFrame) {
+  build();
+  reader_->clearReadRequests();
+  ASSERT_TRUE(controller_->start(4));
+
+  ASSERT_FALSE(reader_->readRequests().empty());
+  EXPECT_EQ(reader_->readRequests().front().first, 4u);
+  for (const auto& request : reader_->readRequests()) {
+    EXPECT_EQ(request.second, kFeedChunkFrames);
+  }
+}
+
+TEST_F(PreviewAudioControllerTest,
+       Feed_DeliversAContiguousStream_FromTheStartFrame) {
+  build();
+  ASSERT_TRUE(controller_->start(3));
+  playPairsWithFeed(5 * kPalPairsPerFrame);
+
+  // Every fake sample carries its absolute stream position, so a gap or a
+  // repeat anywhere in the feed path shows up here.
+  const auto& written = output_->written();
+  ASSERT_GT(written.size(), 0u);
+  const uint64_t first_position = reader_->pairPositionForFrame(3);
+  for (size_t pair = 0; pair < written.size() / 2; ++pair) {
+    ASSERT_FLOAT_EQ(written[pair * 2],
+                    static_cast<float>(first_position + pair))
+        << "at pair " << pair;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Video chase
+// ---------------------------------------------------------------------------
+
+TEST_F(PreviewAudioControllerTest, TargetFrame_IsTheStartFrame_BeforeAnyAudio) {
+  build();
+  ASSERT_TRUE(controller_->start(12));
+
+  EXPECT_EQ(controller_->targetFrame(), 12u);
+  EXPECT_EQ(controller_->targetPreviewIndex(), 12u);
+}
+
+TEST_F(PreviewAudioControllerTest, TargetFrame_IsTheStartFrame_WhenStopped) {
+  build();
+  ASSERT_TRUE(controller_->start(12));
+  playPairsWithFeed(3 * kPalPairsPerFrame);
+  controller_->stop();
+
+  EXPECT_EQ(controller_->targetFrame(), 12u);
+}
+
+TEST_F(PreviewAudioControllerTest, TargetFrame_FollowsThePalCadence) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+
+  for (uint64_t frame = 0; frame < 6; ++frame) {
+    EXPECT_EQ(controller_->targetFrame(), frame);
+    playPairsWithFeed(kPalPairsPerFrame);
+  }
+  EXPECT_EQ(controller_->targetFrame(), 6u);
+}
+
+TEST_F(PreviewAudioControllerTest, TargetFrame_FollowsTheNtscFiveFrameCadence) {
+  build(kLongRange, orc::VideoSystem::NTSC);
+  ASSERT_TRUE(controller_->start(0));
+
+  // SMPTE 272M-1994 §14.3 Table 1: 1602/1601/1602/1601/1602 over five frames.
+  const uint64_t kSequence[] = {1602, 1601, 1602, 1601, 1602};
+  for (uint64_t frame = 0; frame < 10; ++frame) {
+    EXPECT_EQ(controller_->targetFrame(), frame) << "frame " << frame;
+    playPairsWithFeed(kSequence[frame % 5]);
+  }
+  EXPECT_EQ(controller_->targetFrame(), 10u);
+}
+
+TEST_F(PreviewAudioControllerTest,
+       TargetFrame_StaysOnAFrame_UntilItsLastPairHasPlayed) {
+  build(kLongRange, orc::VideoSystem::NTSC);
+  ASSERT_TRUE(controller_->start(0));
+
+  // One pair short of the frame boundary must still show frame 0.
+  playPairsWithFeed(1601);
+  EXPECT_EQ(controller_->targetFrame(), 0u);
+  playPairsWithFeed(1);
+  EXPECT_EQ(controller_->targetFrame(), 1u);
+}
+
+TEST_F(PreviewAudioControllerTest,
+       TargetPreviewIndex_AdvancesTwoPerFrame_ForFieldIndexedOutputs) {
+  build();
+  controller_->setItemsPerFrame(2);
+  ASSERT_TRUE(controller_->start(5));
+
+  EXPECT_EQ(controller_->targetPreviewIndex(), 10u);
+  playPairsWithFeed(3 * kPalPairsPerFrame);
+  EXPECT_EQ(controller_->targetFrame(), 8u);
+  EXPECT_EQ(controller_->targetPreviewIndex(), 16u);
+}
+
+TEST_F(PreviewAudioControllerTest, TargetFrame_IsClampedToTheReaderRange) {
+  build(orc::FrameIDRange{0, 2});
+  ASSERT_TRUE(controller_->start(0));
+
+  // Play well past the end of the material.
+  playPairsWithFeed(10 * kPalPairsPerFrame);
+  EXPECT_LE(controller_->targetFrame(), 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Seek
+// ---------------------------------------------------------------------------
+
+TEST_F(PreviewAudioControllerTest, Seek_RestartsTheDevice_WhilePlaying) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+  playPairsWithFeed(2 * kPalPairsPerFrame);
+  ASSERT_EQ(output_->startCalls(), 1);
+
+  controller_->seek(40);
+
+  EXPECT_TRUE(controller_->isPlaying());
+  EXPECT_EQ(output_->startCalls(), 2);
+  EXPECT_GE(output_->stopCalls(), 1);
+  EXPECT_EQ(controller_->startFrame(), 40u);
+  EXPECT_EQ(controller_->targetFrame(), 40u);
+}
+
+TEST_F(PreviewAudioControllerTest, Seek_RebasesTheClock_SoTheChaseResumes) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+  playPairsWithFeed(2 * kPalPairsPerFrame);
+
+  controller_->seek(40);
+  playPairsWithFeed(3 * kPalPairsPerFrame);
+
+  EXPECT_EQ(controller_->targetFrame(), 43u);
+}
+
+TEST_F(PreviewAudioControllerTest, Seek_OnlyRecordsThePosition_WhenNotPlaying) {
+  build();
+
+  controller_->seek(40);
+
+  EXPECT_FALSE(controller_->isPlaying());
+  EXPECT_EQ(output_->startCalls(), 0);
+  EXPECT_EQ(controller_->startFrame(), 40u);
+  EXPECT_EQ(controller_->targetFrame(), 40u);
+}
+
+// ---------------------------------------------------------------------------
+// Drain and underrun
+// ---------------------------------------------------------------------------
+
+TEST_F(PreviewAudioControllerTest, Feed_ReportsFinished_WhenTheRangeDrains) {
+  build(orc::FrameIDRange{0, 1});
+  QSignalSpy finished(controller_.get(), &PreviewAudioController::finished);
+  ASSERT_TRUE(controller_->start(0));
+
+  // Two PAL frames fit in the device buffer, so one drain ends the session.
+  output_->playAllQueued();
+  controller_->feed();
+
+  EXPECT_EQ(finished.count(), 1);
+  EXPECT_FALSE(controller_->isPlaying());
+  EXPECT_FALSE(output_->isStarted());
+}
+
+TEST_F(PreviewAudioControllerTest,
+       Feed_DoesNotReportFinished_WhileFramesRemain) {
+  build(orc::FrameIDRange{0, 199});
+  QSignalSpy finished(controller_.get(), &PreviewAudioController::finished);
+  ASSERT_TRUE(controller_->start(0));
+
+  output_->playAllQueued();
+  controller_->feed();
+
+  EXPECT_EQ(finished.count(), 0);
+  EXPECT_TRUE(controller_->isPlaying());
+}
+
+TEST_F(PreviewAudioControllerTest,
+       Feed_ReportsAnUnderrun_WhenTheDeviceRunsDryMidStream) {
+  build(orc::FrameIDRange{0, 199});
+  QSignalSpy underrun(controller_.get(),
+                      &PreviewAudioController::underrunDetected);
+  ASSERT_TRUE(controller_->start(0));
+
+  output_->playAllQueued();
+  controller_->feed();
+
+  EXPECT_EQ(underrun.count(), 1);
+  EXPECT_EQ(controller_->underrunCount(), 1u);
+}
+
+TEST_F(PreviewAudioControllerTest, Feed_RefillsAndResumes_AfterAnUnderrun) {
+  build(orc::FrameIDRange{0, 199});
+  ASSERT_TRUE(controller_->start(0));
+  const uint64_t starved_target = 9600 / kPalPairsPerFrame;
+
+  output_->playAllQueued();
+  controller_->feed();
+  // The clock stalls with the device, so the chase stalls rather than drifts.
+  EXPECT_EQ(controller_->targetFrame(), starved_target);
+  EXPECT_GT(output_->queuedPairs(), 0u);
+
+  // The stream stays contiguous across the gap, so the chase picks up exactly
+  // where it stopped.
+  playPairsWithFeed(2 * kPalPairsPerFrame);
+  EXPECT_EQ(controller_->targetFrame(), starved_target + 2);
+  EXPECT_EQ(controller_->underrunCount(), 1u);
+}
+
+TEST_F(PreviewAudioControllerTest,
+       Feed_ReportsAnUnderrun_OncePerStarvationNotPerTick) {
+  build(orc::FrameIDRange{0, 199});
+  QSignalSpy underrun(controller_.get(),
+                      &PreviewAudioController::underrunDetected);
+  ASSERT_TRUE(controller_->start(0));
+
+  output_->playAllQueued();
+  controller_->feed();
+  ASSERT_EQ(underrun.count(), 1);
+
+  // Ticks where the device kept up must stay silent.
+  output_->playPairs(480);
+  controller_->feed();
+  output_->playPairs(480);
+  controller_->feed();
+  EXPECT_EQ(underrun.count(), 1);
+
+  // A fresh starvation is reported again.
+  output_->playAllQueued();
+  controller_->feed();
+  EXPECT_EQ(underrun.count(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Invalidation
+// ---------------------------------------------------------------------------
+
+TEST_F(PreviewAudioControllerTest, Stop_ClosesTheDevice_AndKeepsTheReader) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+
+  controller_->stop();
+
+  EXPECT_FALSE(controller_->isPlaying());
+  EXPECT_FALSE(output_->isStarted());
+  EXPECT_TRUE(controller_->hasReader());
+}
+
+TEST_F(PreviewAudioControllerTest, SetReader_StopsPlayback_OnANodeOrDagChange) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+
+  controller_->setReader(std::make_shared<FakeAudioStreamReader>(
+      kLongRange, orc::VideoSystem::PAL));
+
+  EXPECT_FALSE(controller_->isPlaying());
+  EXPECT_FALSE(output_->isStarted());
+}
+
+TEST_F(PreviewAudioControllerTest,
+       SetReader_ClearsPlayback_WhenTheAudioGoesAway) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+
+  controller_->setReader(nullptr);
+
+  EXPECT_FALSE(controller_->isPlaying());
+  EXPECT_FALSE(controller_->hasReader());
+  EXPECT_FALSE(controller_->start(0));
+}
+
+TEST_F(PreviewAudioControllerTest,
+       SetReader_ClampsTheStartFrame_ToTheNewRange) {
+  build();
+  ASSERT_TRUE(controller_->start(500));
+  controller_->stop();
+
+  controller_->setReader(std::make_shared<FakeAudioStreamReader>(
+      orc::FrameIDRange{0, 9}, orc::VideoSystem::PAL));
+
+  EXPECT_EQ(controller_->startFrame(), 0u);
+}
+
+TEST_F(PreviewAudioControllerTest, SetAudioOutput_StopsPlayback) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+  FakeAudioOutput* previous = output_;
+
+  controller_->setAudioOutput(std::make_unique<FakeAudioOutput>());
+
+  EXPECT_FALSE(controller_->isPlaying());
+  EXPECT_EQ(previous->stopCalls(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Volume and mute
+// ---------------------------------------------------------------------------
+
+TEST_F(PreviewAudioControllerTest, SetVolume_ForwardsASquaredTaper) {
+  build();
+
+  controller_->setVolume(0.5);
+
+  EXPECT_DOUBLE_EQ(controller_->volume(), 0.5);
+  EXPECT_DOUBLE_EQ(output_->volume(), 0.25);
+}
+
+TEST_F(PreviewAudioControllerTest, SetVolume_ClampsToTheControlRange) {
+  build();
+
+  controller_->setVolume(1.5);
+  EXPECT_DOUBLE_EQ(controller_->volume(), 1.0);
+  EXPECT_DOUBLE_EQ(output_->volume(), 1.0);
+
+  controller_->setVolume(-0.5);
+  EXPECT_DOUBLE_EQ(controller_->volume(), 0.0);
+  EXPECT_DOUBLE_EQ(output_->volume(), 0.0);
+}
+
+TEST_F(PreviewAudioControllerTest,
+       SetMuted_SilencesTheDevice_AndUnmuteRestores) {
+  build();
+  controller_->setVolume(0.5);
+
+  controller_->setMuted(true);
+  EXPECT_TRUE(controller_->isMuted());
+  EXPECT_DOUBLE_EQ(output_->volume(), 0.0);
+
+  controller_->setMuted(false);
+  EXPECT_FALSE(controller_->isMuted());
+  EXPECT_DOUBLE_EQ(output_->volume(), 0.25);
+}
+
+TEST_F(PreviewAudioControllerTest, SetMuted_LeavesTheClockAndChaseRunning) {
+  build();
+  ASSERT_TRUE(controller_->start(0));
+  controller_->setMuted(true);
+
+  playPairsWithFeed(3 * kPalPairsPerFrame);
+
+  EXPECT_TRUE(controller_->isPlaying());
+  EXPECT_EQ(controller_->targetFrame(), 3u);
+}
+
+TEST_F(PreviewAudioControllerTest, Volume_IsRetainedAcrossSessions) {
+  build();
+  controller_->setVolume(0.5);
+  controller_->setMuted(true);
+
+  ASSERT_TRUE(controller_->start(0));
+
+  EXPECT_DOUBLE_EQ(output_->volume(), 0.0);
+  controller_->setMuted(false);
+  EXPECT_DOUBLE_EQ(output_->volume(), 0.25);
+}
+
+}  // namespace

--- a/orc-tests/gui/unit/preview_dialog_audio_test.cpp
+++ b/orc-tests/gui/unit/preview_dialog_audio_test.cpp
@@ -1,0 +1,536 @@
+/*
+ * File:        preview_dialog_audio_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Audio selector, volume wiring and audio-clocked playback tests
+ *              for the preview dialog
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include <gtest/gtest.h>
+#include <orc/stage/audio/audio_channel_pair.h>  // audio_pairs_in_frame
+#include <orc/stage/common_types.h>              // VideoSystem
+
+#include <QApplication>
+#include <QComboBox>
+#include <QCoreApplication>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QSlider>
+#include <QThread>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "mocks/fake_audio_output.h"
+#include "mocks/fake_audio_stream_reader.h"
+#include "previewdialog.h"
+
+namespace gui_unit_test {
+
+namespace {
+
+QApplication& ensureApplication() {
+  if (auto* existing_app =
+          qobject_cast<QApplication*>(QCoreApplication::instance())) {
+    return *existing_app;
+  }
+
+  static int argc = 3;
+  static char app_name[] = "orc-gui-widget-test";
+  static char platform_opt[] = "-platform";
+  static char platform_val[] = "offscreen";
+  static char* argv[] = {app_name, platform_opt, platform_val, nullptr};
+  static QApplication* app = [] {
+    auto* created_app = new QApplication(argc, argv);
+    created_app->setQuitOnLastWindowClosed(false);
+    return created_app;
+  }();
+  return *app;
+}
+
+constexpr int kFirstIndex = 0;
+constexpr int kLastIndex = 99;
+
+// Priming runs on its own thread and the chase runs off the dialogue's
+// playback timer, so the test drives the event loop until the condition holds
+// rather than assuming either has completed.
+bool waitFor(const std::function<bool()>& condition, int timeout_ms = 2000) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    QCoreApplication::processEvents();
+    if (condition()) {
+      return true;
+    }
+    QThread::msleep(2);
+  }
+  return condition();
+}
+
+std::vector<orc::AudioPairView> twoPairs() {
+  return {orc::AudioPairView{0, "Analogue", "analogue"},
+          orc::AudioPairView{1, "EFM digital audio", "efm"}};
+}
+
+// Installs a device-free output and returns a borrowed pointer to it.
+orc::gui::test::FakeAudioOutput* installFakeOutput(PreviewDialog& dialog) {
+  auto output = std::make_unique<orc::gui::test::FakeAudioOutput>();
+  auto* borrowed = output.get();
+  dialog.setAudioOutput(std::move(output));
+  return borrowed;
+}
+
+std::shared_ptr<orc::gui::test::FakeAudioStreamReader> palReader() {
+  return std::make_shared<orc::gui::test::FakeAudioStreamReader>(
+      orc::FrameIDRange{static_cast<orc::FrameID>(kFirstIndex),
+                        static_cast<orc::FrameID>(kLastIndex)},
+      orc::VideoSystem::PAL);
+}
+
+// Play with the given pair selected and run through reader delivery and
+// priming until the audio clock is driving the preview.
+bool startAudioPlayback(PreviewDialog& dialog, int combo_index) {
+  dialog.audioPairCombo()->setCurrentIndex(combo_index);
+  dialog.playPauseButton()->click();
+  dialog.setAudioStreamReader(palReader());
+  return waitFor([&dialog]() { return dialog.isAudioPlaybackActive(); });
+}
+
+}  // namespace
+
+// --- Selector population and enable states ---------------------------------
+
+TEST(PreviewDialogAudio, NoPairs_DisablesSelectorAndVolume) {
+  ensureApplication();
+  PreviewDialog dialog;
+
+  dialog.setAudioChannelPairs({});
+
+  EXPECT_EQ(dialog.audioPairCombo()->count(), 1);
+  EXPECT_EQ(dialog.audioPairCombo()->currentText(), QString("Mute/None"));
+  EXPECT_FALSE(dialog.audioPairCombo()->isEnabled());
+  EXPECT_FALSE(dialog.audioVolumeSlider()->isEnabled());
+  // The advisory text explains that the absence is a property of the pipeline.
+  EXPECT_FALSE(dialog.audioPairCombo()->toolTip().isEmpty());
+}
+
+TEST(PreviewDialogAudio, PairsAvailable_PopulateSelectorAndDefaultToNoAudio) {
+  ensureApplication();
+  PreviewDialog dialog;
+
+  dialog.setAudioChannelPairs(twoPairs());
+
+  ASSERT_EQ(dialog.audioPairCombo()->count(), 3);
+  EXPECT_EQ(dialog.audioPairCombo()->itemText(0), QString("Mute/None"));
+  EXPECT_EQ(dialog.audioPairCombo()->itemText(1), QString("0: Analogue"));
+  EXPECT_EQ(dialog.audioPairCombo()->itemText(2),
+            QString("1: EFM digital audio"));
+  EXPECT_TRUE(dialog.audioPairCombo()->isEnabled());
+
+  // Pair indices are node-specific, so nothing is selected until the user says
+  // so — and volume stays disabled with "Mute/None" selected.
+  EXPECT_EQ(dialog.audioPairCombo()->currentIndex(), 0);
+  EXPECT_FALSE(dialog.selectedAudioPair().has_value());
+  EXPECT_FALSE(dialog.audioVolumeSlider()->isEnabled());
+}
+
+TEST(PreviewDialogAudio, SelectingAPair_EnablesVolumeWhilePaused) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.setAudioChannelPairs(twoPairs());
+
+  dialog.audioPairCombo()->setCurrentIndex(2);
+
+  ASSERT_TRUE(dialog.selectedAudioPair().has_value());
+  EXPECT_EQ(*dialog.selectedAudioPair(), 1u);
+  EXPECT_TRUE(dialog.audioVolumeSlider()->isEnabled());
+}
+
+TEST(PreviewDialogAudio, NodeChange_ClearsSelectorBackToNoAudio) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.setCurrentNodeId(orc::NodeID(1));
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(1);
+
+  dialog.setCurrentNodeId(orc::NodeID(2));
+
+  EXPECT_EQ(dialog.audioPairCombo()->count(), 1);
+  EXPECT_FALSE(dialog.selectedAudioPair().has_value());
+  EXPECT_FALSE(dialog.audioPairCombo()->isEnabled());
+}
+
+TEST(PreviewDialogAudio, NodeChange_ReselectsTheSamePairAtTheNewNode) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.setCurrentNodeId(orc::NodeID(1));
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(2);  // EFM digital audio
+
+  dialog.setCurrentNodeId(orc::NodeID(2));
+  dialog.setAudioChannelPairs(twoPairs());
+
+  // The pair the user chose carries through the pipeline, so stepping to the
+  // next stage keeps playing it rather than reverting to "Mute/None".
+  EXPECT_EQ(dialog.audioPairCombo()->currentIndex(), 2);
+  ASSERT_TRUE(dialog.selectedAudioPair().has_value());
+  EXPECT_EQ(*dialog.selectedAudioPair(), 1u);
+  EXPECT_TRUE(dialog.audioVolumeSlider()->isEnabled());
+}
+
+TEST(PreviewDialogAudio, NodeChange_MatchesTheDescriptorNotThePairIndex) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.setCurrentNodeId(orc::NodeID(1));
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(2);  // EFM digital audio, index 1
+
+  // A node that dropped the analogue pair renumbers what is left.
+  dialog.setCurrentNodeId(orc::NodeID(2));
+  dialog.setAudioChannelPairs(
+      {orc::AudioPairView{0, "EFM digital audio", "efm"}});
+
+  EXPECT_EQ(dialog.audioPairCombo()->currentIndex(), 1);
+  ASSERT_TRUE(dialog.selectedAudioPair().has_value());
+  EXPECT_EQ(*dialog.selectedAudioPair(), 0u);
+}
+
+TEST(PreviewDialogAudio, NodeWithoutThePair_FallsBackButKeepsTheChoice) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.setCurrentNodeId(orc::NodeID(1));
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(2);  // EFM digital audio
+
+  dialog.setCurrentNodeId(orc::NodeID(2));
+  dialog.setAudioChannelPairs({orc::AudioPairView{0, "Analogue", "analogue"}});
+
+  EXPECT_FALSE(dialog.selectedAudioPair().has_value());
+
+  // Stepping on to a node that does carry the pair restores it: passing a
+  // stage without audio must not lose the selection.
+  dialog.setCurrentNodeId(orc::NodeID(3));
+  dialog.setAudioChannelPairs(twoPairs());
+
+  ASSERT_TRUE(dialog.selectedAudioPair().has_value());
+  EXPECT_EQ(*dialog.selectedAudioPair(), 1u);
+}
+
+TEST(PreviewDialogAudio, ChoosingNoAudio_IsRememberedAcrossNodes) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.setCurrentNodeId(orc::NodeID(1));
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(1);
+  dialog.audioPairCombo()->setCurrentIndex(0);  // Back to "Mute/None"
+
+  dialog.setCurrentNodeId(orc::NodeID(2));
+  dialog.setAudioChannelPairs(twoPairs());
+
+  EXPECT_EQ(dialog.audioPairCombo()->currentIndex(), 0);
+  EXPECT_FALSE(dialog.selectedAudioPair().has_value());
+}
+
+// --- Volume wiring ---------------------------------------------------------
+
+TEST(PreviewDialogAudio, VolumeSlider_ForwardsSquaredTaperToTheDevice) {
+  ensureApplication();
+  PreviewDialog dialog;
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(1);
+
+  dialog.audioVolumeSlider()->setValue(50);
+
+  // A linear slider tracks perceived loudness better as an amplitude square.
+  EXPECT_DOUBLE_EQ(output->volume(), 0.25);
+  EXPECT_DOUBLE_EQ(dialog.audioController()->volume(), 0.5);
+}
+
+// --- Play button paths -----------------------------------------------------
+
+TEST(PreviewDialogAudio, PlayWithNoAudioSelected_KeepsTheVideoOnlyPath) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());  // Available but not selected
+
+  QSignalSpy reader_requested(&dialog,
+                              &PreviewDialog::audioStreamReaderRequested);
+  dialog.playPauseButton()->click();
+
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_EQ(reader_requested.count(), 0);
+  EXPECT_FALSE(output->isStarted());  // No device is opened
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, PlayWithPairSelected_RequestsAReaderBeforeStarting) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(2);
+
+  QSignalSpy reader_requested(&dialog,
+                              &PreviewDialog::audioStreamReaderRequested);
+  dialog.playPauseButton()->click();
+
+  ASSERT_EQ(reader_requested.count(), 1);
+  EXPECT_EQ(reader_requested.at(0).at(0).toULongLong(), 1u);
+  // The transport shows playback intent, but nothing runs until the reader
+  // arrives and its deferred decode has been forced.
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, ReaderDelivered_StartsAudioClockedPlayback) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  EXPECT_TRUE(output->isStarted());
+  EXPECT_EQ(output->requestedSampleRateHz(), orc::kAudioSampleRateHz);
+  EXPECT_EQ(output->requestedChannels(), 2u);
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+
+  dialog.stopPlayback();
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+}
+
+TEST(PreviewDialogAudio, NullReader_FallsBackToVideoOnlyPlayback) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  dialog.audioPairCombo()->setCurrentIndex(1);
+
+  dialog.playPauseButton()->click();
+  dialog.setAudioStreamReader(nullptr);
+
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+  // Playback continues — just without sound.
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, AudioClock_DrivesThePreviewPositionAndSkipsFrames) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+  ASSERT_EQ(dialog.currentIndex(), 0);
+
+  // Consume three PAL frames' worth of audio in one go — what a device does
+  // while a heavy DAG is still rendering frame 1.
+  const uint64_t three_frames =
+      orc::audio_pairs_in_frame(0, orc::VideoSystem::PAL) +
+      orc::audio_pairs_in_frame(1, orc::VideoSystem::PAL) +
+      orc::audio_pairs_in_frame(2, orc::VideoSystem::PAL);
+  output->playPairs(three_frames);
+
+  // The chase jumps straight to the frame the audio has reached; the frames
+  // in between are simply never shown.
+  EXPECT_TRUE(waitFor([&dialog]() { return dialog.currentIndex() == 3; }));
+
+  dialog.stopPlayback();
+}
+
+// --- Invalidation ----------------------------------------------------------
+
+TEST(PreviewDialogAudio, InvalidateAudioSource_StopsPlaybackAndDropsTheReader) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  dialog.invalidateAudioSource();
+
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("▶"));
+  EXPECT_FALSE(dialog.audioController()->hasReader());
+
+  // The dropped reader must be re-requested rather than silently reused.
+  QSignalSpy reader_requested(&dialog,
+                              &PreviewDialog::audioStreamReaderRequested);
+  dialog.playPauseButton()->click();
+  EXPECT_EQ(reader_requested.count(), 1);
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, ReselectingThePair_RequestsAReaderForTheNewPair) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  QSignalSpy reader_requested(&dialog,
+                              &PreviewDialog::audioStreamReaderRequested);
+  dialog.audioPairCombo()->setCurrentIndex(2);
+
+  // The old session is gone, but playback intent survives: the new pair's
+  // reader is asked for without the user pressing Play again.
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+  EXPECT_FALSE(dialog.audioController()->hasReader());
+  ASSERT_EQ(reader_requested.count(), 1);
+  EXPECT_EQ(reader_requested.at(0).at(0).toULongLong(), 1u);
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, ReselectingThePair_ResumesOnTheNewPairOncePrimed) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  // Move off frame 0 so the resume position is observable.
+  output->playPairs(orc::audio_pairs_in_frame(0, orc::VideoSystem::PAL) +
+                    orc::audio_pairs_in_frame(1, orc::VideoSystem::PAL));
+  ASSERT_TRUE(waitFor([&dialog]() { return dialog.currentIndex() == 2; }));
+
+  dialog.audioPairCombo()->setCurrentIndex(2);
+  dialog.setAudioStreamReader(palReader());
+  ASSERT_TRUE(waitFor([&dialog]() { return dialog.isAudioPlaybackActive(); }));
+
+  EXPECT_TRUE(output->isStarted());
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+  // Switching pair compares the same moment, so the position is kept.
+  EXPECT_EQ(dialog.currentIndex(), 2);
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, ReselectingNoAudioWhilePlaying_KeepsTheVideoRunning) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  QSignalSpy reader_requested(&dialog,
+                              &PreviewDialog::audioStreamReaderRequested);
+  dialog.audioPairCombo()->setCurrentIndex(0);  // "Mute/None"
+
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+  EXPECT_EQ(reader_requested.count(), 0);
+  // Playback continues — just without sound.
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, NodeChangeDuringPlayback_StopsPlayback) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  dialog.setCurrentNodeId(orc::NodeID(1));
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  dialog.setCurrentNodeId(orc::NodeID(2));
+
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("▶"));
+}
+
+TEST(PreviewDialogAudio, ClosingTheDialog_StopsAudioPlayback) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  dialog.close();
+
+  EXPECT_FALSE(dialog.isAudioPlaybackActive());
+  EXPECT_FALSE(output->isStarted());
+}
+
+// --- Seeking ---------------------------------------------------------------
+
+TEST(PreviewDialogAudio, UserSeekDuringPlayback_RebasesTheAudioClock) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+  const int starts_before_seek = output->startCalls();
+
+  dialog.navigateToIndex(40);
+
+  // The device is restarted from the new position, so the clock never has to
+  // carry a correction term across the seek.
+  EXPECT_EQ(dialog.audioController()->startFrame(), 40u);
+  EXPECT_GT(output->startCalls(), starts_before_seek);
+  EXPECT_TRUE(dialog.isAudioPlaybackActive());
+  EXPECT_EQ(dialog.currentIndex(), 40);
+
+  dialog.stopPlayback();
+}
+
+TEST(PreviewDialogAudio, ScrubbingSilencesTheDeviceUntilThePositionSettles) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  auto* output = installFakeOutput(dialog);
+  dialog.setAudioChannelPairs(twoPairs());
+  ASSERT_TRUE(startAudioPlayback(dialog, 1));
+
+  // A drag emits a position per mouse move. Rebasing the device on each one
+  // would thrash it, so it goes quiet for the duration of the scrub.
+  dialog.navigateToIndexDebounced(10);
+  dialog.navigateToIndexDebounced(20);
+  dialog.navigateToIndexDebounced(30);
+  EXPECT_FALSE(output->isStarted());
+  EXPECT_EQ(output->startCalls(), 1);
+  // Playback intent survives the scrub — this is a seek, not a stop.
+  EXPECT_TRUE(dialog.isAudioPlaybackActive());
+  EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("⏸"));
+
+  // Once the debounce settles the clock restarts at the settled position.
+  EXPECT_TRUE(waitFor([output]() { return output->isStarted(); }));
+  EXPECT_EQ(output->startCalls(), 2);
+  EXPECT_EQ(dialog.audioController()->startFrame(), 30u);
+
+  dialog.stopPlayback();
+}
+
+}  // namespace gui_unit_test

--- a/orc-tests/gui/unit/preview_dialog_playback_test.cpp
+++ b/orc-tests/gui/unit/preview_dialog_playback_test.cpp
@@ -89,4 +89,27 @@ TEST(PreviewDialogPlayback, PlayThenPause_TogglesWithoutMoving) {
   EXPECT_EQ(dialog.playPauseButton()->text(), QString::fromUtf8("▶"));
 }
 
+// The owner reads isPlaying() to decide between the Sequential and Random
+// navigation hints, so it has to track the transport exactly — including the
+// stop that the end of the range triggers.
+TEST(PreviewDialogPlayback, IsPlaying_TracksTheTransportState) {
+  ensureApplication();
+  PreviewDialog dialog;
+  dialog.previewSlider()->setRange(kFirstIndex, kLastIndex);
+  dialog.navigateToIndex(kFirstIndex);
+
+  EXPECT_FALSE(dialog.isPlaying());
+
+  dialog.playPauseButton()->click();
+  EXPECT_TRUE(dialog.isPlaying());
+
+  dialog.playPauseButton()->click();
+  EXPECT_FALSE(dialog.isPlaying());
+
+  dialog.playPauseButton()->click();
+  ASSERT_TRUE(dialog.isPlaying());
+  dialog.stopPlayback();
+  EXPECT_FALSE(dialog.isPlaying());
+}
+
 }  // namespace gui_unit_test

--- a/orc-tests/gui/unit/render_coordinator_test.cpp
+++ b/orc-tests/gui/unit/render_coordinator_test.cpp
@@ -18,8 +18,11 @@
 #include <QMetaType>
 #include <QSignalSpy>
 #include <QThread>
+#include <atomic>
 #include <chrono>
+#include <mutex>
 #include <thread>
+#include <vector>
 
 #include "mocks/mock_render_presenter.h"
 
@@ -27,6 +30,8 @@ Q_DECLARE_METATYPE(orc::PreviewRenderResult)
 Q_DECLARE_METATYPE(orc::presenters::VideoParameterObservationView)
 Q_DECLARE_METATYPE(orc::presenters::NtscFieldObservationsView)
 Q_DECLARE_METATYPE(orc::presenters::TeletextFieldPacketsView)
+Q_DECLARE_METATYPE(std::vector<orc::AudioPairView>)
+Q_DECLARE_METATYPE(std::shared_ptr<orc::presenters::IAudioStreamReader>)
 
 namespace gui_unit_test {
 
@@ -161,6 +166,47 @@ TEST(RenderCoordinatorTest, TriggerRequests_AreProcessedInOrder) {
   coordinator.stop();
 }
 
+namespace {
+
+// A render the test can hold open: it announces that it has started, then
+// blocks until released. Lets a test fill the request queue behind a render
+// that is provably already in flight, instead of racing the worker.
+struct BlockingRender {
+  std::atomic<bool> started{false};
+  std::atomic<bool> release{false};
+  std::atomic<int> calls{0};
+
+  void wait() {
+    started.store(true);
+    while (!release.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+};
+
+orc::PreviewRenderResult makeRenderResult(orc::NodeID node_id,
+                                          orc::PreviewOutputType output_type,
+                                          uint64_t output_index) {
+  return orc::PreviewRenderResult{
+      {}, true, "", node_id, output_type, output_index, std::nullopt};
+}
+
+// Spin the calling thread (no event loop needed) until @p predicate holds.
+template <typename Predicate>
+bool waitForFlag(Predicate predicate, int timeout_ms = 2000) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return predicate();
+}
+
+}  // namespace
+
 TEST(RenderCoordinatorTest, StalePreviewResponses_AreSuppressed) {
   (void)kMetatypesRegistered;
 
@@ -170,21 +216,20 @@ TEST(RenderCoordinatorTest, StalePreviewResponses_AreSuppressed) {
   EXPECT_CALL(*mock_presenter, setDAG(testing::_)).Times(1);
   EXPECT_CALL(*mock_presenter, setShowDropouts(false)).Times(1);
 
-  EXPECT_CALL(*mock_presenter,
-              renderPreview(orc::NodeID(9),
-                            orc::PreviewOutputType::Frame_Field1, 0, ""))
-      .WillOnce(
-          Invoke([](orc::NodeID node_id, orc::PreviewOutputType output_type,
-                    uint64_t output_index, const std::string&) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(20));
-            return orc::PreviewRenderResult{
-                {}, true, "", node_id, output_type, output_index, std::nullopt};
-          }))
-      .WillOnce(
-          Invoke([](orc::NodeID node_id, orc::PreviewOutputType output_type,
-                    uint64_t output_index, const std::string&) {
-            return orc::PreviewRenderResult{
-                {}, true, "", node_id, output_type, output_index, std::nullopt};
+  auto blocker = std::make_shared<BlockingRender>();
+  EXPECT_CALL(
+      *mock_presenter,
+      renderPreview(orc::NodeID(9), orc::PreviewOutputType::Frame_Field1, 0, "",
+                    testing::_))
+      .Times(2)
+      .WillRepeatedly(Invoke(
+          [blocker](orc::NodeID node_id, orc::PreviewOutputType output_type,
+                    uint64_t output_index, const std::string&,
+                    orc::PreviewNavigationHint) {
+            if (blocker->calls.fetch_add(1) == 0) {
+              blocker->wait();
+            }
+            return makeRenderResult(node_id, output_type, output_index);
           }));
 
   RenderCoordinator coordinator(
@@ -201,14 +246,172 @@ TEST(RenderCoordinatorTest, StalePreviewResponses_AreSuppressed) {
 
   const uint64_t first_id = coordinator.requestPreview(
       orc::NodeID(9), orc::PreviewOutputType::Frame_Field1, 0);
+
+  // The second request must be queued while the first is already rendering;
+  // otherwise it would supersede the first in the queue and the first would
+  // never run at all (that is the pruning test below, not this one).
+  ASSERT_TRUE(waitForFlag([&] { return blocker->started.load(); }));
   const uint64_t second_id = coordinator.requestPreview(
       orc::NodeID(9), orc::PreviewOutputType::Frame_Field1, 0);
+  blocker->release.store(true);
 
   ASSERT_TRUE(waitForCount(preview_spy, 1));
   EXPECT_EQ(preview_spy.count(), 1);
   EXPECT_EQ(preview_spy.at(0).at(0).toULongLong(), second_id);
   EXPECT_NE(first_id, second_id);
 
+  coordinator.stop();
+}
+
+// A burst of navigations (playback catching up, or a scrub that outruns the
+// renderer) used to queue one render per position; every one but the last was
+// rendered in full and then thrown away. Only the newest is ever displayed, so
+// the queued ones are dropped before they cost anything.
+TEST(RenderCoordinatorTest, SupersededQueuedPreviews_AreDiscardedUnrendered) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+
+  EXPECT_CALL(*mock_presenter, setDAG(testing::_)).Times(1);
+  EXPECT_CALL(*mock_presenter, setShowDropouts(false)).Times(1);
+
+  auto blocker = std::make_shared<BlockingRender>();
+  std::mutex rendered_mutex;
+  std::vector<uint64_t> rendered_indices;
+
+  EXPECT_CALL(*mock_presenter, renderPreview(orc::NodeID(4), testing::_,
+                                             testing::_, "", testing::_))
+      .WillRepeatedly(Invoke(
+          [&, blocker](orc::NodeID node_id, orc::PreviewOutputType output_type,
+                       uint64_t output_index, const std::string&,
+                       orc::PreviewNavigationHint) {
+            {
+              const std::lock_guard<std::mutex> lock(rendered_mutex);
+              rendered_indices.push_back(output_index);
+            }
+            if (blocker->calls.fetch_add(1) == 0) {
+              blocker->wait();
+            }
+            return makeRenderResult(node_id, output_type, output_index);
+          }));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy preview_spy(&coordinator, &RenderCoordinator::previewReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(456));
+
+  // Index 0 occupies the worker; 1..7 pile up behind it.
+  coordinator.requestPreview(orc::NodeID(4),
+                             orc::PreviewOutputType::Frame_Field1, 0);
+  ASSERT_TRUE(waitForFlag([&] { return blocker->started.load(); }));
+
+  uint64_t last_id = 0;
+  for (uint64_t index = 1; index <= 7; ++index) {
+    last_id = coordinator.requestPreview(
+        orc::NodeID(4), orc::PreviewOutputType::Frame_Field1, index);
+  }
+  blocker->release.store(true);
+
+  ASSERT_TRUE(waitForCount(preview_spy, 1));
+  EXPECT_EQ(preview_spy.count(), 1);
+  EXPECT_EQ(preview_spy.at(0).at(0).toULongLong(), last_id);
+
+  // Give any wrongly-retained request time to be rendered before asserting.
+  QThread::msleep(50);
+  QCoreApplication::processEvents();
+
+  const std::lock_guard<std::mutex> lock(rendered_mutex);
+  EXPECT_EQ(rendered_indices, (std::vector<uint64_t>{0, 7}))
+      << "superseded queued previews were rendered instead of discarded";
+
+  coordinator.stop();
+}
+
+// The hint is what tells a stage that playback is running and adjacent frames
+// are worth pre-fetching. It has to survive the trip through the queue.
+TEST(RenderCoordinatorTest, PreviewNavigationHint_IsForwardedToThePresenter) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+
+  EXPECT_CALL(*mock_presenter, setDAG(testing::_)).Times(1);
+  EXPECT_CALL(*mock_presenter, setShowDropouts(false)).Times(1);
+
+  EXPECT_CALL(*mock_presenter,
+              renderPreview(orc::NodeID(5), testing::_, 3, "",
+                            orc::PreviewNavigationHint::Sequential))
+      .WillOnce(
+          Invoke([](orc::NodeID node_id, orc::PreviewOutputType output_type,
+                    uint64_t output_index, const std::string&,
+                    orc::PreviewNavigationHint) {
+            return makeRenderResult(node_id, output_type, output_index);
+          }));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy preview_spy(&coordinator, &RenderCoordinator::previewReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(567));
+
+  coordinator.requestPreview(orc::NodeID(5),
+                             orc::PreviewOutputType::Frame_Field1, 3, "",
+                             orc::PreviewNavigationHint::Sequential);
+
+  ASSERT_TRUE(waitForCount(preview_spy, 1));
+  coordinator.stop();
+}
+
+// Scrubbing and one-off navigations must keep rendering exactly as before.
+TEST(RenderCoordinatorTest, PreviewRequestsDefaultToTheRandomHint) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+
+  EXPECT_CALL(*mock_presenter, setDAG(testing::_)).Times(1);
+  EXPECT_CALL(*mock_presenter, setShowDropouts(false)).Times(1);
+
+  EXPECT_CALL(*mock_presenter,
+              renderPreview(orc::NodeID(6), testing::_, 2, "",
+                            orc::PreviewNavigationHint::Random))
+      .WillOnce(
+          Invoke([](orc::NodeID node_id, orc::PreviewOutputType output_type,
+                    uint64_t output_index, const std::string&,
+                    orc::PreviewNavigationHint) {
+            return makeRenderResult(node_id, output_type, output_index);
+          }));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy preview_spy(&coordinator, &RenderCoordinator::previewReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(678));
+
+  coordinator.requestPreview(orc::NodeID(6),
+                             orc::PreviewOutputType::Frame_Field1, 2);
+
+  ASSERT_TRUE(waitForCount(preview_spy, 1));
   coordinator.stop();
 }
 
@@ -724,6 +927,319 @@ TEST(RenderCoordinatorTest, ExecutionProgress_ForwardedToSignal) {
   EXPECT_EQ(execution_spy.at(1).at(1).toULongLong(), 2ull);
 
   coordinator.stop();
+}
+
+// --- Preview audio playback: pair enumeration and reader creation ---------
+
+namespace {
+
+// Minimal IAudioStreamReader stand-in: the coordinator only moves the pointer
+// across threads, so no behaviour is needed beyond identity.
+class StubAudioStreamReader final : public orc::presenters::IAudioStreamReader {
+ public:
+  void prime(const orc::presenters::AudioPrimeProgressCallback&) override {}
+  std::vector<float> readFrames(orc::FrameID, uint64_t) override { return {}; }
+  uint64_t frameForPairPosition(uint64_t) const override { return 0; }
+  uint64_t pairPositionForFrame(orc::FrameID) const override { return 0; }
+  orc::FrameIDRange frameRange() const override { return {0, 0}; }
+};
+
+orc::AudioPairView makePairView(size_t index, std::string name,
+                                std::string origin) {
+  orc::AudioPairView view;
+  view.index = index;
+  view.name = std::move(name);
+  view.origin = std::move(origin);
+  return view;
+}
+
+}  // namespace
+
+TEST(RenderCoordinatorTest, AudioChannelPairsRequest_RoundTripsThroughWorker) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+
+  EXPECT_CALL(*mock_presenter, getAudioChannelPairs(orc::NodeID(3)))
+      .WillOnce(Return(std::vector<orc::AudioPairView>{
+          makePairView(0, "Analogue", "analogue"),
+          makePairView(1, "EFM digital audio", "efm")}));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy pairs_spy(&coordinator,
+                       &RenderCoordinator::audioChannelPairsReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(1));
+
+  const uint64_t request_id =
+      coordinator.requestAudioChannelPairs(orc::NodeID(3));
+
+  ASSERT_TRUE(waitForCount(pairs_spy, 1));
+  EXPECT_EQ(pairs_spy.at(0).at(0).toULongLong(), request_id);
+  const auto pairs =
+      pairs_spy.at(0).at(1).value<std::vector<orc::AudioPairView>>();
+  ASSERT_EQ(pairs.size(), 2u);
+  EXPECT_EQ(pairs[1].index, 1u);
+  EXPECT_EQ(pairs[1].name, "EFM digital audio");
+  EXPECT_EQ(pairs[1].origin, "efm");
+
+  coordinator.stop();
+}
+
+// An audio-less node answers with an empty list, not an error: the dialogue's
+// combo simply stays disabled.
+TEST(RenderCoordinatorTest,
+     AudioChannelPairsRequest_EmptyListForNodeWithNoAudio) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+
+  EXPECT_CALL(*mock_presenter, getAudioChannelPairs(orc::NodeID(5)))
+      .WillOnce(Return(std::vector<orc::AudioPairView>{}));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy pairs_spy(&coordinator,
+                       &RenderCoordinator::audioChannelPairsReady);
+  QSignalSpy error_spy(&coordinator, &RenderCoordinator::error);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(1));
+
+  coordinator.requestAudioChannelPairs(orc::NodeID(5));
+
+  ASSERT_TRUE(waitForCount(pairs_spy, 1));
+  EXPECT_TRUE(
+      pairs_spy.at(0).at(1).value<std::vector<orc::AudioPairView>>().empty());
+  EXPECT_EQ(error_spy.count(), 0);
+
+  coordinator.stop();
+}
+
+// The viewed node can change while a heavy DAG is still enumerating, so only
+// the newest enumeration is delivered.
+TEST(RenderCoordinatorTest, StaleAudioChannelPairsResponses_AreSuppressed) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+
+  EXPECT_CALL(*mock_presenter, getAudioChannelPairs(testing::_))
+      .WillOnce(Invoke([](orc::NodeID) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        return std::vector<orc::AudioPairView>{
+            makePairView(0, "First", "analogue")};
+      }))
+      .WillOnce(Invoke([](orc::NodeID) {
+        return std::vector<orc::AudioPairView>{
+            makePairView(0, "Second", "efm")};
+      }));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy pairs_spy(&coordinator,
+                       &RenderCoordinator::audioChannelPairsReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(1));
+
+  const uint64_t first_id =
+      coordinator.requestAudioChannelPairs(orc::NodeID(1));
+  const uint64_t second_id =
+      coordinator.requestAudioChannelPairs(orc::NodeID(2));
+
+  ASSERT_TRUE(waitForCount(pairs_spy, 1));
+  EXPECT_EQ(pairs_spy.count(), 1);
+  EXPECT_EQ(pairs_spy.at(0).at(0).toULongLong(), second_id);
+  EXPECT_NE(first_id, second_id);
+  EXPECT_EQ(
+      pairs_spy.at(0).at(1).value<std::vector<orc::AudioPairView>>().at(0).name,
+      "Second");
+
+  coordinator.stop();
+}
+
+TEST(RenderCoordinatorTest, AudioStreamReaderRequest_DeliversReaderFromWorker) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+  auto reader = std::make_shared<StubAudioStreamReader>();
+
+  EXPECT_CALL(*mock_presenter, createAudioStreamReader(orc::NodeID(3), 1u))
+      .WillOnce(Return(reader));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy reader_spy(&coordinator,
+                        &RenderCoordinator::audioStreamReaderReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(1));
+
+  const uint64_t request_id =
+      coordinator.requestAudioStreamReader(orc::NodeID(3), 1);
+
+  ASSERT_TRUE(waitForCount(reader_spy, 1));
+  EXPECT_EQ(reader_spy.at(0).at(0).toULongLong(), request_id);
+  EXPECT_EQ(reader_spy.at(0)
+                .at(1)
+                .value<std::shared_ptr<orc::presenters::IAudioStreamReader>>()
+                .get(),
+            reader.get());
+
+  coordinator.stop();
+}
+
+// An unusable pair is reported as a null reader rather than an error, so the
+// dialogue can fall back to the video-only playback path.
+TEST(RenderCoordinatorTest,
+     AudioStreamReaderRequest_NullReaderForUnusablePair) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+
+  EXPECT_CALL(*mock_presenter, createAudioStreamReader(orc::NodeID(3), 0u))
+      .WillOnce(Return(nullptr));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy reader_spy(&coordinator,
+                        &RenderCoordinator::audioStreamReaderReady);
+  QSignalSpy error_spy(&coordinator, &RenderCoordinator::error);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(1));
+
+  coordinator.requestAudioStreamReader(orc::NodeID(3), 0);
+
+  ASSERT_TRUE(waitForCount(reader_spy, 1));
+  EXPECT_EQ(reader_spy.at(0)
+                .at(1)
+                .value<std::shared_ptr<orc::presenters::IAudioStreamReader>>(),
+            nullptr);
+  EXPECT_EQ(error_spy.count(), 0);
+
+  coordinator.stop();
+}
+
+// Reselecting the pair while the first creation is still resolving must not
+// deliver the superseded reader.
+TEST(RenderCoordinatorTest, StaleAudioStreamReaderResponses_AreSuppressed) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+  auto first_reader = std::make_shared<StubAudioStreamReader>();
+  auto second_reader = std::make_shared<StubAudioStreamReader>();
+
+  EXPECT_CALL(*mock_presenter, createAudioStreamReader(orc::NodeID(3), 0u))
+      .WillOnce(Invoke([first_reader](orc::NodeID, size_t) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        return std::static_pointer_cast<orc::presenters::IAudioStreamReader>(
+            first_reader);
+      }));
+  EXPECT_CALL(*mock_presenter, createAudioStreamReader(orc::NodeID(3), 1u))
+      .WillOnce(Return(second_reader));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy reader_spy(&coordinator,
+                        &RenderCoordinator::audioStreamReaderReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(1));
+
+  const uint64_t first_id =
+      coordinator.requestAudioStreamReader(orc::NodeID(3), 0);
+  const uint64_t second_id =
+      coordinator.requestAudioStreamReader(orc::NodeID(3), 1);
+
+  ASSERT_TRUE(waitForCount(reader_spy, 1));
+  EXPECT_EQ(reader_spy.count(), 1);
+  EXPECT_EQ(reader_spy.at(0).at(0).toULongLong(), second_id);
+  EXPECT_NE(first_id, second_id);
+  EXPECT_EQ(reader_spy.at(0)
+                .at(1)
+                .value<std::shared_ptr<orc::presenters::IAudioStreamReader>>()
+                .get(),
+            second_reader.get());
+
+  coordinator.stop();
+}
+
+// Requests still queued at shutdown are simply dropped: stop() must return and
+// no reader may be delivered afterwards.
+TEST(RenderCoordinatorTest, Shutdown_WithPendingAudioReaderRequest_IsClean) {
+  (void)kMetatypesRegistered;
+
+  auto mock_presenter =
+      std::make_shared<NiceMock<orc::presenters::test::MockRenderPresenter>>();
+  auto reader = std::make_shared<StubAudioStreamReader>();
+
+  // A slow first creation keeps the worker busy while stop() is called.
+  ON_CALL(*mock_presenter, createAudioStreamReader(testing::_, testing::_))
+      .WillByDefault(Invoke([reader](orc::NodeID, size_t) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+        return std::static_pointer_cast<orc::presenters::IAudioStreamReader>(
+            reader);
+      }));
+
+  RenderCoordinator coordinator(
+      [mock_presenter](
+          void*) -> std::shared_ptr<orc::presenters::IRenderPresenter> {
+        return mock_presenter;
+      });
+
+  QSignalSpy reader_spy(&coordinator,
+                        &RenderCoordinator::audioStreamReaderReady);
+
+  coordinator.start();
+  coordinator.setProject(reinterpret_cast<void*>(0x1));
+  coordinator.updateDAG(std::make_shared<int>(1));
+
+  coordinator.requestAudioStreamReader(orc::NodeID(3), 0);
+  coordinator.requestAudioStreamReader(orc::NodeID(3), 1);
+  coordinator.stop();
+
+  // Deliveries are queued signals; none may arrive for a stopped coordinator.
+  QCoreApplication::processEvents();
+  EXPECT_LE(reader_spy.count(), 1);
 }
 
 }  // namespace gui_unit_test

--- a/orc/gui/CMakeLists.txt
+++ b/orc/gui/CMakeLists.txt
@@ -8,6 +8,26 @@ if(NOT Qt6_FOUND)
     return()
 endif()
 
+# =============================================================================
+# Preview audio playback
+# =============================================================================
+# Audio playback in the preview dialogue needs Qt Multimedia for the output
+# device. Everything above the device (the IAudioOutput seam, the chase clock
+# and PreviewAudioController) is device-free and always built, so the feature
+# can be compiled out on a platform that cannot provide the module without
+# disturbing the rest of the GUI: only the QAudioSink-backed implementation
+# and the factory that returns it are guarded.
+# =============================================================================
+option(ORC_GUI_AUDIO_PLAYBACK "Build preview audio playback (needs Qt6 Multimedia)" ON)
+
+if(ORC_GUI_AUDIO_PLAYBACK)
+    find_package(Qt6 COMPONENTS Multimedia QUIET)
+    if(NOT Qt6Multimedia_FOUND)
+        message(WARNING "Qt6 Multimedia not found, building without preview audio playback")
+        set(ORC_GUI_AUDIO_PLAYBACK OFF)
+    endif()
+endif()
+
 # Enable Qt's MOC (Meta-Object Compiler)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -54,6 +74,14 @@ set(ORC_GUI_LIB_SOURCES
     preview_image_qt.h
     previewdialog.cpp
     previewdialog.h
+
+    # Preview audio playback (device-free part; see ORC_GUI_AUDIO_PLAYBACK)
+    audio_output.cpp
+    audio_output.h
+    preview_audio_chase.h
+    preview_audio_controller.cpp
+    preview_audio_controller.h
+
     framescopedialog.cpp
     framescopedialog.h
     line_navigation_mapper.cpp
@@ -184,6 +212,13 @@ set(ORC_GUI_LIB_SOURCES
     orc_gui_resources.qrc
 )
 
+if(ORC_GUI_AUDIO_PLAYBACK)
+    list(APPEND ORC_GUI_LIB_SOURCES
+        qt_audio_output.cpp
+        qt_audio_output.h
+    )
+endif()
+
 add_library(orc-gui-lib STATIC ${ORC_GUI_LIB_SOURCES})
 
 add_executable(orc-gui MACOSX_BUNDLE
@@ -220,6 +255,12 @@ target_link_libraries(orc-gui-lib PUBLIC
     Qt6::Widgets
     ${QTNODES_TARGET}
 )
+
+if(ORC_GUI_AUDIO_PLAYBACK)
+    # PUBLIC so the GUI test targets that link orc-gui-lib inherit the module.
+    target_link_libraries(orc-gui-lib PUBLIC Qt6::Multimedia)
+    target_compile_definitions(orc-gui-lib PUBLIC ORC_GUI_AUDIO_PLAYBACK)
+endif()
 
 target_link_libraries(orc-gui PRIVATE orc-gui-lib)
 

--- a/orc/gui/audio_channel_pair_notice.h
+++ b/orc/gui/audio_channel_pair_notice.h
@@ -1,0 +1,60 @@
+/*
+ * File:        audio_channel_pair_notice.h
+ * Module:      orc-gui
+ * Purpose:     Pure helper that notes when an audio stage's input carries no
+ *              audio channel pairs (Tier 1 / gui-logic testable)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace orc::gui {
+
+// Note shown in an audio stage's parameter dialog when the node's input
+// carries |pair_count| audio channel pairs. Empty unless the input carries
+// none: with no pairs to choose from, the channel-pair dropdown falls back to
+// the stage's full container-slot list, so every selection the user can make
+// is one the input cannot satisfy. The stages pass their input through
+// unchanged in that case, and this explains why nothing happens.
+inline std::string audioChannelPairNotice(std::size_t pair_count) {
+  if (pair_count > 0) {
+    return {};
+  }
+  return "The input to this node carries no audio channel pairs, so this "
+         "stage will pass its input through unchanged. Add audio to the "
+         "pipeline (for example with an Audio Import stage) before mapping or "
+         "aligning channel pairs.";
+}
+
+// Note shown on the preview dialogue's audio selector when the viewed node
+// carries no audio channel pairs. Separate from audioChannelPairNotice()
+// because nothing is being passed through here: the preview simply has no
+// audio to offer, and the user needs to know that is a property of the
+// pipeline rather than a broken control.
+inline std::string audioChannelPairPreviewNotice() {
+  return "This stage's output carries no audio channel pairs, so there is "
+         "nothing to play. Add audio to the pipeline (for example with an "
+         "Audio Import stage) or view a stage downstream of one that carries "
+         "audio.";
+}
+
+// Appends audioChannelPairNotice() to a stage description, separated by a
+// blank line. Returns |description| unchanged when there is nothing to note.
+inline std::string withAudioChannelPairNotice(const std::string& description,
+                                              std::size_t pair_count) {
+  const std::string note = audioChannelPairNotice(pair_count);
+  if (note.empty()) {
+    return description;
+  }
+  if (description.empty()) {
+    return note;
+  }
+  return description + "\n\n" + note;
+}
+
+}  // namespace orc::gui

--- a/orc/gui/audio_output.cpp
+++ b/orc/gui/audio_output.cpp
@@ -1,0 +1,28 @@
+/*
+ * File:        audio_output.cpp
+ * Module:      orc-gui
+ * Purpose:     Platform audio output selection for preview playback
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "audio_output.h"
+
+#ifdef ORC_GUI_AUDIO_PLAYBACK
+#include "qt_audio_output.h"
+#endif
+
+namespace orc::gui {
+
+std::unique_ptr<IAudioOutput> createSystemAudioOutput() {
+#ifdef ORC_GUI_AUDIO_PLAYBACK
+  return std::make_unique<QtAudioOutput>();
+#else
+  // Built without an audio backend: the preview dialogue keeps its legacy
+  // timer-paced video-only playback and never opens a device.
+  return nullptr;
+#endif
+}
+
+}  // namespace orc::gui

--- a/orc/gui/audio_output.h
+++ b/orc/gui/audio_output.h
@@ -1,0 +1,94 @@
+/*
+ * File:        audio_output.h
+ * Module:      orc-gui
+ * Purpose:     Device-free seam for the preview playback audio output
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace orc::gui {
+
+/**
+ * @brief Sink for interleaved stereo float audio, and the playback clock.
+ *
+ * The preview playback design makes audio the master clock and lets video
+ * chase it, so the only thing the controller needs from a device is: somewhere
+ * to push samples, back-pressure telling it how much fits, and how much audio
+ * the device has actually consumed so far.
+ *
+ * Everything is counted in *stereo pairs* (one left plus one right sample),
+ * never in bytes: the implementation may fall back from float to a narrower
+ * device format, which would make a byte count mean different things on
+ * different machines. Pairs are also the unit the SMPTE 272M-1994 §14.3
+ * cadence is expressed in, so no conversion is needed anywhere in the clock
+ * arithmetic.
+ *
+ * Thread safety: none. Create, use and destroy on one thread — the GUI thread
+ * for the Qt-backed implementation.
+ */
+class IAudioOutput {
+ public:
+  virtual ~IAudioOutput() = default;
+
+  /**
+   * @brief Open the device and begin consuming written samples.
+   *
+   * @param sample_rate_hz Sample rate to request (48 000 for pipeline audio)
+   * @param channels       Channel count to request (2 for a channel pair)
+   * @return false when no device is available or the format is unsupported
+   */
+  virtual bool start(uint32_t sample_rate_hz, uint32_t channels) = 0;
+
+  /// Stop the device and discard anything still queued. Safe when not started.
+  virtual void stop() = 0;
+
+  /// Stereo pairs that write() can currently accept without blocking.
+  virtual size_t stereoPairsFree() const = 0;
+
+  /**
+   * @brief Queue interleaved stereo float samples (±1.0 full scale).
+   *
+   * @param interleaved  2 × @p stereo_pairs floats, L R L R …
+   * @param stereo_pairs Pairs offered
+   * @return Pairs actually accepted; the caller must retain the remainder
+   */
+  virtual size_t write(const float* interleaved, size_t stereo_pairs) = 0;
+
+  /**
+   * @brief Audio consumed by the device since start(), in microseconds.
+   *
+   * This is the master clock: it advances only as the device actually plays,
+   * so it stalls rather than drifts if the feeder ever falls behind.
+   */
+  virtual uint64_t playedMicroseconds() const = 0;
+
+  /**
+   * @brief Set the output amplitude.
+   *
+   * @param linear Linear amplitude factor, 0.0 (silent) to 1.0 (unattenuated)
+   *
+   * Applied at the device, not in the sample feed, so a change takes effect
+   * without flushing anything already queued and never disturbs the clock.
+   */
+  virtual void setVolume(double linear) = 0;
+};
+
+/**
+ * @brief Create the platform audio output, or nullptr when unavailable.
+ *
+ * Returns nullptr when the build has no audio backend
+ * (ORC_GUI_AUDIO_PLAYBACK off). Constructing the returned object is what first
+ * touches the audio subsystem, so a project with no audio never does.
+ *
+ * Must be called on the GUI thread.
+ */
+std::unique_ptr<IAudioOutput> createSystemAudioOutput();
+
+}  // namespace orc::gui

--- a/orc/gui/docs/preview_window.md
+++ b/orc/gui/docs/preview_window.md
@@ -13,7 +13,7 @@ Waveform Monitor, Vectorscope, and several metadata observers.
 |---------|-------------|
 | << | Jump to the first frame or field. |
 | < | Step back one frame or field. Hold to step continuously. |
-| ▶ / ⏸ | Play back at the project frame rate (PAL: 25 fps; NTSC: ~30 fps). Press again to pause. Stops automatically at the last frame. |
+| ▶ / ⏸ | Play back at the project frame rate (PAL: 25 fps; NTSC: ~30 fps), or at the audio rate when a channel pair is selected. Press again to pause. Stops automatically at the last frame. |
 | > | Step forward one frame or field. Hold to step continuously. |
 | >> | Jump to the last frame or field. |
 | Frame spinbox | Type a frame number to jump there directly (1-indexed display). |
@@ -28,6 +28,41 @@ Waveform Monitor, Vectorscope, and several metadata observers.
 | Aspect Ratio | Set the display aspect ratio: Square Pixels, 4:3, 16:9, and others. |
 | Zoom 1:1 | Resize the preview window so the image is displayed at its native pixel resolution. |
 | Dropouts: Off/On | Toggle the dropout overlay. When enabled, samples flagged as dropout are highlighted in red over the preview image. |
+| Audio | Choose an audio channel pair to play with the preview, or **No audio**. Greyed out when the stage's output carries no audio. |
+| Volume | Playback volume for the selected pair. Takes effect immediately, including mid-playback. |
+| 🔊 / 🔇 | Mute the audio without pausing. The preview keeps playing at the same rate. |
+
+## Audio Playback
+
+Select a channel pair in the **Audio** control and press play: the pair is
+played at normal speed and the preview follows it.
+
+Audio is the clock and the video chases it. Preview rendering is not
+guaranteed to reach real time — a 3D chroma decoder or a neural stage can take
+seconds per frame — so instead of slowing the audio to match, the preview shows
+whichever frame the audio has reached and skips the ones the renderer could not
+deliver in time. Sound is always continuous; on a heavy pipeline the picture
+simply updates less often.
+
+A few things worth knowing:
+
+- **The first play may pause to prepare the audio.** Some sources decode their
+  whole audio stream on first access — an EFM disc decode can take minutes.
+  A progress window appears if the wait is long enough to notice, and the
+  prepared audio is kept, so pausing and playing again is instant. A CVBS
+  container reads audio per frame and needs no preparation at all.
+- **Preparing audio can use a lot of memory.** A TBC or imported-WAV source
+  holds the decoded audio in RAM for the whole disc; this can be hundreds of
+  megabytes on a feature-length title.
+- **The selection resets when you change stage.** Channel-pair numbering is a
+  property of the stage's output, so the selector re-reads it and returns to
+  **No audio** whenever you view a different stage.
+- **Editing the pipeline stops playback.** Changing a parameter or the graph
+  invalidates the prepared audio; press play again to restart.
+- **Scrubbing restarts the audio** at the new position rather than trying to
+  catch up.
+- Most projects carry no audio at all. The **Audio** control is then disabled
+  and play behaves exactly as it always has.
 
 ## Line Scope
 

--- a/orc/gui/dropout_editor_dialog.cpp
+++ b/orc/gui/dropout_editor_dialog.cpp
@@ -697,7 +697,8 @@ void DropoutEditorRenderWorker::renderFrame(uint64_t frame_id) {
   result.success = false;
   try {
     result = render_presenter_->renderPreview(
-        input_node_id_, frame_output_type_, frame_id, render_option_id_);
+        input_node_id_, frame_output_type_, frame_id, render_option_id_,
+        orc::PreviewNavigationHint::Random);
   } catch (const std::exception& e) {
     result.error_message = e.what();
     ORC_LOG_ERROR("DropoutEditorRenderWorker: render of frame {} failed: {}",

--- a/orc/gui/mainwindow.cpp
+++ b/orc/gui/mainwindow.cpp
@@ -12,6 +12,7 @@
 #include <orc/stage/common_types.h>
 #include <orc/stage/node_type.h>
 
+#include "audio_channel_pair_notice.h"
 #include "burstlevelanalysisdialog.h"
 #include "closedcaptiondialog.h"
 #include "dropout_editor_dialog.h"
@@ -34,6 +35,7 @@
 #include "presenters/include/project_presenter.h"
 #include "presenters/include/render_presenter.h"
 #include "presenters/include/video_parameter_observation_presenter.h"
+#include "preview_audio_chase.h"
 #include "previewdialog.h"
 #include "project_load_status_formatter.h"
 #include "projectpropertiesdialog.h"
@@ -437,6 +439,10 @@ MainWindow::MainWindow(QWidget* parent)
           this, &MainWindow::onClosedCaptionDataReady, Qt::QueuedConnection);
   connect(render_coordinator_.get(), &RenderCoordinator::availableOutputsReady,
           this, &MainWindow::onAvailableOutputsReady, Qt::QueuedConnection);
+  connect(render_coordinator_.get(), &RenderCoordinator::audioChannelPairsReady,
+          this, &MainWindow::onAudioChannelPairsReady, Qt::QueuedConnection);
+  connect(render_coordinator_.get(), &RenderCoordinator::audioStreamReaderReady,
+          this, &MainWindow::onAudioStreamReaderReady, Qt::QueuedConnection);
   connect(render_coordinator_.get(), &RenderCoordinator::lineSamplesReady, this,
           &MainWindow::onLineSamplesReady, Qt::QueuedConnection);
   connect(render_coordinator_.get(), &RenderCoordinator::frameTimingDataReady,
@@ -667,6 +673,18 @@ void MainWindow::setupUI() {
           [this](bool show) {
             render_coordinator_->setShowDropouts(show);
             updatePreview();
+          });
+  // Creating a playback reader resolves the node's representation, which
+  // executes the DAG — so it goes through the worker like every other query.
+  connect(preview_dialog_, &PreviewDialog::audioStreamReaderRequested, this,
+          [this](size_t pair) {
+            if (!current_view_node_id_.is_valid()) {
+              preview_dialog_->setAudioStreamReader(nullptr);
+              return;
+            }
+            pending_audio_reader_request_id_ =
+                render_coordinator_->requestAudioStreamReader(
+                    current_view_node_id_, pair);
           });
   connect(preview_dialog_, &PreviewDialog::showVBIDialogRequested, this,
           &MainWindow::onShowVBIDialog);
@@ -2719,6 +2737,7 @@ void MainWindow::onEditParameters(const orc::NodeID& node_id) {
   // dropdown to the pairs the node's input actually carries. The stage
   // descriptor lists all container slots; here we narrow it using the upstream
   // node's audio pair count.
+  std::optional<size_t> input_audio_pair_count;
   if (stage_name == "audio_channel_map" || stage_name == "audio_align" ||
       stage_name == "AudioSink") {
     auto* core_project = project_.presenter()->getCoreProjectHandle();
@@ -2743,6 +2762,7 @@ void MainWindow::onEditParameters(const orc::NodeID& node_id) {
 
       const auto pair_names =
           render_presenter.getAudioChannelPairNames(input_source_node_id);
+      input_audio_pair_count = pair_names.size();
       if (!pair_names.empty()) {
         // Combo entry "value␟label": stored value is the bare index (or "new"),
         // display adds the pair description when present, e.g. "0 - Analogue".
@@ -2824,6 +2844,14 @@ void MainWindow::onEditParameters(const orc::NodeID& node_id) {
   std::string stage_description;
   if (type_info && !type_info->description.empty()) {
     stage_description = type_info->description;
+  }
+
+  // An audio stage whose input carries no channel pairs cannot be configured
+  // usefully — say so in the dialog header rather than letting the user pick a
+  // pair the input does not have.
+  if (input_audio_pair_count) {
+    stage_description = orc::gui::withAudioChannelPairNotice(
+        stage_description, *input_audio_pair_count);
   }
 
   // Show parameter dialog
@@ -2960,6 +2988,11 @@ void MainWindow::applyStageSelection(const orc::NodeID& node_id) {
   // Request available outputs from coordinator
   pending_outputs_request_id_ =
       render_coordinator_->requestAvailableOutputs(node_id);
+
+  // Audio channel pairs are node-specific; the dialogue has already cleared
+  // its selector (setCurrentNodeId) and repopulates when this answers.
+  pending_audio_pairs_request_id_ =
+      render_coordinator_->requestAudioChannelPairs(node_id);
 
   // Note: Analysis dialogs (dropout/SNR) are triggered from stage context menu,
   // not automatically updated when switching nodes
@@ -3210,10 +3243,17 @@ void MainWindow::updatePreview() {
                   current_option_id_, suffix, effective_option_id);
   }
 
+  // During playback the next request is almost always the following frame, so
+  // stages are told to expect a sequential run and may pre-fetch. Scrubbing and
+  // one-off navigations stay Random — a pre-fetch there is wasted work.
+  const orc::PreviewNavigationHint navigation_hint =
+      preview_dialog_->isPlaying() ? orc::PreviewNavigationHint::Sequential
+                                   : orc::PreviewNavigationHint::Random;
+
   // Request preview from coordinator (async, thread-safe)
   pending_preview_request_id_ = render_coordinator_->requestPreview(
       current_view_node_id_, current_output_type_, current_index,
-      effective_option_id);
+      effective_option_id, navigation_hint);
 
   // Mark that a render is now in-flight (will be cleared when onPreviewReady is
   // called)
@@ -3511,6 +3551,14 @@ void MainWindow::refreshViewerControls(bool skip_preview) {
   // This helper updates all viewer controls based on current node's available
   // outputs Should be called after available_outputs_ is populated
 
+  // Audio maps to whole frames, so the chase target has to know how many
+  // preview indices one frame spans at the current output.
+  if (preview_dialog_) {
+    preview_dialog_->setAudioItemsPerFrame(
+        orc::gui::preview_audio::itemsPerFrameForOutputType(
+            current_output_type_));
+  }
+
   if (current_view_node_id_.is_valid() == false || available_outputs_.empty()) {
     ORC_LOG_DEBUG("refreshViewerControls: no node or outputs");
     return;
@@ -3581,6 +3629,13 @@ void MainWindow::refreshViewerControls(bool skip_preview) {
 
 void MainWindow::updatePreviewRenderer() {
   ORC_LOG_DEBUG("Updating preview renderer");
+
+  // A playback reader holds the representation it was created from alive, so
+  // any DAG or parameter edit makes it stale. Stop playback and drop it before
+  // the worker rebuilds; the selector repopulates with the refreshed outputs.
+  if (preview_dialog_) {
+    preview_dialog_->invalidateAudioSource();
+  }
 
   // Get the DAG - could be null for empty projects, that's fine
   auto dag = project_.hasSource() ? project_.getDAG() : nullptr;

--- a/orc/gui/mainwindow.h
+++ b/orc/gui/mainwindow.h
@@ -185,6 +185,13 @@ class MainWindow : public QMainWindow {
   void onObservationsInvalidated(QVector<int> changed_node_ids);
   void onAvailableOutputsReady(uint64_t request_id,
                                std::vector<orc::PreviewOutputInfo> outputs);
+  // Preview audio playback: the pair list feeds the dialogue's selector, the
+  // reader is what playback pulls samples from.
+  void onAudioChannelPairsReady(uint64_t request_id,
+                                std::vector<orc::AudioPairView> pairs);
+  void onAudioStreamReaderReady(
+      uint64_t request_id,
+      std::shared_ptr<orc::presenters::IAudioStreamReader> reader);
   void onLineSamplesReady(uint64_t request_id, uint64_t field_index,
                           int line_number, int sample_x,
                           std::vector<int16_t> samples,
@@ -360,6 +367,11 @@ class MainWindow : public QMainWindow {
   orc::NodeID closed_caption_cache_node_id_;
 
   uint64_t pending_outputs_request_id_{0};
+  // Preview audio queries. The coordinator already answers only the newest of
+  // each, so these exist to drop a response that the view has moved past
+  // before the worker got to it.
+  uint64_t pending_audio_pairs_request_id_{0};
+  uint64_t pending_audio_reader_request_id_{0};
   uint64_t pending_trigger_request_id_{0};
   orc::NodeID pending_trigger_node_id_;  // Track which node is being triggered
   uint64_t pending_line_sample_request_id_{0};

--- a/orc/gui/mainwindow_coordinator_callbacks.cpp
+++ b/orc/gui/mainwindow_coordinator_callbacks.cpp
@@ -486,6 +486,37 @@ void MainWindow::onAvailableOutputsReady(
   updatePreview();
 }
 
+void MainWindow::onAudioChannelPairsReady(
+    uint64_t request_id, std::vector<orc::AudioPairView> pairs) {
+  if (request_id != pending_audio_pairs_request_id_) {
+    return;  // Superseded by a later node selection
+  }
+  pending_audio_pairs_request_id_ = 0;
+
+  ORC_LOG_DEBUG("onAudioChannelPairsReady: request_id={}, pairs={}", request_id,
+                pairs.size());
+
+  // An empty list is the normal answer for most projects: the selector then
+  // shows a disabled "Mute/None" and playback keeps its video-only path.
+  preview_dialog_->setAudioChannelPairs(pairs);
+}
+
+void MainWindow::onAudioStreamReaderReady(
+    uint64_t request_id,
+    std::shared_ptr<orc::presenters::IAudioStreamReader> reader) {
+  if (request_id != pending_audio_reader_request_id_) {
+    return;  // Superseded by a later pair selection
+  }
+  pending_audio_reader_request_id_ = 0;
+
+  ORC_LOG_DEBUG("onAudioStreamReaderReady: request_id={}, usable={}",
+                request_id, reader != nullptr);
+
+  // A null reader means the pair turned out to be unplayable; the dialogue
+  // falls back to timer-paced video-only playback.
+  preview_dialog_->setAudioStreamReader(std::move(reader));
+}
+
 void MainWindow::onTriggerProgress(size_t current, size_t total,
                                    QString message) {
   // Ignore progress updates if we're not waiting for a trigger

--- a/orc/gui/preview_audio_chase.h
+++ b/orc/gui/preview_audio_chase.h
@@ -1,0 +1,102 @@
+/*
+ * File:        preview_audio_chase.h
+ * Module:      orc-gui
+ * Purpose:     Pure clock arithmetic for audio-mastered preview playback
+ *              (Tier 1 / gui-logic testable)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <orc/stage/common_types.h>  // PreviewOutputType
+
+#include <cstdint>
+
+namespace orc::gui::preview_audio {
+
+// Pipeline audio channel pairs are stereo (SMPTE 272M-1994 §1.2).
+inline constexpr uint32_t kAudioChannels = 2;
+
+// Cap on how far ahead of the device the feeder reads. The device buffer is
+// the effective lead: the feeder shares the GUI thread, so a stall that delays
+// a feed tick delays the reads with it and only audio already handed to the
+// device keeps playing. The cap simply stops the feeder reading unboundedly
+// ahead of a device that reports a very deep buffer.
+inline constexpr uint32_t kFeedLeadMs = 500;
+
+// Feed timer period. Short relative to the device buffer, so several ticks
+// pass before a queue that stops being topped up could run down.
+inline constexpr uint32_t kFeedIntervalMs = 50;
+
+// Video frames pulled from the reader per top-up. At 1920 pairs/frame (PAL)
+// this is 40 ms of audio per read — small enough that a read never blocks the
+// caller noticeably, large enough to keep per-frame overhead irrelevant.
+inline constexpr uint64_t kFeedChunkFrames = 4;
+
+/**
+ * @brief Stereo pairs a device has consumed after playing for @p played_us.
+ *
+ * Truncating division: the result is the last pair the device has definitely
+ * finished, which is what the video chase should not run ahead of.
+ */
+constexpr uint64_t stereoPairsPlayed(uint64_t played_us,
+                                     uint32_t sample_rate_hz) {
+  return played_us * sample_rate_hz / 1000000ULL;
+}
+
+/// Playing time occupied by @p stereo_pairs at @p sample_rate_hz.
+constexpr uint64_t microsecondsForStereoPairs(uint64_t stereo_pairs,
+                                              uint32_t sample_rate_hz) {
+  return sample_rate_hz == 0 ? 0 : stereo_pairs * 1000000ULL / sample_rate_hz;
+}
+
+/// Stereo pairs making up @p milliseconds of audio at @p sample_rate_hz.
+constexpr uint64_t stereoPairsForMilliseconds(uint64_t milliseconds,
+                                              uint32_t sample_rate_hz) {
+  return milliseconds * sample_rate_hz / 1000ULL;
+}
+
+/**
+ * @brief Preview item index showing video frame @p frame.
+ *
+ * @param items_per_frame 1 for a frame-indexed output, 2 for a field-indexed
+ *                        one (audio always maps to whole frames, so a field
+ *                        output advances two indices per frame period).
+ *
+ * Field-indexed outputs land on the first field of the frame: the audio for a
+ * frame starts with it, and stepping to the second field would put the chase
+ * half a frame ahead of the samples that have actually played.
+ */
+constexpr uint64_t previewIndexForFrame(uint64_t frame,
+                                        uint32_t items_per_frame) {
+  return frame * (items_per_frame == 0 ? 1 : items_per_frame);
+}
+
+/// Video frame shown at preview item index @p index. Inverse of the above.
+constexpr uint64_t frameForPreviewIndex(uint64_t index,
+                                        uint32_t items_per_frame) {
+  return index / (items_per_frame == 0 ? 1 : items_per_frame);
+}
+
+/**
+ * @brief Preview items making up one video frame at output @p type.
+ *
+ * Field-indexed outputs step a field per index, so a frame spans two of them;
+ * every other output steps a whole frame. The classification matches the one
+ * the preview navigation itself uses when converting positions between output
+ * types (MainWindow::onPreviewModeChanged).
+ */
+constexpr uint32_t itemsPerFrameForOutputType(orc::PreviewOutputType type) {
+  switch (type) {
+    case orc::PreviewOutputType::Frame_Field1:
+    case orc::PreviewOutputType::Frame_Field2:
+    case orc::PreviewOutputType::Luma:
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+}  // namespace orc::gui::preview_audio

--- a/orc/gui/preview_audio_controller.cpp
+++ b/orc/gui/preview_audio_controller.cpp
@@ -1,0 +1,249 @@
+/*
+ * File:        preview_audio_controller.cpp
+ * Module:      orc-gui
+ * Purpose:     Audio-mastered playback session for the preview dialogue
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "preview_audio_controller.h"
+
+#include <orc/stage/audio/audio_channel_pair.h>  // kAudioSampleRateHz
+
+#include <QTimer>
+#include <algorithm>
+#include <utility>
+
+#include "logging.h"
+#include "preview_audio_chase.h"
+
+namespace orc::gui {
+
+using preview_audio::kAudioChannels;
+using preview_audio::kFeedChunkFrames;
+using preview_audio::kFeedIntervalMs;
+using preview_audio::kFeedLeadMs;
+
+PreviewAudioController::PreviewAudioController(QObject* parent)
+    : QObject(parent),
+      feed_timer_(new QTimer(this)),
+      lead_target_pairs_(preview_audio::stereoPairsForMilliseconds(
+          kFeedLeadMs, orc::kAudioSampleRateHz)) {
+  feed_timer_->setInterval(static_cast<int>(kFeedIntervalMs));
+  connect(feed_timer_, &QTimer::timeout, this, &PreviewAudioController::feed);
+}
+
+PreviewAudioController::~PreviewAudioController() { stop(); }
+
+void PreviewAudioController::setAudioOutput(
+    std::unique_ptr<IAudioOutput> output) {
+  stop();
+  output_ = std::move(output);
+  applyVolume();
+}
+
+void PreviewAudioController::setReader(
+    std::shared_ptr<orc::presenters::IAudioStreamReader> reader) {
+  // A new reader means a new node, pair or DAG version: whatever was playing
+  // came from a representation the dialogue has moved on from.
+  stop();
+  reader_ = std::move(reader);
+  range_ = reader_ ? reader_->frameRange() : orc::FrameIDRange{1, 0};
+  if (!range_.contains(start_frame_)) {
+    start_frame_ = range_.empty() ? 0 : range_.first;
+  }
+}
+
+void PreviewAudioController::setItemsPerFrame(uint32_t items_per_frame) {
+  items_per_frame_ = items_per_frame == 0 ? 1 : items_per_frame;
+}
+
+bool PreviewAudioController::start(orc::FrameID first_frame) {
+  stop();
+
+  if (!output_ || !reader_) {
+    return false;
+  }
+  if (range_.empty() || !range_.contains(first_frame)) {
+    ORC_LOG_DEBUG(
+        "PreviewAudioController: Frame {} is outside the audio range [{}, {}]",
+        first_frame, range_.first, range_.last);
+    return false;
+  }
+
+  if (!output_->start(orc::kAudioSampleRateHz, kAudioChannels)) {
+    ORC_LOG_WARN("PreviewAudioController: Audio device refused to start");
+    return false;
+  }
+  applyVolume();
+
+  start_frame_ = first_frame;
+  feed_cursor_ = first_frame;
+  fed_pairs_ = 0;
+  underrun_count_ = 0;
+  pending_.clear();
+  pending_offset_ = 0;
+  state_ = State::kPlaying;
+
+  // Fill the device before the first tick so playback starts immediately
+  // rather than one feed interval later.
+  feed();
+  if (state_ == State::kPlaying) {
+    feed_timer_->start();
+  }
+  return state_ == State::kPlaying;
+}
+
+void PreviewAudioController::stop() {
+  feed_timer_->stop();
+  if (output_) {
+    output_->stop();
+  }
+  state_ = State::kStopped;
+  fed_pairs_ = 0;
+  pending_.clear();
+  pending_offset_ = 0;
+  feed_cursor_ = start_frame_;
+}
+
+void PreviewAudioController::seek(orc::FrameID frame) {
+  const bool was_playing = isPlaying();
+  stop();
+  start_frame_ = frame;
+  feed_cursor_ = frame;
+  if (was_playing) {
+    start(frame);
+  }
+}
+
+orc::FrameID PreviewAudioController::targetFrame() const {
+  if (state_ != State::kPlaying || !reader_) {
+    return start_frame_;
+  }
+  const uint64_t position =
+      reader_->pairPositionForFrame(start_frame_) + playedPairs();
+  const orc::FrameID frame = reader_->frameForPairPosition(position);
+  if (range_.empty()) {
+    return start_frame_;
+  }
+  return std::clamp(frame, range_.first, range_.last);
+}
+
+uint64_t PreviewAudioController::targetPreviewIndex() const {
+  return preview_audio::previewIndexForFrame(targetFrame(), items_per_frame_);
+}
+
+void PreviewAudioController::setVolume(double volume) {
+  volume_ = std::clamp(volume, 0.0, 1.0);
+  applyVolume();
+}
+
+void PreviewAudioController::setMuted(bool muted) {
+  muted_ = muted;
+  applyVolume();
+}
+
+void PreviewAudioController::feed() {
+  if (state_ != State::kPlaying || !output_ || !reader_) {
+    return;
+  }
+
+  // Sample starvation before topping up: once the device has been refilled
+  // there is nothing left to tell that it had run dry since the last tick.
+  const bool starved = fed_pairs_ > 0 && playedPairs() >= fed_pairs_;
+
+  // Anything the device refused last time goes in first: the stream must stay
+  // contiguous for the played-pairs → frame mapping to hold.
+  writePending();
+
+  while (pending_offset_ >= pending_.size() && !feedExhausted() &&
+         bufferedPairs() < lead_target_pairs_) {
+    pending_ = reader_->readFrames(feed_cursor_, kFeedChunkFrames);
+    pending_offset_ = 0;
+    feed_cursor_ = std::min(feed_cursor_ + kFeedChunkFrames, range_.last + 1);
+    if (pending_.empty()) {
+      // Nothing readable at the cursor; the loop still terminates because the
+      // cursor advanced, and the drain check below closes out the session.
+      continue;
+    }
+    writePending();
+  }
+
+  if (feedExhausted() && pendingPairs() == 0 && playedPairs() >= fed_pairs_) {
+    ORC_LOG_DEBUG(
+        "PreviewAudioController: Reached the end of the audio range after {} "
+        "stereo pairs",
+        fed_pairs_);
+    finish();
+    return;
+  }
+
+  if (starved) {
+    // The device consumed everything queued while frames remain. The clock
+    // stalls rather than drifts, so the video chase stalls with it, and the
+    // refill above resumes the stream exactly where it left off — nothing to
+    // correct, only something to report.
+    ++underrun_count_;
+    ORC_LOG_DEBUG(
+        "PreviewAudioController: Audio underrun at stereo pair {} (frame {})",
+        fed_pairs_, feed_cursor_);
+    emit underrunDetected();
+  }
+}
+
+uint64_t PreviewAudioController::playedPairs() const {
+  if (!output_) {
+    return 0;
+  }
+  const uint64_t played = preview_audio::stereoPairsPlayed(
+      output_->playedMicroseconds(), orc::kAudioSampleRateHz);
+  return std::min(played, fed_pairs_);
+}
+
+uint64_t PreviewAudioController::pendingPairs() const {
+  if (pending_offset_ >= pending_.size()) {
+    return 0;
+  }
+  return (pending_.size() - pending_offset_) / kAudioChannels;
+}
+
+uint64_t PreviewAudioController::bufferedPairs() const {
+  return (fed_pairs_ - playedPairs()) + pendingPairs();
+}
+
+bool PreviewAudioController::feedExhausted() const {
+  return range_.empty() || feed_cursor_ > range_.last;
+}
+
+void PreviewAudioController::writePending() {
+  while (pending_offset_ < pending_.size()) {
+    const size_t offered = static_cast<size_t>(pendingPairs());
+    const size_t accepted =
+        output_->write(pending_.data() + pending_offset_, offered);
+    if (accepted == 0) {
+      return;  // Device full; the tail waits for the next tick.
+    }
+    pending_offset_ += accepted * kAudioChannels;
+    fed_pairs_ += accepted;
+  }
+  pending_.clear();
+  pending_offset_ = 0;
+}
+
+void PreviewAudioController::applyVolume() {
+  if (!output_) {
+    return;
+  }
+  // Squared taper: a linear slider then tracks perceived loudness reasonably
+  // well. Muting is amplitude only — the device keeps consuming, so the clock
+  // and the video chase are unaffected.
+  output_->setVolume(muted_ ? 0.0 : volume_ * volume_);
+}
+
+void PreviewAudioController::finish() {
+  stop();
+  emit finished();
+}
+
+}  // namespace orc::gui

--- a/orc/gui/preview_audio_controller.h
+++ b/orc/gui/preview_audio_controller.h
@@ -1,0 +1,208 @@
+/*
+ * File:        preview_audio_controller.h
+ * Module:      orc-gui
+ * Purpose:     Audio-mastered playback session for the preview dialogue
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <audio_stream_reader.h>  // IAudioStreamReader
+#include <orc/stage/frame_id.h>   // FrameID, FrameIDRange
+
+#include <QObject>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "audio_output.h"
+
+class QTimer;
+
+namespace orc::gui {
+
+/**
+ * @brief Plays one audio channel pair and tells the preview what frame to show.
+ *
+ * Preview rendering cannot be relied on to reach real time — a heavy DAG can
+ * take seconds per frame — so the audio device is the clock and the video
+ * chases it. The controller feeds the device continuously at 1× and, on every
+ * playback tick, reports the preview index whose audio the device has actually
+ * reached. Frames the renderer could not deliver in time are simply skipped by
+ * the target jumping more than one index; no frame-dropping machinery is
+ * needed beyond that.
+ *
+ * Because the clock is derived from audio the device has consumed, an underrun
+ * stalls the chase instead of desynchronising it: the target stops advancing
+ * until the device is fed again, and the frame ↔ stream-position mapping stays
+ * exact because samples are always fed contiguously from the start frame.
+ *
+ * The reader must already be primed — prime() can take minutes on an EFM or
+ * TBC source and belongs behind a progress dialogue on the caller's side.
+ *
+ * Thread affinity: GUI thread. Reads from the reader are cheap once primed
+ * (an O(1) vector copy per frame), so the feeder runs on the GUI thread's
+ * timer; moving it to a worker later needs no interface change because the
+ * reader's read methods are already safe from one other thread.
+ */
+class PreviewAudioController : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit PreviewAudioController(QObject* parent = nullptr);
+  ~PreviewAudioController() override;
+
+  /**
+   * @brief Install the audio device.
+   *
+   * Takes ownership. Passing nullptr (what createSystemAudioOutput() returns
+   * when there is no backend) leaves the controller inert: start() fails and
+   * the dialogue keeps its video-only playback. Stops any playback in
+   * progress.
+   */
+  void setAudioOutput(std::unique_ptr<IAudioOutput> output);
+
+  /// Whether an audio device is installed and playback is possible at all.
+  bool hasAudioOutput() const { return output_ != nullptr; }
+
+  /**
+   * @brief Install the channel-pair reader for the session.
+   *
+   * Takes a share of the reader, which keeps the underlying representation
+   * alive for as long as playback needs it. Stops any playback in progress —
+   * a new reader means a new node, pair or DAG version.
+   */
+  void setReader(std::shared_ptr<orc::presenters::IAudioStreamReader> reader);
+
+  /// Whether a reader is installed.
+  bool hasReader() const { return reader_ != nullptr; }
+
+  /**
+   * @brief Preview items per video frame at the viewed output.
+   *
+   * 1 for a frame-indexed output, 2 for a field-indexed one. Audio maps to
+   * whole frames either way; this only scales the reported target index.
+   */
+  void setItemsPerFrame(uint32_t items_per_frame);
+  uint32_t itemsPerFrame() const { return items_per_frame_; }
+
+  /**
+   * @brief Open the device and begin playing from @p first_frame.
+   *
+   * @return false when there is no output or reader, when the frame is outside
+   *         the reader's range, or when the device refused to start.
+   */
+  bool start(orc::FrameID first_frame);
+
+  /// Stop the device, discard queued audio and keep the reader for a restart.
+  void stop();
+
+  /**
+   * @brief Move the playback position to @p frame.
+   *
+   * Restarts the device from the new position when playing, so the clock is
+   * always rebased by construction rather than corrected; when stopped it just
+   * records where the next start() begins.
+   */
+  void seek(orc::FrameID frame);
+
+  bool isPlaying() const { return state_ == State::kPlaying; }
+
+  /// Frame the playback started from (also where a stopped controller sits).
+  orc::FrameID startFrame() const { return start_frame_; }
+
+  /**
+   * @brief Video frame the device's audio clock has reached.
+   *
+   * Clamped to the reader's range. Equals startFrame() when not playing.
+   */
+  orc::FrameID targetFrame() const;
+
+  /// targetFrame() expressed as a preview item index (see setItemsPerFrame).
+  uint64_t targetPreviewIndex() const;
+
+  /**
+   * @brief Set the playback volume from a linear 0.0–1.0 control.
+   *
+   * Forwarded to the device as volume², which approximates perceptual loudness
+   * for a linear slider. Applies live and is retained across sessions.
+   */
+  void setVolume(double volume);
+  double volume() const { return volume_; }
+
+  /// Mute without pausing: the clock runs on and the video keeps chasing.
+  void setMuted(bool muted);
+  bool isMuted() const { return muted_; }
+
+  /// Underruns observed since the last start(); exposed for tests and logging.
+  uint64_t underrunCount() const { return underrun_count_; }
+
+ public slots:
+  /**
+   * @brief Top the device up and check for drain or underrun.
+   *
+   * Driven by the internal timer while playing; called directly by tests so
+   * they need no event loop.
+   */
+  void feed();
+
+ signals:
+  /// The last frame's audio has finished playing. The controller is stopped.
+  void finished();
+
+  /// The device ran dry mid-stream; the chase stalls until it is fed again.
+  void underrunDetected();
+
+ private:
+  enum class State { kStopped, kPlaying };
+
+  // Stereo pairs the device has consumed, never more than has been fed: a
+  // device reporting further would push the chase past audio nobody has heard.
+  uint64_t playedPairs() const;
+
+  // Pairs read from the reader but not yet accepted by the device.
+  uint64_t pendingPairs() const;
+
+  // Pairs read from the reader and not yet played, queued or pending.
+  uint64_t bufferedPairs() const;
+
+  // Whether every frame in range has been read into the feed path.
+  bool feedExhausted() const;
+
+  // Push as much of the pending buffer into the device as it will take.
+  void writePending();
+
+  // Send the current volume/mute state to the device.
+  void applyVolume();
+
+  // Stop and report the end of the stream.
+  void finish();
+
+  std::unique_ptr<IAudioOutput> output_;
+  std::shared_ptr<orc::presenters::IAudioStreamReader> reader_;
+  QTimer* feed_timer_ = nullptr;
+
+  State state_ = State::kStopped;
+  uint32_t items_per_frame_ = 1;
+
+  // Frames are fed contiguously from here, so played pairs map back to an
+  // absolute stream position without any per-underrun bookkeeping.
+  orc::FrameID start_frame_ = 0;
+  orc::FrameID feed_cursor_ = 0;
+  orc::FrameIDRange range_{1, 0};  // Empty until a reader is installed
+
+  uint64_t fed_pairs_ = 0;
+  uint64_t lead_target_pairs_ = 0;
+  uint64_t underrun_count_ = 0;
+
+  // Samples read from the reader that the device would not take yet.
+  std::vector<float> pending_;
+  size_t pending_offset_ = 0;  // Floats already accepted from pending_
+
+  double volume_ = 1.0;
+  bool muted_ = false;
+};
+
+}  // namespace orc::gui

--- a/orc/gui/previewdialog.cpp
+++ b/orc/gui/previewdialog.cpp
@@ -18,21 +18,28 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QMoveEvent>
+#include <QProgressDialog>
 #include <QPushButton>
 #include <QResizeEvent>
 #include <QScreen>
 #include <QSettings>
 #include <QShowEvent>
+#include <QSignalBlocker>
 #include <QStatusBar>
+#include <QThread>
 #include <QVBoxLayout>
 #include <algorithm>
+#include <limits>
+#include <utility>
 
+#include "audio_channel_pair_notice.h"
 #include "fieldpreviewwidget.h"
 #include "framescopedialog.h"
 #include "frametimingdialog.h"
 #include "logging.h"
 #include "preview/histogram_dialog.h"
 #include "preview/vectorscope_dialog.h"
+#include "preview_audio_chase.h"
 #include "stage_help_dialog.h"
 #include "waveformmonitordialog.h"
 
@@ -44,6 +51,19 @@ constexpr const char* kWaveformMonitorViewId = "preview.frame_timing";
 constexpr const char* kComponentVectorscopeViewId = "preview.vectorscope";
 constexpr const char* kHistogramViewId = "preview.histogram";
 
+// Combo entry that plays nothing — it is also how the user silences playback,
+// so it is named for both. Always present, so the selector reads the same
+// whether or not the node happens to carry audio.
+constexpr const char* kNoAudioEntry = "Mute/None";
+
+// Preparing audio is usually instantaneous (a CVBS source reads its WAV per
+// frame) but can take minutes (an EFM disc decode). Only put a dialog on
+// screen once the wait has become long enough to need explaining.
+constexpr int kAudioPrimeDialogDelayMs = 400;
+
+// How often the prime dialog picks up the worker's published progress.
+constexpr int kAudioPrimeTickMs = 200;
+
 }  // namespace
 
 PreviewDialog::PreviewDialog(QWidget* parent)
@@ -53,24 +73,41 @@ PreviewDialog::PreviewDialog(QWidget* parent)
       waveform_monitor_dialog_(nullptr),
       vectorscope_dialog_(nullptr),
       nav_debounce_timer_(new QTimer(this)),
-      playback_timer_(new QTimer(this)) {
+      playback_timer_(new QTimer(this)),
+      audio_controller_(new orc::gui::PreviewAudioController(this)),
+      audio_prime_show_timer_(new QTimer(this)),
+      audio_prime_tick_timer_(new QTimer(this)) {
   nav_debounce_timer_->setSingleShot(true);
   nav_debounce_timer_->setInterval(100);  // ms: coalesces rapid scrub moves
-  connect(nav_debounce_timer_, &QTimer::timeout,
-          [this]() { emit renderRequested(currentIndex()); });
+  connect(nav_debounce_timer_, &QTimer::timeout, this, [this]() {
+    // The scrub has settled: audio suspended by the drag resumes here, at the
+    // position the render about to be requested will show.
+    resumeAudioAtCurrentIndex();
+    emit renderRequested(currentIndex());
+  });
 
   // ITU-R BT.470-6 §5.1 (PAL 25 fps) / SMPTE 170M-2004 §2 (NTSC ~30 fps).
   // Default to PAL rate; MainWindow calls setPlaybackFrameRateMs() once it
-  // knows the video standard.
+  // knows the video standard. With audio playing the interval only sets how
+  // often the chase target is re-read; the audio device sets the pace.
   playback_timer_->setInterval(40);
-  connect(playback_timer_, &QTimer::timeout, [this]() {
-    const int next = currentIndex() + 1;
-    if (next > preview_slider_->maximum()) {
-      stopPlayback();
-      return;
-    }
-    navigateToIndex(next);
-  });
+  connect(playback_timer_, &QTimer::timeout, this,
+          &PreviewDialog::onPlaybackTick);
+
+  // The last frame's audio finishing is what ends an audio-clocked session:
+  // the video may still be several frames behind, but there is nothing left
+  // to chase.
+  connect(audio_controller_, &orc::gui::PreviewAudioController::finished, this,
+          &PreviewDialog::stopPlayback);
+
+  audio_prime_show_timer_->setSingleShot(true);
+  audio_prime_show_timer_->setInterval(kAudioPrimeDialogDelayMs);
+  connect(audio_prime_show_timer_, &QTimer::timeout, this,
+          &PreviewDialog::showAudioPrimeDialog);
+
+  audio_prime_tick_timer_->setInterval(kAudioPrimeTickMs);
+  connect(audio_prime_tick_timer_, &QTimer::timeout, this,
+          &PreviewDialog::updateAudioPrimeDialog);
 
   setupUI();
   setWindowTitle("Field/Frame Preview");
@@ -122,6 +159,7 @@ void PreviewDialog::navigateToIndex(int zero_based) {
                                  preview_slider_->maximum());
   nav_debounce_timer_->stop();  // cancel any pending debounced render
   setIndex(clamped);
+  resumeAudioAtCurrentIndex();  // rebase the audio clock on the new position
   emit positionChanged(clamped);
   emit renderRequested(clamped);
 }
@@ -130,6 +168,7 @@ void PreviewDialog::navigateToIndexDebounced(int zero_based) {
   const int clamped = std::clamp(zero_based, preview_slider_->minimum(),
                                  preview_slider_->maximum());
   setIndex(clamped);  // update UI immediately for visual feedback
+  suspendAudioForScrub();
   emit positionChanged(clamped);
   nav_debounce_timer_
       ->start();  // (re)starts; fires renderRequested when settled
@@ -362,6 +401,8 @@ void PreviewDialog::setupUI() {
   dropouts_button_->setToolTip("Show/hide dropout regions");
   controlLayout->addWidget(dropouts_button_);
 
+  setupAudioControls(controlLayout);
+
   controlLayout->addStretch();
   mainLayout->addLayout(controlLayout);
 
@@ -409,9 +450,7 @@ void PreviewDialog::setupUI() {
       if (currentIndex() >= preview_slider_->maximum()) {
         navigateToIndex(preview_slider_->minimum());
       }
-      is_playing_ = true;
-      play_pause_button_->setText("⏸");  // ⏸ pause symbol
-      playback_timer_->start();
+      startPlayback();
     }
   });
 
@@ -525,10 +564,16 @@ void PreviewDialog::setPlaybackFrameRateMs(int ms) {
 }
 
 void PreviewDialog::stopPlayback() {
+  // Audio teardown runs unconditionally: a session can be waiting for a reader
+  // or priming before is_playing_ has ever driven the timer.
+  endAudioPreparation();
+  audio_controller_->stop();
+  audio_state_ = AudioState::kIdle;
+  playback_timer_->stop();
+
   if (!is_playing_) {
     return;
   }
-  playback_timer_->stop();
   is_playing_ = false;
   play_pause_button_->setText("▶");  // ▶ play symbol
 }
@@ -541,12 +586,445 @@ void PreviewDialog::setCurrentNode(const QString& node_label,
 }
 
 void PreviewDialog::setCurrentNodeId(orc::NodeID node_id) {
+  // Pair indices and the representation behind a reader are both node-
+  // specific, so a different node invalidates everything audio holds. The
+  // owner re-enumerates and calls setAudioChannelPairs() with the new list.
+  if (node_id != current_node_id_) {
+    invalidateAudioSource();
+    setAudioChannelPairs({});
+  }
+
   current_node_id_ = node_id;
 
   if (vectorscope_dialog_ && vectorscope_dialog_->isVisible() &&
       node_id.is_valid()) {
     vectorscope_node_id_ = node_id;
     vectorscope_dialog_->setStage(node_id);
+  }
+}
+
+// ===========================================================================
+// Audio playback
+// ===========================================================================
+
+void PreviewDialog::setupAudioControls(QHBoxLayout* layout) {
+  audio_label_ = new QLabel("Audio:");
+  layout->addWidget(audio_label_);
+
+  audio_pair_combo_ = new QComboBox();
+  layout->addWidget(audio_pair_combo_);
+
+  audio_volume_slider_ = new QSlider(Qt::Horizontal);
+  audio_volume_slider_->setRange(0, 100);  // per cent of full scale
+  audio_volume_slider_->setValue(100);
+  audio_volume_slider_->setFixedWidth(80);
+  audio_volume_slider_->setToolTip("Playback volume");
+  layout->addWidget(audio_volume_slider_);
+
+  connect(audio_pair_combo_,
+          QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          [this](int) {
+            // Only user-driven changes reach here: repopulating blocks the
+            // signal, so this is the choice worth carrying to the next node.
+            rememberSelectedAudioPair();
+            // A different pair needs a different reader, and the running
+            // session belongs to the old one. Playback is torn down and then
+            // taken up again on the new pair at the position reached, so
+            // comparing pairs does not cost a trip back to the Play button.
+            const bool was_playing = is_playing_;
+            invalidateAudioSource();
+            updateAudioControlStates();
+            if (was_playing) {
+              startPlayback();
+            }
+          });
+
+  connect(audio_volume_slider_, &QSlider::valueChanged, this,
+          [this](int value) {
+            audio_controller_->setVolume(static_cast<double>(value) / 100.0);
+          });
+
+#ifndef ORC_GUI_AUDIO_PLAYBACK
+  // Built without an audio backend: these controls could never do anything, so
+  // they are not offered at all and playback keeps its video-only path.
+  audio_label_->setVisible(false);
+  audio_pair_combo_->setVisible(false);
+  audio_volume_slider_->setVisible(false);
+#endif
+
+  setAudioChannelPairs({});
+}
+
+void PreviewDialog::setAudioChannelPairs(
+    const std::vector<orc::AudioPairView>& pairs) {
+  audio_pairs_ = pairs;
+
+  // Repopulating resets the selection, which must not be read as the user
+  // picking a different pair.
+  const QSignalBlocker block(audio_pair_combo_);
+  audio_pair_combo_->clear();
+  audio_pair_combo_->addItem(kNoAudioEntry);
+  for (const auto& pair : audio_pairs_) {
+    const QString name =
+        QString::fromStdString(pair.name.empty() ? pair.origin : pair.name);
+    const QString label =
+        QString("%1: %2").arg(static_cast<qulonglong>(pair.index)).arg(name);
+    audio_pair_combo_->addItem(label, QVariant::fromValue<qulonglong>(
+                                          static_cast<qulonglong>(pair.index)));
+  }
+  audio_pair_combo_->setCurrentIndex(comboIndexForRememberedPair());
+
+  updateAudioControlStates();
+}
+
+void PreviewDialog::rememberSelectedAudioPair() {
+  const int index = audio_pair_combo_->currentIndex();
+  const size_t pair_index = static_cast<size_t>(index - 1);  // 0 is "Mute/None"
+  if (index <= 0 || pair_index >= audio_pairs_.size()) {
+    remembered_audio_pair_.reset();  // "Mute/None" is a choice worth keeping
+    return;
+  }
+  remembered_audio_pair_ = audio_pairs_[pair_index];
+}
+
+int PreviewDialog::comboIndexForRememberedPair() const {
+  if (!remembered_audio_pair_.has_value()) {
+    return 0;  // "Mute/None"
+  }
+
+  // Pair indices are node-specific, so the remembered pair is matched by what
+  // describes it — name and origin — and the index only breaks ties between
+  // otherwise identical pairs. No match means this node does not carry the
+  // pair and the selector falls back to "Mute/None", leaving the choice
+  // remembered for a node that does.
+  const orc::AudioPairView& want = *remembered_audio_pair_;
+  int fallback = 0;
+  for (size_t i = 0; i < audio_pairs_.size(); ++i) {
+    const orc::AudioPairView& pair = audio_pairs_[i];
+    if (pair.name != want.name || pair.origin != want.origin) {
+      continue;
+    }
+    const int combo_index = static_cast<int>(i) + 1;  // 0 is "Mute/None"
+    if (pair.index == want.index) {
+      return combo_index;
+    }
+    if (fallback == 0) {
+      fallback = combo_index;
+    }
+  }
+  return fallback;
+}
+
+void PreviewDialog::updateAudioControlStates() {
+  const bool has_pairs = !audio_pairs_.empty();
+  const bool pair_selected = selectedAudioPair().has_value();
+
+  audio_label_->setEnabled(has_pairs);
+  audio_pair_combo_->setEnabled(has_pairs);
+  // Volume acts on a selected pair whether or not it is playing, so the level
+  // can be set before pressing Play.
+  audio_volume_slider_->setEnabled(pair_selected);
+
+  audio_pair_combo_->setToolTip(
+      has_pairs
+          ? QString("Audio channel pair to play with the preview")
+          : QString::fromStdString(orc::gui::audioChannelPairPreviewNotice()));
+}
+
+std::optional<size_t> PreviewDialog::selectedAudioPair() const {
+  const QVariant data = audio_pair_combo_->currentData();
+  if (!data.isValid()) {
+    return std::nullopt;  // "Mute/None"
+  }
+  return static_cast<size_t>(data.toULongLong());
+}
+
+bool PreviewDialog::isAudioPlaybackActive() const {
+  return audio_state_ == AudioState::kPlaying;
+}
+
+void PreviewDialog::setAudioOutput(
+    std::unique_ptr<orc::gui::IAudioOutput> output) {
+  audio_controller_->setAudioOutput(std::move(output));
+}
+
+void PreviewDialog::setAudioItemsPerFrame(uint32_t items_per_frame) {
+  audio_controller_->setItemsPerFrame(items_per_frame);
+}
+
+void PreviewDialog::invalidateAudioSource() {
+  stopPlayback();
+  audio_reader_.reset();
+  audio_reader_pair_.reset();
+  audio_controller_->setReader(nullptr);
+}
+
+void PreviewDialog::startPlayback() {
+  const std::optional<size_t> pair = selectedAudioPair();
+  if (!pair.has_value() || !ensureAudioOutput()) {
+    beginVideoOnlyPlayback();
+    return;
+  }
+
+  // Playback intent is taken now, before the reader exists: preparing audio
+  // can take a while and pressing Play again must cancel it.
+  is_playing_ = true;
+  play_pause_button_->setText("⏸");  // ⏸ pause symbol
+
+  if (audio_reader_ && audio_reader_pair_ == pair) {
+    beginAudioPlayback();  // Already primed — resume costs nothing
+    return;
+  }
+
+  audio_state_ = AudioState::kAwaitingReader;
+  status_bar_->showMessage("Preparing audio…");
+  emit audioStreamReaderRequested(*pair);
+}
+
+void PreviewDialog::beginVideoOnlyPlayback() {
+  audio_state_ = AudioState::kIdle;
+  is_playing_ = true;
+  play_pause_button_->setText("⏸");  // ⏸ pause symbol
+  playback_timer_->start();
+}
+
+bool PreviewDialog::ensureAudioOutput() {
+  if (audio_controller_->hasAudioOutput()) {
+    return true;
+  }
+  if (audio_output_unavailable_) {
+    return false;
+  }
+
+  // First playback with a pair selected is what touches the audio subsystem;
+  // a project with no audio never gets here.
+  auto output = orc::gui::createSystemAudioOutput();
+  if (!output) {
+    ORC_LOG_WARN(
+        "PreviewDialog: No audio output backend; playing the preview silently");
+    audio_output_unavailable_ = true;
+    status_bar_->showMessage("No audio output is available; playing video only",
+                             4000);
+    return false;
+  }
+  audio_controller_->setAudioOutput(std::move(output));
+  return true;
+}
+
+void PreviewDialog::setAudioStreamReader(
+    std::shared_ptr<orc::presenters::IAudioStreamReader> reader) {
+  if (audio_state_ != AudioState::kAwaitingReader) {
+    return;  // Superseded: playback was stopped or the pair changed
+  }
+
+  const std::optional<size_t> pair = selectedAudioPair();
+  if (!reader || !pair.has_value()) {
+    ORC_LOG_DEBUG("PreviewDialog: No playable audio for the selected pair");
+    status_bar_->showMessage(
+        "The selected channel pair has no playable audio; playing video only",
+        4000);
+    beginVideoOnlyPlayback();
+    return;
+  }
+
+  audio_reader_ = std::move(reader);
+  audio_reader_pair_ = pair;
+  beginAudioPrime();
+}
+
+void PreviewDialog::beginAudioPrime() {
+  audio_state_ = AudioState::kPriming;
+  ++audio_prime_generation_;
+  const uint64_t generation = audio_prime_generation_;
+
+  audio_prime_state_ = std::make_shared<AudioPrimeProgressState>();
+  auto reader = audio_reader_;
+  auto state = audio_prime_state_;
+
+  // The decode runs off the GUI thread (and off the render worker, which it
+  // would otherwise block for its whole duration). Progress is published into
+  // the shared state and polled here, so the worker never touches a Qt object.
+  // The thread owns a share of the reader, so it stays valid even if the
+  // dialogue abandons the wait.
+  auto* thread = QThread::create([reader, state]() {
+    try {
+      reader->prime(
+          [state](uint64_t done, uint64_t total, const std::string& message) {
+            const std::lock_guard<std::mutex> lock(state->mutex);
+            state->done = done;
+            state->total = total;
+            state->message = message;
+          });
+    } catch (const std::exception& e) {
+      ORC_LOG_ERROR("PreviewDialog: Audio priming failed: {}", e.what());
+    } catch (...) {
+      ORC_LOG_ERROR("PreviewDialog: Audio priming failed");
+    }
+  });
+  connect(thread, &QThread::finished, this,
+          [this, generation]() { finishAudioPrime(generation); });
+  connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+  thread->start();
+
+  audio_prime_show_timer_->start();
+}
+
+void PreviewDialog::finishAudioPrime(uint64_t generation) {
+  if (generation != audio_prime_generation_ ||
+      audio_state_ != AudioState::kPriming) {
+    return;  // The wait was abandoned; this decode's result is nobody's
+  }
+
+  endAudioPreparation();
+  audio_controller_->setReader(audio_reader_);
+  beginAudioPlayback();
+}
+
+void PreviewDialog::beginAudioPlayback() {
+  const uint64_t frame = orc::gui::preview_audio::frameForPreviewIndex(
+      static_cast<uint64_t>(std::max(0, currentIndex())),
+      audio_controller_->itemsPerFrame());
+
+  if (!audio_controller_->start(frame)) {
+    ORC_LOG_WARN("PreviewDialog: Audio playback could not start at frame {}",
+                 frame);
+    status_bar_->showMessage("Audio could not be started; playing video only",
+                             4000);
+    beginVideoOnlyPlayback();
+    return;
+  }
+
+  audio_state_ = AudioState::kPlaying;
+  is_playing_ = true;
+  play_pause_button_->setText("⏸");  // ⏸ pause symbol
+  status_bar_->clearMessage();
+  playback_timer_->start();
+}
+
+void PreviewDialog::onPlaybackTick() {
+  if (audio_state_ == AudioState::kPlaying) {
+    if (!audio_controller_->isPlaying()) {
+      stopPlayback();  // The device stopped under us
+      return;
+    }
+
+    // Frames the renderer could not deliver in time are skipped simply by the
+    // target having moved on by more than one; the in-flight gate above this
+    // dialogue coalesces the rest.
+    const uint64_t target = std::min<uint64_t>(
+        audio_controller_->targetPreviewIndex(),
+        static_cast<uint64_t>(std::max(0, preview_slider_->maximum())));
+    const int target_index = static_cast<int>(target);
+    if (target_index != currentIndex()) {
+      chase_navigation_ = true;
+      navigateToIndex(target_index);
+      chase_navigation_ = false;
+    }
+    return;
+  }
+
+  const int next = currentIndex() + 1;
+  if (next > preview_slider_->maximum()) {
+    stopPlayback();
+    return;
+  }
+  navigateToIndex(next);
+}
+
+void PreviewDialog::suspendAudioForScrub() {
+  if (chase_navigation_ || audio_state_ != AudioState::kPlaying) {
+    return;
+  }
+  // A drag emits a new position per mouse move, and rebasing the device on
+  // each one would thrash it. The clock instead goes quiet for the duration of
+  // the scrub and is restarted once the position settles; the chase stops with
+  // it so it cannot pull the preview off the position being dragged to.
+  playback_timer_->stop();
+  audio_controller_->stop();
+}
+
+void PreviewDialog::resumeAudioAtCurrentIndex() {
+  if (chase_navigation_ || audio_state_ != AudioState::kPlaying) {
+    return;
+  }
+  // Restarting the device at the settled position rebases the clock by
+  // construction, so no correction term is ever carried across a seek.
+  beginAudioPlayback();
+}
+
+void PreviewDialog::showAudioPrimeDialog() {
+  if (audio_state_ != AudioState::kPriming || audio_prime_dialog_) {
+    return;
+  }
+
+  // No cancel button: the decode runs inside a producer's std::call_once and
+  // nothing in that path is interruptible, so offering Cancel would be a lie.
+  auto* dialog = new QProgressDialog("Preparing audio…", QString(), 0, 0, this);
+  dialog->setWindowTitle("Preview Audio");
+  dialog->setWindowModality(Qt::WindowModal);
+  dialog->setCancelButton(nullptr);
+  dialog->setAutoClose(false);
+  dialog->setAutoReset(false);
+  dialog->setAttribute(Qt::WA_DeleteOnClose, false);
+  // QProgressDialog shows itself from an internal timer once minimumDuration
+  // elapses, which would race this one. Push it out of reach and reset() (which
+  // stops that timer) so the show decision stays here.
+  dialog->setMinimumDuration(std::numeric_limits<int>::max());
+  dialog->reset();
+  audio_prime_dialog_ = dialog;
+
+  updateAudioPrimeDialog();
+  dialog->show();
+  audio_prime_tick_timer_->start();
+}
+
+void PreviewDialog::updateAudioPrimeDialog() {
+  if (!audio_prime_dialog_ || !audio_prime_state_) {
+    return;
+  }
+
+  uint64_t done = 0;
+  uint64_t total = 0;
+  std::string message;
+  {
+    const std::lock_guard<std::mutex> lock(audio_prime_state_->mutex);
+    done = audio_prime_state_->done;
+    total = audio_prime_state_->total;
+    message = audio_prime_state_->message;
+  }
+
+  audio_prime_dialog_->setLabelText(
+      message.empty() ? QString("Preparing audio…")
+                      : QString("Preparing audio… %1")
+                            .arg(QString::fromStdString(message)));
+
+  // A producer that cannot size the work reports total 0; the dialog then
+  // stays a busy indicator (range 0..0) rather than claiming a percentage.
+  if (total > 0) {
+    audio_prime_dialog_->setRange(0, 100);
+    audio_prime_dialog_->setValue(
+        static_cast<int>(std::min<uint64_t>(99, done * 100 / total)));
+  }
+}
+
+void PreviewDialog::endAudioPreparation() {
+  // Bumping the generation orphans any prime still running: it finishes,
+  // releases its share of the reader and self-deletes with nobody listening.
+  ++audio_prime_generation_;
+  audio_prime_state_.reset();
+  audio_prime_show_timer_->stop();
+  audio_prime_tick_timer_->stop();
+
+  if (audio_prime_dialog_) {
+    audio_prime_dialog_->hide();
+    audio_prime_dialog_->deleteLater();
+    audio_prime_dialog_ = nullptr;
+  }
+
+  if (audio_state_ == AudioState::kAwaitingReader ||
+      audio_state_ == AudioState::kPriming) {
+    audio_state_ = AudioState::kIdle;
+    status_bar_->clearMessage();
   }
 }
 

--- a/orc/gui/previewdialog.h
+++ b/orc/gui/previewdialog.h
@@ -14,6 +14,7 @@
 #include <orc/stage/node_id.h>
 #include <orc/stage/preview/orc_preview_types.h>
 #include <orc/stage/preview/orc_vectorscope.h>
+#include <orc_audio_views.h>
 #include <orc_preview_views.h>
 
 #include <QComboBox>
@@ -28,18 +29,24 @@
 #include <QTimer>
 #include <QVBoxLayout>
 #include <cstdint>
+#include <memory>
+#include <mutex>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "presenters/include/hints_view_models.h"  // For VideoParametersView
 #include "presenters/include/project_presenter_types.h"  // For VideoFormat
+#include "preview_audio_controller.h"  // PreviewAudioController, IAudioOutput
 
 class FieldPreviewWidget;
 class FrameScopeDialog;
 class FrameTimingDialog;
 class HistogramDialog;
+class QHBoxLayout;
+class QProgressDialog;
 class VectorscopeDialog;
 class WaveformMonitorDialog;
 
@@ -116,6 +123,83 @@ class PreviewDialog : public QDialog {
   QPushButton* playPauseButton() {
     return play_pause_button_;
   }  ///< Get play/pause button
+  QComboBox* audioPairCombo() {
+    return audio_pair_combo_;
+  }  ///< Get audio channel-pair selector
+  QSlider* audioVolumeSlider() {
+    return audio_volume_slider_;
+  }  ///< Get audio volume slider
+  /// @}
+
+  /// @name Audio playback
+  /// @{
+
+  /**
+   * @brief Playback session that makes audio the clock and video chase it.
+   *
+   * Owned by the dialogue and shared with tests, which drive it through a
+   * mocked IAudioOutput rather than a real device.
+   */
+  orc::gui::PreviewAudioController* audioController() {
+    return audio_controller_;
+  }
+
+  /**
+   * @brief Populate the channel-pair selector for the viewed node.
+   *
+   * An empty list is the normal "this node has no audio" answer: the selector
+   * shows a disabled "Mute/None" entry and the volume control is disabled with
+   * it.
+   *
+   * The pair the user last picked is re-selected if this node carries it, so
+   * switching stages keeps the audio playing rather than silently reverting to
+   * "Mute/None"; a node without that pair falls back to "Mute/None" but does
+   * not forget the choice.
+   */
+  void setAudioChannelPairs(const std::vector<orc::AudioPairView>& pairs);
+
+  /**
+   * @brief Install the audio device instead of the platform one.
+   *
+   * Production code never calls this: the dialogue creates the platform output
+   * lazily when playback with a pair selected first starts, so a project with
+   * no audio never touches the audio subsystem. Tests install a device-free
+   * stand-in up front.
+   */
+  void setAudioOutput(std::unique_ptr<orc::gui::IAudioOutput> output);
+
+  /**
+   * @brief Deliver a reader requested via audioStreamReaderRequested().
+   *
+   * A null reader means the pair turned out to be unplayable; playback then
+   * falls back to the timer-paced video-only path. Ignored unless the dialogue
+   * is still waiting for this reader.
+   */
+  void setAudioStreamReader(
+      std::shared_ptr<orc::presenters::IAudioStreamReader> reader);
+
+  /**
+   * @brief Preview items per video frame at the viewed output (1 or 2).
+   *
+   * Audio maps to whole frames, so a field-indexed output advances two preview
+   * indices per frame period. Set whenever the output type changes.
+   */
+  void setAudioItemsPerFrame(uint32_t items_per_frame);
+
+  /// Channel pair the user has selected, or empty for "Mute/None".
+  std::optional<size_t> selectedAudioPair() const;
+
+  /// True while the audio clock is driving the preview position.
+  bool isAudioPlaybackActive() const;
+
+  /**
+   * @brief Drop the cached reader and stop any playback using it.
+   *
+   * The reader holds a resolved representation alive, so it is only valid for
+   * the DAG version it was created from. Call whenever the DAG, its parameters
+   * or the project change.
+   */
+  void invalidateAudioSource();
   /// @}
 
   /**
@@ -351,6 +435,14 @@ class PreviewDialog : public QDialog {
    */
   void stopPlayback();
 
+  /**
+   * @brief True while playback is running (or being prepared).
+   *
+   * The owner uses this to render with PreviewNavigationHint::Sequential, so
+   * stages know a run of adjacent frames is coming and may pre-fetch.
+   */
+  bool isPlaying() const { return is_playing_; }
+
  Q_SIGNALS:
   /**
    * Emitted whenever the current index changes (every navigate/scrub).
@@ -404,6 +496,12 @@ class PreviewDialog : public QDialog {
   void previewCoordinateChanged(
       const orc::PreviewCoordinate&
           coordinate);  // Emitted whenever shared coordinate changes
+  /**
+   * Emitted when playback needs a reader for the selected channel pair.
+   * Creating one executes the DAG, so the owner routes it through the render
+   * coordinator and answers with setAudioStreamReader().
+   */
+  void audioStreamReaderRequested(size_t pair);
 
  private slots:
   void onSampleMarkerMoved(int sample_x);
@@ -412,6 +510,47 @@ class PreviewDialog : public QDialog {
 
  private:
   void setupUI();
+
+  // Audio playback session state. Reader creation and the deferred whole-
+  // stream decode behind it both take an unbounded amount of time, so pressing
+  // Play with a pair selected walks through them before any audio starts.
+  enum class AudioState {
+    kIdle,            ///< No audio session (video-only playback or stopped)
+    kAwaitingReader,  ///< Reader requested from the owner, not yet delivered
+    kPriming,         ///< Deferred decode running on the prime thread
+    kPlaying          ///< Audio is the clock and the video is chasing it
+  };
+
+  // Progress published by the prime thread. Polled from the GUI thread rather
+  // than signalled, so the worker never touches a Qt object it does not own.
+  struct AudioPrimeProgressState {
+    std::mutex mutex;
+    uint64_t done = 0;
+    uint64_t total = 0;
+    std::string message;
+  };
+
+  void setupAudioControls(QHBoxLayout* layout);
+  void updateAudioControlStates();
+
+  // Selection carried across the repopulate that follows a stage change.
+  void rememberSelectedAudioPair();
+  int comboIndexForRememberedPair() const;
+
+  // Playback entry points. startPlayback() picks the audio or the legacy
+  // video-only path from the current selection; the others are its steps.
+  void startPlayback();
+  void beginVideoOnlyPlayback();
+  void beginAudioPlayback();
+  bool ensureAudioOutput();
+  void beginAudioPrime();
+  void finishAudioPrime(uint64_t generation);
+  void endAudioPreparation();
+  void showAudioPrimeDialog();
+  void updateAudioPrimeDialog();
+  void onPlaybackTick();
+  void suspendAudioForScrub();
+  void resumeAudioAtCurrentIndex();
 
   // UI components
   FieldPreviewWidget* preview_widget_;
@@ -473,6 +612,41 @@ class PreviewDialog : public QDialog {
   // Playback
   QTimer* playback_timer_;
   bool is_playing_{false};
+
+  // Audio playback
+  QLabel* audio_label_;
+  QComboBox* audio_pair_combo_;
+  QSlider* audio_volume_slider_;
+  orc::gui::PreviewAudioController* audio_controller_;
+  std::vector<orc::AudioPairView> audio_pairs_;
+
+  // Last pair the user picked, held as a descriptor rather than an index so it
+  // can be found again in another node's list. Survives nodes that offer no
+  // audio at all, so stepping past one does not lose the choice.
+  std::optional<orc::AudioPairView> remembered_audio_pair_;
+
+  // Reader for audio_reader_pair_, kept across pause/resume so restarting
+  // costs nothing; dropped whenever the representation behind it goes stale.
+  std::shared_ptr<orc::presenters::IAudioStreamReader> audio_reader_;
+  std::optional<size_t> audio_reader_pair_;
+
+  AudioState audio_state_{AudioState::kIdle};
+
+  // Set while the playback tick is driving navigation, so the chase target is
+  // not mistaken for a user seek and fed straight back into the audio clock.
+  bool chase_navigation_{false};
+
+  // Remembers that this machine has no audio backend, so playback does not
+  // retry the (failed) device creation on every press of Play.
+  bool audio_output_unavailable_{false};
+
+  // Bumped whenever a preparation step is abandoned. A prime thread cannot be
+  // interrupted, so its completion is matched against this instead.
+  uint64_t audio_prime_generation_{0};
+  std::shared_ptr<AudioPrimeProgressState> audio_prime_state_;
+  QProgressDialog* audio_prime_dialog_{nullptr};
+  QTimer* audio_prime_show_timer_;
+  QTimer* audio_prime_tick_timer_;
 
   void closeVectorscopeDialogs();
   void closeHistogramDialog();

--- a/orc/gui/qt_audio_output.cpp
+++ b/orc/gui/qt_audio_output.cpp
@@ -1,0 +1,182 @@
+/*
+ * File:        qt_audio_output.cpp
+ * Module:      orc-gui
+ * Purpose:     QAudioSink-backed IAudioOutput for preview audio playback
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "qt_audio_output.h"
+
+#include <QAudioDevice>
+#include <QAudioSink>
+#include <QIODevice>
+#include <QMediaDevices>
+#include <algorithm>
+#include <cmath>
+
+#include "logging.h"
+
+namespace orc::gui {
+
+namespace {
+
+// Float ±1.0 to signed 16-bit, matching the carrier-domain conversions in
+// orc/stage/audio/audio_sample_feed.h: a float sample is carrier / 8388608 and
+// the S16 feed is carrier >> 8, so full scale is ±32768 with the positive end
+// saturating at the int16 maximum.
+int16_t float_to_s16(float sample) {
+  const int64_t scaled = std::llround(sample * 32768.0f);
+  return static_cast<int16_t>(std::clamp<int64_t>(scaled, -32768, 32767));
+}
+
+}  // namespace
+
+QtAudioOutput::QtAudioOutput() = default;
+
+QtAudioOutput::~QtAudioOutput() { stop(); }
+
+bool QtAudioOutput::start(uint32_t sample_rate_hz, uint32_t channels) {
+  stop();
+
+  const QAudioDevice device = QMediaDevices::defaultAudioOutput();
+  if (device.isNull()) {
+    ORC_LOG_WARN("QtAudioOutput: No default audio output device available");
+    return false;
+  }
+
+  QAudioFormat format;
+  format.setSampleRate(static_cast<int>(sample_rate_hz));
+  format.setChannelCount(static_cast<int>(channels));
+  format.setSampleFormat(QAudioFormat::Float);
+
+  if (!device.isFormatSupported(format)) {
+    // Fall back to the format every device supports rather than resampling.
+    format.setSampleFormat(QAudioFormat::Int16);
+    if (!device.isFormatSupported(format)) {
+      ORC_LOG_WARN(
+          "QtAudioOutput: Device '{}' supports neither float nor 16-bit "
+          "{} Hz {}-channel output",
+          device.description().toStdString(), sample_rate_hz, channels);
+      return false;
+    }
+    ORC_LOG_DEBUG("QtAudioOutput: Device rejected float, using 16-bit output");
+  }
+
+  format_ = format;
+  sink_ = std::make_unique<QAudioSink>(device, format_);
+  sink_->setBufferSize(
+      format_.bytesForDuration(static_cast<qint64>(kDeviceBufferMs) * 1000));
+
+  push_device_ = sink_->start();
+  if (push_device_ == nullptr) {
+    ORC_LOG_WARN("QtAudioOutput: Failed to start audio sink (state {})",
+                 static_cast<int>(sink_->state()));
+    sink_.reset();
+    return false;
+  }
+
+  sink_->setVolume(volume_);
+
+  ORC_LOG_DEBUG(
+      "QtAudioOutput: Started {} Hz {}-channel {} output on '{}' ({} byte "
+      "buffer)",
+      sample_rate_hz, channels,
+      format_.sampleFormat() == QAudioFormat::Float ? "float" : "16-bit",
+      device.description().toStdString(), sink_->bufferSize());
+  return true;
+}
+
+void QtAudioOutput::stop() {
+  if (!sink_) {
+    return;
+  }
+  sink_->stop();
+  // The push device belongs to the sink and does not outlive it.
+  push_device_ = nullptr;
+  sink_.reset();
+}
+
+size_t QtAudioOutput::stereoPairsFree() const {
+  if (!sink_ || push_device_ == nullptr) {
+    return 0;
+  }
+  const int bytes_per_pair = format_.bytesPerFrame();
+  if (bytes_per_pair <= 0) {
+    return 0;
+  }
+  return static_cast<size_t>(sink_->bytesFree() / bytes_per_pair);
+}
+
+size_t QtAudioOutput::write(const float* interleaved, size_t stereo_pairs) {
+  if (!sink_ || push_device_ == nullptr || interleaved == nullptr ||
+      stereo_pairs == 0) {
+    return 0;
+  }
+
+  const int bytes_per_pair = format_.bytesPerFrame();
+  if (bytes_per_pair <= 0) {
+    return 0;
+  }
+
+  // Never offer more than the device can take: a partially accepted write
+  // would leave the caller re-queuing a tail it has to track anyway, and this
+  // keeps that case to what the device genuinely refused.
+  const size_t offered = std::min(stereo_pairs, stereoPairsFree());
+  if (offered == 0) {
+    return 0;
+  }
+
+  const size_t channels = static_cast<size_t>(format_.channelCount());
+  qint64 written_bytes = 0;
+
+  if (format_.sampleFormat() == QAudioFormat::Float) {
+    written_bytes = push_device_->write(
+        reinterpret_cast<const char*>(interleaved),
+        static_cast<qint64>(offered) * static_cast<qint64>(bytes_per_pair));
+  } else {
+    const size_t sample_count = offered * channels;
+    convert_buffer_.resize(sample_count);
+    for (size_t s = 0; s < sample_count; ++s) {
+      convert_buffer_[s] = float_to_s16(interleaved[s]);
+    }
+    written_bytes = push_device_->write(
+        reinterpret_cast<const char*>(convert_buffer_.data()),
+        static_cast<qint64>(offered) * static_cast<qint64>(bytes_per_pair));
+  }
+
+  if (written_bytes <= 0) {
+    return 0;
+  }
+
+  // A device that stops mid-pair would desynchronise the channels for the rest
+  // of the session; report only whole pairs so the caller re-sends the tail.
+  if (written_bytes % bytes_per_pair != 0) {
+    ORC_LOG_WARN(
+        "QtAudioOutput: Device accepted a partial stereo pair ({} of "
+        "{} bytes per pair)",
+        written_bytes % bytes_per_pair, bytes_per_pair);
+  }
+  return static_cast<size_t>(written_bytes / bytes_per_pair);
+}
+
+uint64_t QtAudioOutput::playedMicroseconds() const {
+  if (!sink_) {
+    return 0;
+  }
+  // processedUSecs() counts audio the device has consumed since start(), so it
+  // stalls on an underrun instead of running away from what is audible.
+  return static_cast<uint64_t>(sink_->processedUSecs());
+}
+
+void QtAudioOutput::setVolume(double linear) {
+  volume_ = std::clamp(linear, 0.0, 1.0);
+  if (sink_) {
+    // Applied at the device: already-queued samples are untouched, so a
+    // volume or mute change never flushes the buffer or disturbs the clock.
+    sink_->setVolume(static_cast<qreal>(volume_));
+  }
+}
+
+}  // namespace orc::gui

--- a/orc/gui/qt_audio_output.h
+++ b/orc/gui/qt_audio_output.h
@@ -1,0 +1,70 @@
+/*
+ * File:        qt_audio_output.h
+ * Module:      orc-gui
+ * Purpose:     QAudioSink-backed IAudioOutput for preview audio playback
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <QAudioFormat>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "audio_output.h"
+
+class QAudioSink;
+class QIODevice;
+
+namespace orc::gui {
+
+/**
+ * @brief IAudioOutput on top of Qt Multimedia's QAudioSink (push mode).
+ *
+ * Only compiled when ORC_GUI_AUDIO_PLAYBACK is on; everything else in the
+ * playback path is device-free so it builds either way. Nothing in Qt
+ * Multimedia is touched until start() is called, so a project with no audio
+ * never initialises the audio subsystem.
+ *
+ * Format: the requested rate with float samples, falling back to signed 16-bit
+ * when the device rejects float. The buffer is sized to ~200 ms, which is deep
+ * enough to ride out a late feed tick and shallow enough that the video chase
+ * stays within a couple of frame periods of what is audible.
+ *
+ * Thread safety: none, and QAudioSink requires a running event loop to drain
+ * the push device — construct and drive this from the GUI thread.
+ */
+class QtAudioOutput final : public IAudioOutput {
+ public:
+  QtAudioOutput();
+  ~QtAudioOutput() override;
+
+  QtAudioOutput(const QtAudioOutput&) = delete;
+  QtAudioOutput& operator=(const QtAudioOutput&) = delete;
+
+  bool start(uint32_t sample_rate_hz, uint32_t channels) override;
+  void stop() override;
+  size_t stereoPairsFree() const override;
+  size_t write(const float* interleaved, size_t stereo_pairs) override;
+  uint64_t playedMicroseconds() const override;
+  void setVolume(double linear) override;
+
+ private:
+  // Device buffer depth. Long enough to absorb a missed feed tick, short
+  // enough to keep audio-to-video skew inside a frame or two.
+  static constexpr uint32_t kDeviceBufferMs = 200;
+
+  std::unique_ptr<QAudioSink> sink_;
+  QIODevice* push_device_ = nullptr;  // Owned by sink_, valid while started
+  QAudioFormat format_;
+  // Retained across stop()/start() so a volume set while stopped still applies
+  // to the next session.
+  double volume_ = 1.0;
+  // Scratch for the Int16 fallback path; kept to avoid a per-write allocation.
+  std::vector<int16_t> convert_buffer_;
+};
+
+}  // namespace orc::gui

--- a/orc/gui/render_coordinator.cpp
+++ b/orc/gui/render_coordinator.cpp
@@ -12,6 +12,8 @@
 
 #include <orc/stage/common_types.h>  // For analysis result types
 
+#include <algorithm>
+
 #include "closed_caption_observation_presenter.h"
 #include "logging.h"
 #include "ntsc_observation_presenter.h"
@@ -64,9 +66,10 @@ class RenderPresenterAdapter final : public orc::presenters::IRenderPresenter {
 
   orc::PreviewRenderResult renderPreview(
       orc::NodeID node_id, orc::PreviewOutputType output_type,
-      uint64_t output_index, const std::string& option_id) override {
+      uint64_t output_index, const std::string& option_id,
+      orc::PreviewNavigationHint hint) override {
     return presenter_.renderPreview(node_id, output_type, output_index,
-                                    option_id);
+                                    option_id, hint);
   }
 
   std::optional<orc::presenters::DropoutDisplaySeries> getDropoutAnalysisData(
@@ -87,6 +90,16 @@ class RenderPresenterAdapter final : public orc::presenters::IRenderPresenter {
   std::vector<orc::PreviewOutputInfo> getAvailableOutputs(
       orc::NodeID node_id) override {
     return presenter_.getAvailableOutputs(node_id);
+  }
+
+  std::vector<orc::AudioPairView> getAudioChannelPairs(
+      orc::NodeID node_id) override {
+    return presenter_.getAudioChannelPairs(node_id);
+  }
+
+  std::shared_ptr<orc::presenters::IAudioStreamReader> createAudioStreamReader(
+      orc::NodeID node_id, size_t pair) override {
+    return presenter_.createAudioStreamReader(node_id, pair);
   }
 
   LineSampleData getLineSamplesWithYC(orc::NodeID node_id,
@@ -302,9 +315,20 @@ uint64_t RenderCoordinator::nextRequestId() {
 void RenderCoordinator::enqueueRequest(std::unique_ptr<RenderRequest> request) {
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);
-    request_queue_.push(std::move(request));
+    request_queue_.push_back(std::move(request));
   }
   queue_cv_.notify_one();
+}
+
+size_t RenderCoordinator::discardQueuedPreviewsLocked() {
+  const size_t before = request_queue_.size();
+  auto end = std::remove_if(
+      request_queue_.begin(), request_queue_.end(),
+      [](const std::unique_ptr<RenderRequest>& queued) {
+        return queued && queued->type == RenderRequestType::RenderPreview;
+      });
+  request_queue_.erase(end, request_queue_.end());
+  return before - request_queue_.size();
 }
 
 void RenderCoordinator::updateDAG(std::shared_ptr<const void> dag) {
@@ -321,12 +345,31 @@ void RenderCoordinator::setProject(void* project) {
 uint64_t RenderCoordinator::requestPreview(const orc::NodeID& node_id,
                                            orc::PreviewOutputType output_type,
                                            uint64_t output_index,
-                                           const std::string& option_id) {
+                                           const std::string& option_id,
+                                           orc::PreviewNavigationHint hint) {
   uint64_t id = nextRequestId();
   latest_preview_request_id_.store(id);
-  auto req = std::make_unique<RenderPreviewRequest>(id, node_id, output_type,
-                                                    output_index, option_id);
-  enqueueRequest(std::move(req));
+  auto req = std::make_unique<RenderPreviewRequest>(
+      id, node_id, output_type, output_index, option_id, hint);
+
+  size_t discarded = 0;
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    // Only the newest preview is ever displayed, so anything still queued is
+    // already dead work. Removing it here (rather than rendering it and
+    // dropping the response) is what lets a burst of navigations reach the
+    // latest frame in one render instead of N.
+    discarded = discardQueuedPreviewsLocked();
+    request_queue_.push_back(std::move(req));
+  }
+  queue_cv_.notify_one();
+
+  if (discarded > 0) {
+    ORC_LOG_DEBUG(
+        "RenderCoordinator: Discarded {} superseded queued preview request(s) "
+        "for request {}",
+        discarded, id);
+  }
   return id;
 }
 
@@ -390,6 +433,25 @@ uint64_t RenderCoordinator::requestAvailableOutputs(
     const orc::NodeID& node_id) {
   uint64_t id = nextRequestId();
   auto req = std::make_unique<GetAvailableOutputsRequest>(id, node_id);
+  enqueueRequest(std::move(req));
+  return id;
+}
+
+uint64_t RenderCoordinator::requestAudioChannelPairs(
+    const orc::NodeID& node_id) {
+  uint64_t id = nextRequestId();
+  latest_audio_pairs_request_id_.store(id);
+  auto req = std::make_unique<GetAudioChannelPairsRequest>(id, node_id);
+  enqueueRequest(std::move(req));
+  return id;
+}
+
+uint64_t RenderCoordinator::requestAudioStreamReader(const orc::NodeID& node_id,
+                                                     size_t pair) {
+  uint64_t id = nextRequestId();
+  latest_audio_reader_request_id_.store(id);
+  auto req =
+      std::make_unique<CreateAudioStreamReaderRequest>(id, node_id, pair);
   enqueueRequest(std::move(req));
   return id;
 }
@@ -542,7 +604,7 @@ void RenderCoordinator::workerLoop() {
 
       if (!request_queue_.empty()) {
         request = std::move(request_queue_.front());
-        request_queue_.pop();
+        request_queue_.pop_front();
       }
     }
 
@@ -625,6 +687,16 @@ void RenderCoordinator::processRequest(std::unique_ptr<RenderRequest> request) {
     case RenderRequestType::GetAvailableOutputs:
       handleGetAvailableOutputs(
           *static_cast<GetAvailableOutputsRequest*>(request.get()));
+      break;
+
+    case RenderRequestType::GetAudioChannelPairs:
+      handleGetAudioChannelPairs(
+          *static_cast<GetAudioChannelPairsRequest*>(request.get()));
+      break;
+
+    case RenderRequestType::CreateAudioStreamReader:
+      handleCreateAudioStreamReader(
+          *static_cast<CreateAudioStreamReaderRequest*>(request.get()));
       break;
 
     case RenderRequestType::GetLineSamples:
@@ -785,7 +857,8 @@ void RenderCoordinator::handleRenderPreview(const RenderPreviewRequest& req) {
 
   try {
     auto result = worker_render_presenter_->renderPreview(
-        req.node_id, req.output_type, req.output_index, req.option_id);
+        req.node_id, req.output_type, req.output_index, req.option_id,
+        req.hint);
 
     // Drop stale preview responses when a newer preview request exists.
     if (req.request_id != latest_preview_request_id_.load()) {
@@ -1177,6 +1250,89 @@ void RenderCoordinator::handleGetAvailableOutputs(
 
   } catch (const std::exception& e) {
     ORC_LOG_ERROR("RenderCoordinator: Get available outputs failed: {}",
+                  e.what());
+    emit error(req.request_id, QString::fromStdString(e.what()));
+  }
+}
+
+void RenderCoordinator::handleGetAudioChannelPairs(
+    const GetAudioChannelPairsRequest& req) {
+  ORC_LOG_DEBUG(
+      "RenderCoordinator: Enumerating audio channel pairs for node '{}' "
+      "(request {})",
+      req.node_id.to_string(), req.request_id);
+
+  if (!worker_render_presenter_) {
+    emit error(req.request_id, "Render presenter not initialized");
+    return;
+  }
+
+  try {
+    auto pairs = worker_render_presenter_->getAudioChannelPairs(req.node_id);
+
+    if (req.request_id != latest_audio_pairs_request_id_.load()) {
+      ORC_LOG_DEBUG(
+          "RenderCoordinator: Dropping stale audio pair response {} (latest "
+          "{})",
+          req.request_id, latest_audio_pairs_request_id_.load());
+      return;
+    }
+
+    ORC_LOG_DEBUG("RenderCoordinator: Node '{}' carries {} audio channel pairs",
+                  req.node_id.to_string(), pairs.size());
+
+    emit audioChannelPairsReady(req.request_id, std::move(pairs));
+
+  } catch (const std::exception& e) {
+    if (req.request_id != latest_audio_pairs_request_id_.load()) {
+      return;
+    }
+    ORC_LOG_ERROR(
+        "RenderCoordinator: Audio channel pair enumeration failed: {}",
+        e.what());
+    emit error(req.request_id, QString::fromStdString(e.what()));
+  }
+}
+
+void RenderCoordinator::handleCreateAudioStreamReader(
+    const CreateAudioStreamReaderRequest& req) {
+  ORC_LOG_DEBUG(
+      "RenderCoordinator: Creating audio stream reader for node '{}', pair {} "
+      "(request {})",
+      req.node_id.to_string(), req.pair, req.request_id);
+
+  if (!worker_render_presenter_) {
+    emit error(req.request_id, "Render presenter not initialized");
+    return;
+  }
+
+  try {
+    // Creation only resolves the representation; the expensive whole-stream
+    // decode happens later in the caller's prime() on the playback thread, so
+    // this never blocks preview rendering for minutes.
+    auto reader = worker_render_presenter_->createAudioStreamReader(req.node_id,
+                                                                    req.pair);
+
+    if (req.request_id != latest_audio_reader_request_id_.load()) {
+      ORC_LOG_DEBUG(
+          "RenderCoordinator: Dropping stale audio reader response {} (latest "
+          "{})",
+          req.request_id, latest_audio_reader_request_id_.load());
+      return;
+    }
+
+    if (!reader) {
+      ORC_LOG_DEBUG("RenderCoordinator: No usable audio pair {} at node '{}'",
+                    req.pair, req.node_id.to_string());
+    }
+
+    emit audioStreamReaderReady(req.request_id, std::move(reader));
+
+  } catch (const std::exception& e) {
+    if (req.request_id != latest_audio_reader_request_id_.load()) {
+      return;
+    }
+    ORC_LOG_ERROR("RenderCoordinator: Audio stream reader creation failed: {}",
                   e.what());
     emit error(req.request_id, QString::fromStdString(e.what()));
   }

--- a/orc/gui/render_coordinator.h
+++ b/orc/gui/render_coordinator.h
@@ -15,13 +15,16 @@
 #ifndef RENDER_COORDINATOR_H
 #define RENDER_COORDINATOR_H
 
+#include <audio_stream_reader.h>  // IAudioStreamReader (preview audio playback)
 #include <orc/stage/common_types.h>
 #include <orc/stage/field_id.h>
 #include <orc/stage/node_id.h>
 #include <orc/stage/orc_source_parameters.h>   // Public API VideoParameters
 #include <orc/stage/params/parameter_types.h>  // ParameterValue
 #include <orc/stage/preview/orc_rendering.h>  // Public API rendering types (includes mapping result types)
+#include <orc/stage/preview/preview_stage_types.h>  // PreviewNavigationHint
 #include <orc_analysis_series.h>  // Analysis display-series view types
+#include <orc_audio_views.h>      // AudioPairView
 #include <orc_closed_caption.h>   // Closed caption observation view types
 #include <orc_preview_views.h>
 #include <orc_teletext.h>  // Teletext observation view types
@@ -32,11 +35,11 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <string>
 #include <thread>
 
@@ -71,12 +74,14 @@ enum class RenderRequestType {
   TriggerStage,          // Trigger a stage (batch processing)
   CancelTrigger,         // Cancel ongoing trigger
   GetAvailableOutputs,   // Query available preview outputs
-  GetLineSamples,        // Get 16-bit samples for a line
-  GetFrameTiming,        // Get all frame samples for timing view
-  GetWaveformMonitor,    // Get all frame samples for waveform monitor
-  SavePNG,               // Save preview as PNG file
-  NavigateFrameLine,     // Navigate to next/previous line in frame mode
-  Shutdown               // Shutdown the worker thread
+  GetAudioChannelPairs,  // Query the node's audio channel pairs
+  CreateAudioStreamReader,  // Create a playback reader for one channel pair
+  GetLineSamples,           // Get 16-bit samples for a line
+  GetFrameTiming,           // Get all frame samples for timing view
+  GetWaveformMonitor,       // Get all frame samples for waveform monitor
+  SavePNG,                  // Save preview as PNG file
+  NavigateFrameLine,        // Navigate to next/previous line in frame mode
+  Shutdown                  // Shutdown the worker thread
 };
 
 /**
@@ -111,15 +116,18 @@ struct RenderPreviewRequest : public RenderRequest {
   orc::PreviewOutputType output_type;
   uint64_t output_index;
   std::string option_id;
+  orc::PreviewNavigationHint hint;
 
-  RenderPreviewRequest(uint64_t id, orc::NodeID node,
-                       orc::PreviewOutputType type, uint64_t index,
-                       std::string opt_id = "")
+  RenderPreviewRequest(
+      uint64_t id, orc::NodeID node, orc::PreviewOutputType type,
+      uint64_t index, std::string opt_id = "",
+      orc::PreviewNavigationHint nav_hint = orc::PreviewNavigationHint::Random)
       : RenderRequest(RenderRequestType::RenderPreview, id),
         node_id(std::move(node)),
         output_type(type),
         output_index(index),
-        option_id(std::move(opt_id)) {}
+        option_id(std::move(opt_id)),
+        hint(nav_hint) {}
 };
 
 /**
@@ -255,6 +263,30 @@ struct GetAvailableOutputsRequest : public RenderRequest {
   GetAvailableOutputsRequest(uint64_t id, orc::NodeID node)
       : RenderRequest(RenderRequestType::GetAvailableOutputs, id),
         node_id(std::move(node)) {}
+};
+
+/**
+ * @brief Request to enumerate a node's audio channel pairs
+ */
+struct GetAudioChannelPairsRequest : public RenderRequest {
+  orc::NodeID node_id;
+
+  GetAudioChannelPairsRequest(uint64_t id, orc::NodeID node)
+      : RenderRequest(RenderRequestType::GetAudioChannelPairs, id),
+        node_id(std::move(node)) {}
+};
+
+/**
+ * @brief Request to create a playback reader for one audio channel pair
+ */
+struct CreateAudioStreamReaderRequest : public RenderRequest {
+  orc::NodeID node_id;
+  size_t pair;
+
+  CreateAudioStreamReaderRequest(uint64_t id, orc::NodeID node, size_t p)
+      : RenderRequest(RenderRequestType::CreateAudioStreamReader, id),
+        node_id(std::move(node)),
+        pair(p) {}
 };
 
 /**
@@ -492,9 +524,12 @@ class IRenderPresenter {
       orc::presenters::ObservationProgressCallback callback) = 0;
   virtual void unsubscribeObservationProgress(uint64_t subscription_id) = 0;
 
+  // @p hint tells stages whether the frame is part of a run of adjacent frames
+  // (playback) or a one-off position (scrubbing, a single navigation, an
+  // export). Only the playback path sends Sequential.
   virtual orc::PreviewRenderResult renderPreview(
       NodeID node_id, orc::PreviewOutputType output_type, uint64_t output_index,
-      const std::string& option_id) = 0;
+      const std::string& option_id, orc::PreviewNavigationHint hint) = 0;
 
   virtual std::optional<orc::presenters::DropoutDisplaySeries>
   getDropoutAnalysisData(NodeID node_id) = 0;
@@ -504,6 +539,17 @@ class IRenderPresenter {
   getBurstLevelAnalysisData(NodeID node_id) = 0;
   virtual std::vector<orc::PreviewOutputInfo> getAvailableOutputs(
       NodeID node_id) = 0;
+
+  // Audio channel pairs available at the node, for the preview audio selector.
+  // An empty list is the normal "no audio here" answer, not an error.
+  virtual std::vector<orc::AudioPairView> getAudioChannelPairs(
+      NodeID node_id) = 0;
+
+  // Create a frame-addressed reader for one channel pair. Executes the DAG, so
+  // it runs on the coordinator's worker thread; the reader is then primed and
+  // read from the playback thread. Returns nullptr when the pair is unusable.
+  virtual std::shared_ptr<orc::presenters::IAudioStreamReader>
+  createAudioStreamReader(NodeID node_id, size_t pair) = 0;
 
   virtual LineSampleData getLineSamplesWithYC(
       NodeID node_id, orc::PreviewOutputType output_type, uint64_t output_index,
@@ -629,15 +675,22 @@ class RenderCoordinator : public QObject {
    *
    * Result will be emitted via previewReady signal.
    *
+   * Queuing a preview drops any preview still waiting in the queue: the worker
+   * is serial and a superseded render's response is discarded on completion
+   * anyway, so rendering it only delays the one the user is waiting for.
+   *
    * @param node_id Node to render from
    * @param output_type Type of output (field/frame/etc)
    * @param output_index Which field/frame to render
+   * @param option_id Rendering option (preview mode plus any signal suffix)
+   * @param hint Sequential while playback is running so stages can pre-fetch;
+   *        Random for scrubbing and single navigations
    * @return Request ID for matching response
    */
-  uint64_t requestPreview(const orc::NodeID& node_id,
-                          orc::PreviewOutputType output_type,
-                          uint64_t output_index,
-                          const std::string& option_id = "");
+  uint64_t requestPreview(
+      const orc::NodeID& node_id, orc::PreviewOutputType output_type,
+      uint64_t output_index, const std::string& option_id = "",
+      orc::PreviewNavigationHint hint = orc::PreviewNavigationHint::Random);
 
   /**
    * @brief Request VBI data for a field (async)
@@ -741,6 +794,39 @@ class RenderCoordinator : public QObject {
    * @return Request ID for matching response
    */
   uint64_t requestAvailableOutputs(const orc::NodeID& node_id);
+
+  /**
+   * @brief Request the node's audio channel pairs (async)
+   *
+   * Enumeration resolves the node's representation, which executes the DAG, so
+   * it is routed through the worker like every other query. The result is
+   * emitted via audioChannelPairsReady; an empty list means the node carries no
+   * usable audio, which is the normal case for most projects.
+   *
+   * Only the newest request is answered — the viewed node changes faster than
+   * enumeration completes on a heavy DAG.
+   *
+   * @param node_id Node to enumerate
+   * @return Request ID for matching response
+   */
+  uint64_t requestAudioChannelPairs(const orc::NodeID& node_id);
+
+  /**
+   * @brief Request a playback reader for one audio channel pair (async)
+   *
+   * Creation executes the DAG and so must happen on the worker thread; the
+   * reader is delivered via audioStreamReaderReady and may then be primed and
+   * read from the playback thread. A null reader in the response means the pair
+   * is not usable (no audio, unknown video system, or pair out of range).
+   *
+   * Only the newest request is answered, so a rapid pair reselection cannot
+   * deliver a superseded reader.
+   *
+   * @param node_id Node whose representation supplies the audio
+   * @param pair    Channel-pair index
+   * @return Request ID for matching response
+   */
+  uint64_t requestAudioStreamReader(const orc::NodeID& node_id, size_t pair);
 
   /**
    * @brief Request line samples from a field (async)
@@ -994,6 +1080,26 @@ class RenderCoordinator : public QObject {
                              std::vector<orc::PreviewOutputInfo> outputs);
 
   /**
+   * @brief Emitted when an audio channel-pair enumeration completes
+   *
+   * An empty @p pairs list is the normal "this node has no audio" answer.
+   * Marshalled from the worker thread via a queued connection.
+   */
+  void audioChannelPairsReady(uint64_t request_id,
+                              std::vector<orc::AudioPairView> pairs);
+
+  /**
+   * @brief Emitted when a requested audio playback reader has been created
+   *
+   * @p reader is null when the pair turned out to be unusable. Marshalled from
+   * the worker thread via a queued connection; the reader must be primed off
+   * the GUI thread (an EFM decode can take minutes).
+   */
+  void audioStreamReaderReady(
+      uint64_t request_id,
+      std::shared_ptr<orc::presenters::IAudioStreamReader> reader);
+
+  /**
    * @brief Emitted when line samples are ready
    */
   void lineSamplesReady(uint64_t request_id, uint64_t field_index,
@@ -1173,6 +1279,16 @@ class RenderCoordinator : public QObject {
   void handleGetAvailableOutputs(const GetAvailableOutputsRequest& req);
 
   /**
+   * @brief Handle GetAudioChannelPairs request
+   */
+  void handleGetAudioChannelPairs(const GetAudioChannelPairsRequest& req);
+
+  /**
+   * @brief Handle CreateAudioStreamReader request
+   */
+  void handleCreateAudioStreamReader(const CreateAudioStreamReaderRequest& req);
+
+  /**
    * @brief Handle GetLineSamples request
    */
   void handleGetLineSamples(const GetLineSamplesRequest& req);
@@ -1205,6 +1321,15 @@ class RenderCoordinator : public QObject {
   void enqueueRequest(std::unique_ptr<RenderRequest> request);
 
   /**
+   * @brief Drop every queued (not yet started) preview render
+   *
+   * Caller must hold queue_mutex_. Returns how many were removed, for logging.
+   * The request being processed is already off the queue and is unaffected; it
+   * still finishes and is dropped by the existing stale-response check.
+   */
+  size_t discardQueuedPreviewsLocked();
+
+  /**
    * @brief Get next request ID (thread-safe)
    */
   uint64_t nextRequestId();
@@ -1218,10 +1343,18 @@ class RenderCoordinator : public QObject {
 
   std::mutex queue_mutex_;
   std::condition_variable queue_cv_;
-  std::queue<std::unique_ptr<RenderRequest>> request_queue_;
+  // A deque rather than a queue: superseded previews are removed from the
+  // middle of the pending work (discardQueuedPreviewsLocked()).
+  std::deque<std::unique_ptr<RenderRequest>> request_queue_;
 
   std::atomic<uint64_t> next_request_id_{1};
   std::atomic<uint64_t> latest_preview_request_id_{0};
+
+  // Newest-only audio queries: the viewed node and the selected pair both
+  // change faster than a heavy DAG can answer, so superseded responses are
+  // dropped rather than delivered to a dialogue that has moved on.
+  std::atomic<uint64_t> latest_audio_pairs_request_id_{0};
+  std::atomic<uint64_t> latest_audio_reader_request_id_{0};
 
   // ========================================================================
   // Worker thread state (owned by worker thread, never accessed from GUI)

--- a/orc/plugins/stages/audio_align/audio_align_stage.cpp
+++ b/orc/plugins/stages/audio_align/audio_align_stage.cpp
@@ -163,14 +163,28 @@ std::vector<ArtifactPtr> AudioAlignStage::execute(
 
   if (!parameters.empty()) set_parameters(parameters);
 
+  // A channel pair the input does not carry (most commonly a source with no
+  // audio at all) is a configuration mismatch, not a pipeline failure. The
+  // stage passes its input through instead of throwing, because a DAG
+  // execution error here blanks the preview of every downstream node —
+  // including the video sink — for a fault that only concerns audio.
   const size_t pair = static_cast<size_t>(channel_pair_);
-  if (pair >= vfr->audio_channel_pair_count()) {
-    throw DAGExecutionError("AudioAlignStage: channel pair " +
-                            std::to_string(channel_pair_) +
-                            " is out of range: the input carries " +
-                            std::to_string(vfr->audio_channel_pair_count()) +
-                            " audio channel pair(s)");
+  const size_t pair_count = vfr->audio_channel_pair_count();
+  if (pair >= pair_count) {
+    const std::string reason = "channel pair " + std::to_string(channel_pair_) +
+                               " is out of range: the input carries " +
+                               std::to_string(pair_count) +
+                               " audio channel pair(s)";
+    // Executed once per render request, so only log when the reason changes.
+    if (reason != last_inactive_reason_) {
+      ORC_LOG_WARN("AudioAlignStage: {}; passing the input through unchanged",
+                   reason);
+      last_inactive_reason_ = reason;
+    }
+    cached_output_ = vfr;
+    return {inputs[0]};
   }
+  last_inactive_reason_.clear();
 
   auto output = process(vfr);
   cached_output_ = output;

--- a/orc/plugins/stages/audio_align/audio_align_stage.h
+++ b/orc/plugins/stages/audio_align/audio_align_stage.h
@@ -127,6 +127,11 @@ class AudioAlignStage : public DAGStage,
   int32_t channel_pair_ = 0;
   double offset_ms_ = 0.0;
 
+  // Last reported pass-through reason (the selected channel pair is absent
+  // from the input), so a repeated render request does not log the same
+  // warning again. Empty while the stage is applying its offset normally.
+  std::string last_inactive_reason_;
+
   mutable std::shared_ptr<const VideoFrameRepresentation> cached_output_;
 };
 

--- a/orc/plugins/stages/audio_align/instructions.md
+++ b/orc/plugins/stages/audio_align/instructions.md
@@ -14,7 +14,7 @@ Each frame's audio window is assembled from the neighbouring frames' samples, wi
 
 Sample values and the sample rate are never changed; the shift is pure placement, no resampling.
 
-The stage fails validation when the target channel pair does not exist on the input. A zero offset passes the input through unchanged.
+A zero offset passes the input through unchanged. So does a target channel pair the input does not carry: the stage logs a warning and forwards audio and video untouched rather than interrupting the pipeline. The most common cause is a source that carries no audio at all (for example a plain TBC without an accompanying audio import), in which case the parameter dialog says so.
 
 ## Parameters
 

--- a/orc/plugins/stages/audio_channel_map/audio_channel_map_stage.cpp
+++ b/orc/plugins/stages/audio_channel_map/audio_channel_map_stage.cpp
@@ -73,7 +73,18 @@ std::optional<int> parse_pair_index(const std::string& text) {
 // ChannelMappedRepresentation
 // ============================================================================
 
+bool ChannelMappedRepresentation::is_active() const {
+  const size_t count = source_pair_count();
+  if (source_pair_ >= count) return false;
+  if (is_route()) {
+    return target_is_new_ ? count < kMaxAudioChannelPairs
+                          : target_pair_ < count;
+  }
+  return true;
+}
+
 bool ChannelMappedRepresentation::is_result_pair(size_t pair) const {
+  if (!is_active()) return false;
   switch (operation_) {
     case AudioChannelMapOperation::kLeftToMono:
     case AudioChannelMapOperation::kRightToMono:
@@ -89,12 +100,16 @@ bool ChannelMappedRepresentation::is_result_pair(size_t pair) const {
 
 size_t ChannelMappedRepresentation::audio_channel_pair_count() const {
   const size_t count = source_pair_count();
+  // An operation the input cannot satisfy leaves the pair count untouched.
+  if (!is_active()) return count;
   if (is_delete() && count > 0) return count - 1;
   if (is_append()) return count + 1;
   return count;
 }
 
 size_t ChannelMappedRepresentation::source_pair_for(size_t pair) const {
+  // Inactive: every output pair maps straight to the same source pair.
+  if (!is_active()) return pair;
   // Deleting the source pair shifts every later pair up by one source index.
   if (is_delete()) return pair >= source_pair_ ? pair + 1 : pair;
   // The mono result pair (in place, appended, or overwritten target) always
@@ -185,38 +200,29 @@ std::vector<ArtifactPtr> AudioChannelMapStage::execute(
 
   if (!parameters.empty()) set_parameters(parameters);
 
-  const size_t pair_count = vfr->audio_channel_pair_count();
-  const size_t source = static_cast<size_t>(channel_pair_);
-  if (source >= pair_count) {
-    throw DAGExecutionError(
-        "AudioChannelMapStage: channel pair " + std::to_string(channel_pair_) +
-        " is out of range: the input carries " + std::to_string(pair_count) +
-        " audio channel pair(s)");
-  }
-
   const auto operation = parse_operation(operation_)
                              .value_or(AudioChannelMapOperation::kLeftToMono);
-  if (is_route_op(operation)) {
-    if (target_pair_ == kTargetNew) {
-      // Appending a pair must not exceed the pipeline's channel-pair cap; the
-      // limit is enforced here, not just at the container sink, so a DAG that
-      // validates also exports.
-      if (pair_count >= kMaxAudioChannelPairs) {
-        throw DAGExecutionError(
-            "AudioChannelMapStage: cannot append a channel pair: the input "
-            "already carries the maximum of " +
-            std::to_string(kMaxAudioChannelPairs) + " audio channel pairs");
-      }
-    } else {
-      const auto target = parse_pair_index(target_pair_);
-      if (!target || static_cast<size_t>(*target) >= pair_count) {
-        throw DAGExecutionError(
-            "AudioChannelMapStage: target channel pair '" + target_pair_ +
-            "' is out of range: the input carries " +
-            std::to_string(pair_count) + " audio channel pair(s)");
-      }
+
+  // A channel-pair selection the input cannot satisfy (most commonly a source
+  // that carries no audio at all) is a configuration mismatch, not a pipeline
+  // failure. The stage degrades to a transparent pass-through instead of
+  // throwing, because a DAG execution error here blanks the preview of every
+  // downstream node — including the video sink — for a fault that only
+  // concerns audio.
+  const std::string reason =
+      inactive_reason(vfr->audio_channel_pair_count(), operation);
+  if (!reason.empty()) {
+    // Executed once per render request, so only log when the reason changes.
+    if (reason != last_inactive_reason_) {
+      ORC_LOG_WARN(
+          "AudioChannelMapStage: {}; passing the input through unchanged",
+          reason);
+      last_inactive_reason_ = reason;
     }
+    cached_output_ = vfr;
+    return {inputs[0]};
   }
+  last_inactive_reason_.clear();
 
   auto output = process(vfr);
   cached_output_ = output;
@@ -225,6 +231,34 @@ std::vector<ArtifactPtr> AudioChannelMapStage::execute(
   outputs.push_back(std::const_pointer_cast<ChannelMappedRepresentation>(
       std::dynamic_pointer_cast<const ChannelMappedRepresentation>(output)));
   return outputs;
+}
+
+std::string AudioChannelMapStage::inactive_reason(
+    size_t pair_count, AudioChannelMapOperation operation) const {
+  if (static_cast<size_t>(channel_pair_) >= pair_count) {
+    return "channel pair " + std::to_string(channel_pair_) +
+           " is out of range: the input carries " + std::to_string(pair_count) +
+           " audio channel pair(s)";
+  }
+  if (!is_route_op(operation)) return {};
+  if (target_pair_ == kTargetNew) {
+    // Appending a pair must not exceed the pipeline's channel-pair cap; the
+    // limit is checked here, not just at the container sink, so a DAG that
+    // previews also exports.
+    if (pair_count >= kMaxAudioChannelPairs) {
+      return "cannot append a channel pair: the input already carries the "
+             "maximum of " +
+             std::to_string(kMaxAudioChannelPairs) + " audio channel pairs";
+    }
+    return {};
+  }
+  const auto target = parse_pair_index(target_pair_);
+  if (!target || static_cast<size_t>(*target) >= pair_count) {
+    return "target channel pair '" + target_pair_ +
+           "' is out of range: the input carries " +
+           std::to_string(pair_count) + " audio channel pair(s)";
+  }
+  return {};
 }
 
 std::shared_ptr<const VideoFrameRepresentation> AudioChannelMapStage::process(

--- a/orc/plugins/stages/audio_channel_map/audio_channel_map_stage.h
+++ b/orc/plugins/stages/audio_channel_map/audio_channel_map_stage.h
@@ -56,6 +56,12 @@ enum class AudioChannelMapOperation {
 //   target is "new" the mono pair is appended (count +1); when it is an
 //   existing pair that pair is overwritten (count unchanged).
 //
+// When the input cannot satisfy the operation — the source pair (or an
+// existing routing target) is absent, or appending would exceed the
+// channel-pair cap — the wrapper becomes a transparent pass-through: audio and
+// video reach the output untouched. Audio routing is never a reason to stop
+// video reaching a downstream sink or preview.
+//
 // The produced mono pair reports origin DERIVED; its name is |description| when
 // |override_description| is set, otherwise the source pair's existing name is
 // kept unchanged. The remap is a pure per-sample channel operation on the
@@ -111,6 +117,12 @@ class ChannelMappedRepresentation : public VideoFrameRepresentationWrapper,
            operation_ == AudioChannelMapOperation::kCopyRightToTarget;
   }
   bool is_append() const { return is_route() && target_is_new_; }
+  // Whether the configured operation can be applied to the wrapped source. It
+  // cannot when the source pair (or a routing target) is absent from the
+  // input, or when appending would exceed the channel-pair cap. An inactive
+  // wrapper is a transparent pass-through: every pair keeps its index, count
+  // and samples.
+  bool is_active() const;
   // The mono fill implied by a left/right operation.
   ChannelFill mono_fill() const {
     return (operation_ == AudioChannelMapOperation::kLeftToMono ||
@@ -173,6 +185,12 @@ class AudioChannelMapStage : public DAGStage,
   std::shared_ptr<const VideoFrameRepresentation> process(
       std::shared_ptr<const VideoFrameRepresentation> source) const;
 
+  // Human-readable reason the configured operation cannot be applied to an
+  // input carrying |pair_count| audio channel pairs, or an empty string when
+  // it can. Used to report the mismatch and fall back to a pass-through.
+  std::string inactive_reason(size_t pair_count,
+                              AudioChannelMapOperation operation) const;
+
   // ParameterizedStage
   std::vector<ParameterDescriptor> get_parameter_descriptors(
       VideoSystem project_format, SourceType source_type) const override;
@@ -197,6 +215,11 @@ class AudioChannelMapStage : public DAGStage,
   // Custom name for the result pair (target for copy ops, source for the
   // in-place mono ops), used only when set_description_ is true.
   std::string description_;
+
+  // Last reported pass-through reason, so a repeated render request does not
+  // log the same warning again. Empty while the stage is applying its
+  // operation normally.
+  std::string last_inactive_reason_;
 
   mutable std::shared_ptr<const VideoFrameRepresentation> cached_output_;
 };

--- a/orc/plugins/stages/audio_channel_map/instructions.md
+++ b/orc/plugins/stages/audio_channel_map/instructions.md
@@ -27,7 +27,7 @@ The stage wraps the incoming frame representation and remaps channels on the fly
 
 By default the resulting pair keeps its existing description. Tick **Add description** to give it a new one (see `set_description` / `description` below).
 
-The stage fails validation when the selected channel pair does not exist on the input, when a chosen target pair does not exist, or when appending would exceed the 8-pair limit.
+When the input cannot satisfy the operation — the selected channel pair does not exist, a chosen target pair does not exist, or appending would exceed the 8-pair limit — the stage passes its input through unchanged and logs a warning. Audio and video reach the output untouched; nothing downstream is interrupted. The most common cause is a source that carries no audio at all (for example a plain TBC without an accompanying audio import), in which case the parameter dialog says so.
 
 ## Parameters
 

--- a/orc/plugins/stages/sinks/common/ffmpeg_output_backend.cpp
+++ b/orc/plugins/stages/sinks/common/ffmpeg_output_backend.cpp
@@ -11,6 +11,7 @@
 
 #ifdef HAVE_FFMPEG
 
+#include <orc/stage/audio/audio_sample_feed.h>
 #include <orc/stage/common_types.h>
 #include <orc/stage/cvbs_signal_constants.h>
 #include <orc/stage/field_id.h>
@@ -28,7 +29,6 @@
 #include <thread>
 
 #include "audio_pair_selection.h"
-#include "audio_sample_feed.h"
 #include "componentframe.h"
 #include "subtitle_embed_policy.h"
 #include "teletext_subtitle_feed.h"

--- a/orc/presenters/CMakeLists.txt
+++ b/orc/presenters/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(orc-presenters STATIC
     src/filtergraph_parser.cpp
     src/filtergraph_import.cpp
     src/render_presenter.cpp
+    src/representation_audio_stream_reader.cpp
     src/analysis_presenter.cpp
     src/analysis_tool_presenter.cpp
     src/frame_corruption_presenter.cpp

--- a/orc/presenters/include/audio_stream_reader.h
+++ b/orc/presenters/include/audio_stream_reader.h
@@ -1,0 +1,83 @@
+/*
+ * File:        audio_stream_reader.h
+ * Module:      orc-presenters
+ * Purpose:     Frame-addressed audio sample reader contract for preview
+ *              playback
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <orc/stage/audio/audio_channel_pair.h>  // kAudioSampleRateHz
+#include <orc/stage/frame_id.h>                  // FrameID, FrameIDRange
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace orc::presenters {
+
+/**
+ * @brief Progress sink for a deferred whole-stream audio decode.
+ *
+ * (done, total, message). @c total may be 0 while the work size is unknown, in
+ * which case only @c message is meaningful. Signature-compatible with the SDK's
+ * AudioDecodeProgressFn so it forwards straight through to the producer.
+ */
+using AudioPrimeProgressCallback =
+    std::function<void(uint64_t done, uint64_t total, const std::string&)>;
+
+/**
+ * @brief Reads one audio channel pair as frame-addressed interleaved stereo.
+ *
+ * Wraps a resolved representation's audio surface for a single channel pair and
+ * hands out float samples ready for an audio device. All frame ↔
+ * stream-position arithmetic follows the SMPTE 272M-1994 §14.3 cadence (PAL
+ * 1920 pairs/frame; NTSC/PAL-M 1602/1601/1602/1601/1602), so callers never
+ * assume a constant per-frame stride.
+ *
+ * Thread safety: a reader is *created* on the render worker (creation executes
+ * the DAG, which is single-threaded by contract). Once created, prime() and the
+ * read/mapping methods may be called from any one other thread — they only use
+ * representation const accessors, which are documented safe for concurrent use.
+ * The reader itself holds the representation alive for its lifetime.
+ */
+class IAudioStreamReader {
+ public:
+  virtual ~IAudioStreamReader() = default;
+
+  /**
+   * @brief Force any deferred whole-stream decode to run now.
+   *
+   * Blocking: an EFM or TBC audio decode plus resample can take seconds to
+   * minutes, so never call this on the GUI thread or on the render worker.
+   * Idempotent, and safe to call with an empty @p progress.
+   */
+  virtual void prime(const AudioPrimeProgressCallback& progress) = 0;
+
+  /**
+   * @brief Interleaved stereo float samples (±1.0) for a run of frames.
+   *
+   * Covers the half-open frame range [@p first_frame, @p first_frame +
+   * @p frame_count), clamped to frameRange(). The returned vector holds
+   * 2 × (sum of audio_pairs_in_frame() over the covered frames) floats;
+   * cadence-exact silence is substituted for any frame the representation has
+   * no samples for, so the clock arithmetic stays intact across gaps.
+   */
+  virtual std::vector<float> readFrames(orc::FrameID first_frame,
+                                        uint64_t frame_count) = 0;
+
+  /// Frame containing absolute stereo-pair stream position @p pair_position.
+  virtual uint64_t frameForPairPosition(uint64_t pair_position) const = 0;
+
+  /// Absolute stereo-pair stream position of the start of frame @p frame.
+  virtual uint64_t pairPositionForFrame(orc::FrameID frame) const = 0;
+
+  /// Frames this reader can serve (inclusive on both ends).
+  virtual orc::FrameIDRange frameRange() const = 0;
+};
+
+}  // namespace orc::presenters

--- a/orc/presenters/include/render_presenter.h
+++ b/orc/presenters/include/render_presenter.h
@@ -15,7 +15,9 @@
 #include <orc/stage/orc_source_parameters.h>   // Public API SourceParameters
 #include <orc/stage/params/parameter_types.h>  // ParameterValue
 #include <orc/stage/preview/orc_rendering.h>   // Public API rendering types
+#include <orc/stage/preview/preview_stage_types.h>  // PreviewNavigationHint
 #include <orc_analysis_series.h>  // Analysis display-series view types
+#include <orc_audio_views.h>      // AudioPairView
 #include <orc_preview_views.h>
 
 #include <cstdint>
@@ -26,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include "audio_stream_reader.h"            // IAudioStreamReader
 #include "dag_execution_progress_view.h"    // DagExecutionProgressCallback
 #include "observation_invalidation_view.h"  // ObservationInvalidationEvent
 #include "observation_progress_view.h"  // ObservationProgressEvent, ObservationDataReadyCallback
@@ -204,14 +207,17 @@ class RenderPresenter {
    * @param output_type Type of output (Field, Frame, Luma, etc.)
    * @param output_index Index of the output (0-based)
    * @param option_id Optional rendering option ID
+   * @param hint How the frame is being navigated to. Sequential tells stages
+   *        that playback is running and adjacent frames are worth pre-fetching;
+   *        scrubbing and one-off renders stay Random.
    * @return Preview render result with RGB image
    *
    * Thread-safe: Yes (uses internal DAG)
    */
-  orc::PreviewRenderResult renderPreview(NodeID node_id,
-                                         orc::PreviewOutputType output_type,
-                                         uint64_t output_index,
-                                         const std::string& option_id = "");
+  orc::PreviewRenderResult renderPreview(
+      NodeID node_id, orc::PreviewOutputType output_type, uint64_t output_index,
+      const std::string& option_id = "",
+      orc::PreviewNavigationHint hint = orc::PreviewNavigationHint::Random);
 
   /**
    * @brief Get available output types for a node
@@ -585,6 +591,43 @@ class RenderPresenter {
    * @return One name per channel pair; empty when no audio or unavailable
    */
   std::vector<std::string> getAudioChannelPairNames(NodeID node_id);
+
+  /**
+   * @brief Audio channel pairs available at a node's output
+   *
+   * Richer form of getAudioChannelPairNames() for callers that need the pair's
+   * provenance as well as its name (the preview dialogue's audio selector).
+   * Resolves the representation produced at @p node_id and returns one entry
+   * per pair, in pair-index order.
+   *
+   * Returns an empty list — the normal case, not an error — when the node
+   * carries no audio, when the representation cannot be resolved, or when the
+   * video system is unknown (the SMPTE 272M-1994 §14.3 cadence is then
+   * undefined, so no audio can be addressed).
+   *
+   * @param node_id Node whose output representation is inspected
+   * @return One view per channel pair; empty when there is no usable audio
+   */
+  std::vector<orc::AudioPairView> getAudioChannelPairs(NodeID node_id);
+
+  /**
+   * @brief Create a frame-addressed reader for one audio channel pair
+   *
+   * Resolves the representation at @p node_id (which executes the DAG) and
+   * wraps channel pair @p pair as an IAudioStreamReader. The reader holds the
+   * representation alive for its own lifetime.
+   *
+   * @warning Must be called on the render worker thread: resolving the
+   * representation executes the DAG, and the renderers are single-threaded by
+   * contract. The returned reader may then be primed and read from one other
+   * thread (see IAudioStreamReader).
+   *
+   * @param node_id Node whose output representation supplies the audio
+   * @param pair    Channel-pair index, < getAudioChannelPairs().size()
+   * @return Reader, or nullptr when the node has no such usable pair
+   */
+  std::shared_ptr<IAudioStreamReader> createAudioStreamReader(NodeID node_id,
+                                                              size_t pair);
 
   /**
    * @brief Execute DAG to a specific node and return field representation

--- a/orc/presenters/src/render_presenter.cpp
+++ b/orc/presenters/src/render_presenter.cpp
@@ -51,6 +51,7 @@
 #include "analysis_series_decimator.h"
 #include "metrics_presenter.h"
 #include "project_presenter.h"
+#include "representation_audio_stream_reader.h"
 
 namespace orc::presenters {
 
@@ -1546,7 +1547,7 @@ void RenderPresenter::unsubscribeObservationProgress(uint64_t subscription_id) {
 
 orc::PreviewRenderResult RenderPresenter::renderPreview(
     NodeID node_id, orc::PreviewOutputType output_type, uint64_t output_index,
-    const std::string& option_id) {
+    const std::string& option_id, orc::PreviewNavigationHint hint) {
   if (!impl_->preview_renderer_) {
     return orc::PreviewRenderResult{
         {},      false,       "Preview renderer not initialized",
@@ -1556,7 +1557,7 @@ orc::PreviewRenderResult RenderPresenter::renderPreview(
   try {
     // Call core preview renderer
     auto core_result = impl_->preview_renderer_->render_output(
-        node_id, output_type, output_index, option_id);
+        node_id, output_type, output_index, option_id, hint);
 
     // Populate observation cache for the rendered field(s)
     if (impl_->obs_cache_) {
@@ -2353,6 +2354,41 @@ std::vector<std::string> RenderPresenter::getAudioChannelPairNames(
     names.clear();
   }
   return names;
+}
+
+// Both audio accessors resolve the node's representation exactly as
+// getAudioChannelPairNames() does, so they inherit the upstream BFS fallback in
+// get_representation_at_node(): the pair list and the samples always come from
+// the same resolved representation, even when that is an ancestor node's.
+std::vector<orc::AudioPairView> RenderPresenter::getAudioChannelPairs(
+    NodeID node_id) {
+  if (!impl_->preview_renderer_) {
+    return {};
+  }
+
+  try {
+    auto repr = impl_->preview_renderer_->get_representation_at_node(node_id);
+    if (!repr) {
+      return {};
+    }
+    return enumerate_audio_channel_pairs(*repr);
+  } catch (const std::exception&) {
+    return {};
+  }
+}
+
+std::shared_ptr<IAudioStreamReader> RenderPresenter::createAudioStreamReader(
+    NodeID node_id, size_t pair) {
+  if (!impl_->preview_renderer_) {
+    return nullptr;
+  }
+
+  try {
+    auto repr = impl_->preview_renderer_->get_representation_at_node(node_id);
+    return make_audio_stream_reader(std::move(repr), pair);
+  } catch (const std::exception&) {
+    return nullptr;
+  }
 }
 
 // === Analysis Data Access ===

--- a/orc/presenters/src/representation_audio_stream_reader.cpp
+++ b/orc/presenters/src/representation_audio_stream_reader.cpp
@@ -1,0 +1,200 @@
+/*
+ * File:        representation_audio_stream_reader.cpp
+ * Module:      orc-presenters
+ * Purpose:     Frame → float sample reads over a resolved representation's
+ *              audio channel pair
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "representation_audio_stream_reader.h"
+
+#include <orc/stage/audio/audio_sample_feed.h>
+
+#include <algorithm>
+
+namespace orc::presenters {
+
+namespace {
+
+// Frame containing absolute stereo-pair stream position |pos|. PAL is a plain
+// constant stride; NTSC/PAL-M inverts the cumulative round(n × 8008 / 5)
+// mapping by estimate-then-correct, so the 1602/1601 cadence stays exact at
+// every position (SMPTE 272M-1994 §14.3 Table 1). Same arithmetic as
+// audio_align's frame_containing_pair().
+uint64_t frame_containing_pair(uint64_t pos, orc::VideoSystem system) {
+  switch (system) {
+    case orc::VideoSystem::PAL:
+      // ITU-R BT.1700 Annex 1 Part B (625-line PAL): 1920 pairs per frame.
+      return pos / 1920u;
+    case orc::VideoSystem::NTSC:
+    case orc::VideoSystem::PAL_M: {
+      uint64_t n = pos * 5u / 8008u;
+      while (orc::audio_pair_offset(n + 1, system) <= pos) ++n;
+      while (n > 0 && orc::audio_pair_offset(n, system) > pos) --n;
+      return n;
+    }
+    default:
+      // VideoSystem::Unknown has no defined audio layout.
+      return 0;
+  }
+}
+
+// Lower-case spelling of an AudioOrigin for the view layer, so the GUI/CLI need
+// no knowledge of the SDK enum.
+const char* audio_origin_name(orc::AudioOrigin origin) {
+  switch (origin) {
+    case orc::AudioOrigin::ANALOGUE:
+      return "analogue";
+    case orc::AudioOrigin::HIFI:
+      return "hifi";
+    case orc::AudioOrigin::EFM:
+      return "efm";
+    case orc::AudioOrigin::IMPORTED:
+      return "imported";
+    case orc::AudioOrigin::DERIVED:
+      return "derived";
+    case orc::AudioOrigin::UNKNOWN:
+    default:
+      return "unknown";
+  }
+}
+
+// The representation's video system, or Unknown when it reports no parameters.
+orc::VideoSystem system_of(
+    const orc::VideoFrameRepresentation& representation) {
+  const auto params = representation.get_video_parameters();
+  return params ? params->system : orc::VideoSystem::Unknown;
+}
+
+// True when the system fixes a usable audio cadence. audio_pairs_in_frame()
+// returns 0 for VideoSystem::Unknown, which is exactly the "no addressable
+// audio" condition.
+bool cadence_is_defined(orc::VideoSystem system) {
+  return orc::audio_pairs_in_frame(0, system) > 0;
+}
+
+}  // namespace
+
+std::vector<orc::AudioPairView> enumerate_audio_channel_pairs(
+    const orc::VideoFrameRepresentation& representation) {
+  std::vector<orc::AudioPairView> pairs;
+  if (!cadence_is_defined(system_of(representation))) {
+    return pairs;
+  }
+
+  const size_t count = representation.audio_channel_pair_count();
+  pairs.reserve(count);
+  for (size_t p = 0; p < count; ++p) {
+    const auto descriptor = representation.get_audio_channel_pair_descriptor(p);
+    orc::AudioPairView view;
+    view.index = p;
+    view.name = descriptor ? descriptor->name : std::string();
+    view.origin = audio_origin_name(descriptor ? descriptor->origin
+                                               : orc::AudioOrigin::UNKNOWN);
+    pairs.push_back(std::move(view));
+  }
+  return pairs;
+}
+
+std::shared_ptr<IAudioStreamReader> make_audio_stream_reader(
+    std::shared_ptr<const orc::VideoFrameRepresentation> representation,
+    size_t pair) {
+  if (!representation) {
+    return nullptr;
+  }
+  if (pair >= representation->audio_channel_pair_count()) {
+    return nullptr;
+  }
+  const orc::VideoSystem system = system_of(*representation);
+  if (!cadence_is_defined(system)) {
+    return nullptr;
+  }
+  return std::make_shared<RepresentationAudioStreamReader>(
+      std::move(representation), pair, system);
+}
+
+RepresentationAudioStreamReader::RepresentationAudioStreamReader(
+    std::shared_ptr<const orc::VideoFrameRepresentation> representation,
+    size_t pair, orc::VideoSystem system)
+    : representation_(std::move(representation)),
+      pair_(pair),
+      system_(system),
+      range_(representation_ ? representation_->frame_range()
+                             : orc::FrameIDRange{0, 0}) {
+  // An empty representation must not present frame 0 as readable.
+  if (!representation_) {
+    range_ = orc::FrameIDRange{1, 0};
+  }
+}
+
+void RepresentationAudioStreamReader::prime(
+    const AudioPrimeProgressCallback& progress) {
+  if (!representation_) {
+    return;
+  }
+  // AudioPrimeProgressCallback is signature-compatible with the SDK's
+  // AudioDecodeProgressFn, so this forwards straight to the producer.
+  representation_->prime_audio_decode(progress);
+}
+
+std::vector<float> RepresentationAudioStreamReader::readFrames(
+    orc::FrameID first_frame, uint64_t frame_count) {
+  std::vector<float> out;
+  if (!representation_ || frame_count == 0 || range_.empty()) {
+    return out;
+  }
+
+  // Clamp the requested run to the readable range.
+  const orc::FrameID first = std::max(first_frame, range_.first);
+  if (first > range_.last) {
+    return out;
+  }
+  const uint64_t requested_end = first_frame + frame_count;
+  if (requested_end <= first) {
+    return out;
+  }
+  const orc::FrameID last = std::min(requested_end - 1, range_.last);
+
+  // Size the output from the cadence, not from what the producer returns: a
+  // short or missing block becomes silence rather than a shortened buffer, so
+  // the audio clock stays aligned with the frame timeline.
+  const uint64_t total_pairs = orc::audio_pair_offset(last + 1, system_) -
+                               orc::audio_pair_offset(first, system_);
+  out.assign(static_cast<size_t>(total_pairs) * 2, 0.0f);
+
+  size_t write = 0;
+  for (orc::FrameID frame = first; frame <= last; ++frame) {
+    const size_t expected_samples =
+        static_cast<size_t>(orc::audio_pairs_in_frame(frame, system_)) * 2;
+    const std::vector<int32_t> carrier =
+        representation_->get_audio_samples(pair_, frame);
+    // A representation may legitimately return nothing for a frame (e.g. a
+    // placeholder pair); the pre-zeroed span then plays as silence. Anything
+    // longer than the cadence allows is truncated for the same reason.
+    const size_t convert = std::min(carrier.size(), expected_samples);
+    for (size_t s = 0; s < convert; ++s) {
+      out[write + s] = orc::audio_carrier_to_float(carrier[s]);
+    }
+    write += expected_samples;
+  }
+
+  return out;
+}
+
+uint64_t RepresentationAudioStreamReader::frameForPairPosition(
+    uint64_t pair_position) const {
+  return frame_containing_pair(pair_position, system_);
+}
+
+uint64_t RepresentationAudioStreamReader::pairPositionForFrame(
+    orc::FrameID frame) const {
+  return orc::audio_pair_offset(frame, system_);
+}
+
+orc::FrameIDRange RepresentationAudioStreamReader::frameRange() const {
+  return range_;
+}
+
+}  // namespace orc::presenters

--- a/orc/presenters/src/representation_audio_stream_reader.h
+++ b/orc/presenters/src/representation_audio_stream_reader.h
@@ -1,0 +1,87 @@
+/*
+ * File:        representation_audio_stream_reader.h
+ * Module:      orc-presenters
+ * Purpose:     IAudioStreamReader backed by a resolved VideoFrameRepresentation
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <orc/stage/common_types.h>  // VideoSystem
+#include <orc/stage/video_frame_representation.h>
+#include <orc_audio_views.h>  // AudioPairView
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "audio_stream_reader.h"
+
+namespace orc::presenters {
+
+/**
+ * @brief Serves one channel pair of a resolved representation as float stereo.
+ *
+ * Internal to the presenter layer: the GUI only ever sees IAudioStreamReader.
+ * Constructed directly in unit tests against a mocked representation, which is
+ * why it is a named class rather than a lambda inside the presenter.
+ *
+ * Holding the representation shared_ptr keeps it alive for the playback
+ * session — the same thing an export sink does for the duration of a run. Frame
+ * *sample* pointers are never retained: get_audio_samples() returns by value.
+ *
+ * Thread safety: see IAudioStreamReader. Construct on the render worker, then
+ * read from one other thread.
+ */
+class RepresentationAudioStreamReader final : public IAudioStreamReader {
+ public:
+  /**
+   * @param representation Resolved representation carrying the audio (non-null)
+   * @param pair           Channel-pair index to serve
+   * @param system         Video system that fixes the SMPTE 272M cadence
+   */
+  RepresentationAudioStreamReader(
+      std::shared_ptr<const orc::VideoFrameRepresentation> representation,
+      size_t pair, orc::VideoSystem system);
+
+  void prime(const AudioPrimeProgressCallback& progress) override;
+
+  std::vector<float> readFrames(orc::FrameID first_frame,
+                                uint64_t frame_count) override;
+
+  uint64_t frameForPairPosition(uint64_t pair_position) const override;
+
+  uint64_t pairPositionForFrame(orc::FrameID frame) const override;
+
+  orc::FrameIDRange frameRange() const override;
+
+ private:
+  std::shared_ptr<const orc::VideoFrameRepresentation> representation_;
+  size_t pair_ = 0;
+  orc::VideoSystem system_ = orc::VideoSystem::Unknown;
+  orc::FrameIDRange range_{};
+};
+
+/**
+ * @brief Enumerate a representation's audio channel pairs as view types.
+ *
+ * Returns an empty list when the representation carries no pairs, or when its
+ * video system leaves the SMPTE 272M-1994 §14.3 cadence undefined — such audio
+ * cannot be addressed by frame, so it is presented as absent.
+ */
+std::vector<orc::AudioPairView> enumerate_audio_channel_pairs(
+    const orc::VideoFrameRepresentation& representation);
+
+/**
+ * @brief Wrap one channel pair of a representation as a playback reader.
+ *
+ * @return Reader, or nullptr when @p representation is null, @p pair is out of
+ *         range, or the video system leaves the cadence undefined.
+ */
+std::shared_ptr<IAudioStreamReader> make_audio_stream_reader(
+    std::shared_ptr<const orc::VideoFrameRepresentation> representation,
+    size_t pair);
+
+}  // namespace orc::presenters

--- a/orc/sdk/abi_history.yaml
+++ b/orc/sdk/abi_history.yaml
@@ -206,6 +206,14 @@ history:
       TBC metadata marks both fields as padding, alongside the synthetic
       gap-fill frames inserted by `frame_map`/`source_align` (issue #77).
       Comment only; no layout or vtable change, no rebuild required.
+      Also ABI-neutral: `orc/stage/audio/audio_sample_feed.h` is a new
+      stage-tier header, promoted verbatim from the private sink-side
+      `orc/plugins/stages/sinks/common/audio_sample_feed.h` so preview
+      playback can share the carrier-domain conversions with the encoders and
+      WAV writers. Additive and inline-only (`audio_carrier_to_float/_s32/
+      _s16`, `audio_apply_gain`, the `kAudioCarrier{Min,Max}` constants): no
+      type crosses the plugin boundary, so nothing existing changes layout or
+      vtable and no rebuild is required.
     summary: >-
       `NodeTypeInfo` drops the free-text `menu_category` field and the unused
       `SinkCategory` enum/`sink_category` field. The Add Stage menu category is

--- a/orc/sdk/include/orc/stage/audio/audio_sample_feed.h
+++ b/orc/sdk/include/orc/stage/audio/audio_sample_feed.h
@@ -1,15 +1,19 @@
 /*
  * File:        audio_sample_feed.h
- * Module:      orc-core
+ * Module:      decode-orc Plugin SDK (stage contract)
  * Purpose:     Pure conversions from the 24-bit-in-int32 pipeline audio
- *              carrier to the video sink encoders' sample formats
+ *              carrier to consumer sample formats (float, S32, S16)
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2026 decode-orc contributors
  */
 
-#ifndef ORC_CORE_AUDIO_SAMPLE_FEED_H
-#define ORC_CORE_AUDIO_SAMPLE_FEED_H
+#pragma once
+
+// SDK TIER: stage/audio — the carrier-domain conversions every audio consumer
+// shares (encoders, WAV writers, preview playback). Inline functions only: no
+// type layout crosses the plugin boundary here, so a change never bumps the
+// host ABI version.
 
 #include <algorithm>
 #include <cmath>
@@ -22,7 +26,7 @@ namespace orc {
 inline constexpr int32_t kAudioCarrierMin = -8388608;
 inline constexpr int32_t kAudioCarrierMax = 8388607;
 
-// Float feed (AAC FLTP/FLT): full-scale 24-bit maps to ±1.0.
+// Float feed (AAC FLTP/FLT, QAudioSink Float): full-scale 24-bit maps to ±1.0.
 inline float audio_carrier_to_float(int32_t carrier) {
   return static_cast<float>(carrier) / 8388608.0f;
 }
@@ -47,5 +51,3 @@ inline int32_t audio_apply_gain(int32_t carrier, double gain) {
 }
 
 }  // namespace orc
-
-#endif  // ORC_CORE_AUDIO_SAMPLE_FEED_H

--- a/orc/sdk/sdk_headers.yaml
+++ b/orc/sdk/sdk_headers.yaml
@@ -125,6 +125,12 @@ headers:
     deprecated: false
     since_abi: ""
     notes: "Audio channel-pair model shared by all"
+  - path: orc/stage/audio/audio_sample_feed.h
+    tier: stage
+    domain: "audio"
+    deprecated: false
+    since_abi: ""
+    notes: "Pure conversions from the 24-bit-in-int32 pipeline audio"
   - path: orc/stage/audio_channel_pair.h
     tier: stage
     domain: "foundation"

--- a/orc/sdk/src/colour_preview_conversion.cpp
+++ b/orc/sdk/src/colour_preview_conversion.cpp
@@ -10,6 +10,7 @@
 #include <orc/support/colour_preview_conversion.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <vector>
@@ -74,6 +75,91 @@ uint8_t to_u8(double value) {
   return static_cast<uint8_t>(scaled);
 }
 
+// ---------------------------------------------------------------------------
+// Transfer-function lookup tables
+// ---------------------------------------------------------------------------
+//
+// decode_transfer_to_linear() followed by encode_linear_to_srgb() is a pure,
+// monotonic function of one scalar, so the pair collapses into a single table.
+// Evaluating them directly costs two std::pow per component — six per pixel,
+// over four million per PAL frame — which dominated colour preview rendering.
+//
+// The composed curve is smooth apart from its piecewise knees, so linear
+// interpolation between 4096 samples reconstructs it well below the 1/255 step
+// of the 8-bit output. Measured against direct evaluation over two million
+// inputs per characteristic: peak reconstruction error 2.0e-4 of full scale
+// (the BT.709 knee at 0.081, which falls between two table nodes) and 1.0e-6
+// elsewhere. That leaves the rendered byte identical for all but ~0.0002 % of
+// inputs, which land within half a code of a rounding boundary and come out one
+// code away; no input differs by more than one code. See the accuracy
+// assertions in preview_carrier_conversion_test.cpp.
+constexpr size_t kTransferLutIntervals = 4096;
+
+class TransferLut {
+ public:
+  explicit TransferLut(ColorimetricTransferCharacteristics transfer) {
+    for (size_t i = 0; i <= kTransferLutIntervals; ++i) {
+      const double nl =
+          static_cast<double>(i) / static_cast<double>(kTransferLutIntervals);
+      samples_[i] =
+          encode_linear_to_srgb(decode_transfer_to_linear(nl, transfer));
+    }
+  }
+
+  // @p non_linear must already be clamped to [0, 1].
+  double encode(double non_linear) const {
+    const double scaled =
+        non_linear * static_cast<double>(kTransferLutIntervals);
+    const size_t index = static_cast<size_t>(scaled);
+    if (index >= kTransferLutIntervals) {
+      return samples_[kTransferLutIntervals];
+    }
+    const double fraction = scaled - static_cast<double>(index);
+    return samples_[index] + fraction * (samples_[index + 1] - samples_[index]);
+  }
+
+ private:
+  std::array<double, kTransferLutIntervals + 1> samples_{};
+};
+
+// One table per transfer characteristic, built on first use. The tables are
+// immutable once constructed, so the function-local statics are safe to share
+// across the render threads that reach this conversion.
+const TransferLut& transfer_lut_for(
+    ColorimetricTransferCharacteristics transfer) {
+  switch (transfer) {
+    case ColorimetricTransferCharacteristics::Gamma22: {
+      static const TransferLut lut(
+          ColorimetricTransferCharacteristics::Gamma22);
+      return lut;
+    }
+    case ColorimetricTransferCharacteristics::Gamma28: {
+      static const TransferLut lut(
+          ColorimetricTransferCharacteristics::Gamma28);
+      return lut;
+    }
+    case ColorimetricTransferCharacteristics::BT709: {
+      static const TransferLut lut(ColorimetricTransferCharacteristics::BT709);
+      return lut;
+    }
+    case ColorimetricTransferCharacteristics::BT1886: {
+      static const TransferLut lut(ColorimetricTransferCharacteristics::BT1886);
+      return lut;
+    }
+    case ColorimetricTransferCharacteristics::BT1886App1: {
+      static const TransferLut lut(
+          ColorimetricTransferCharacteristics::BT1886App1);
+      return lut;
+    }
+    case ColorimetricTransferCharacteristics::Unspecified:
+    default: {
+      static const TransferLut lut(
+          ColorimetricTransferCharacteristics::Unspecified);
+      return lut;
+    }
+  }
+}
+
 }  // namespace
 
 PreviewImage render_preview_from_colour_carrier(
@@ -101,6 +187,11 @@ PreviewImage render_preview_from_colour_carrier(
   const double y_range = carrier.cvbs_white - carrier.cvbs_black;
   const double uv_range = carrier.cvbs_white - carrier.cvbs_blanking;
 
+  // Transfer decode and sRGB encode are resolved once per frame into a single
+  // interpolated table; the pixel loop then costs no transcendentals at all.
+  const TransferLut& transfer =
+      transfer_lut_for(carrier.colorimetry.transfer_characteristics);
+
   const size_t samples =
       static_cast<size_t>(carrier.width) * static_cast<size_t>(carrier.height);
   for (size_t i = 0; i < samples; ++i) {
@@ -117,16 +208,9 @@ PreviewImage render_preview_from_colour_carrier(
     g_nl = std::clamp(g_nl, 0.0, 1.0);
     b_nl = std::clamp(b_nl, 0.0, 1.0);
 
-    const double r_linear = decode_transfer_to_linear(
-        r_nl, carrier.colorimetry.transfer_characteristics);
-    const double g_linear = decode_transfer_to_linear(
-        g_nl, carrier.colorimetry.transfer_characteristics);
-    const double b_linear = decode_transfer_to_linear(
-        b_nl, carrier.colorimetry.transfer_characteristics);
-
-    const double r_srgb = encode_linear_to_srgb(r_linear);
-    const double g_srgb = encode_linear_to_srgb(g_linear);
-    const double b_srgb = encode_linear_to_srgb(b_linear);
+    const double r_srgb = transfer.encode(r_nl);
+    const double g_srgb = transfer.encode(g_nl);
+    const double b_srgb = transfer.encode(b_nl);
 
     const size_t pixel = i * 3;
     image.rgb_data[pixel + 0] = to_u8(r_srgb);

--- a/orc/view-types/orc_audio_views.h
+++ b/orc/view-types/orc_audio_views.h
@@ -1,0 +1,34 @@
+/*
+ * File:        orc_audio_views.h
+ * Module:      orc-view-types
+ * Purpose:     Audio channel-pair view types shared by presenters, GUI and CLI
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace orc {
+
+/**
+ * @brief One audio channel pair available at a node's output.
+ *
+ * Every pipeline audio channel pair is stereo, 48 kHz frame-locked and
+ * 24-bit-in-int32 (SMPTE 272M-1994 §1.2/§1.3), so a view needs only the pair's
+ * identity and provenance to present it. @c index is the pair index at the
+ * resolved representation and is what audio sample access is keyed on; it is
+ * node-specific and must be re-enumerated when the viewed node changes.
+ */
+struct AudioPairView {
+  size_t index = 0;  ///< Stable pair index at the node (0-based)
+  std::string name;  ///< Descriptor name, e.g. "Analogue", "EFM digital audio"
+  /// Lower-case AudioOrigin spelling: "analogue", "hifi", "efm", "imported",
+  /// "derived" or "unknown".
+  std::string origin;
+};
+
+}  // namespace orc


### PR DESCRIPTION
## Summary

This PR adds the ability to preview audio as well as video when previewing decode-orc stages.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

Unit and functional testing

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [x] Related docs were updated if needed
- [ ] Linked issue (if applicable)