### PR TITLE
Issue 245

### DIFF
--- a/docs/cli-user-guide/overview.md
+++ b/docs/cli-user-guide/overview.md
@@ -171,7 +171,7 @@ orc-cli \
 The same thing with short options and a CVBS source:
 
 ```bash
-orc-cli -i "NTSC_CVBS_Source=input_path=capture.composite" -o "video_sink=output_path=capture.mp4"
+orc-cli -i "NTSC_CVBS_Source=input_path=capture.cvbs" -o "video_sink=output_path=capture.mp4"
 ```
 
 Any of the three may be omitted, but at least one must be non-empty.

--- a/docs/gui-user-guide/dialogues/main.md
+++ b/docs/gui-user-guide/dialogues/main.md
@@ -54,8 +54,8 @@ When you choose **File → Quick Project…**, Orc-GUI asks you to select a vide
 
 * `.tbc` (composite TBC)
 * `.tbcc` / `.tbcy` (YC TBC; requires both files as a pair)
-* `.composite` (composite CVBS)
-* `.y` / `.c` (YC CVBS; requires both files as a pair)
+* `.cvbs` (composite CVBS)
+* `.cvbsy` / `.cvbsc` (YC CVBS; requires both files as a pair)
 
 Orc-GUI then looks for the associated metadata alongside the file:
 

--- a/docs/gui-user-guide/quick-projects.md
+++ b/docs/gui-user-guide/quick-projects.md
@@ -10,7 +10,7 @@ The Quick Project feature provides the fastest way to get started with decoding 
 
 - Open **File** → **Quick Project...**
 - A file dialog will open asking you to select a video file
-- Choose a `.tbc`, `.tbcc`, or `.tbcy` file (TBC captures), or a `.composite`, `.y`, or `.c` file (CVBS captures) from your system
+- Choose a `.tbc`, `.tbcc`, or `.tbcy` file (TBC captures), or a `.cvbs`, `.cvbsy`, or `.cvbsc` file (CVBS captures) from your system
 - The application will automatically:
     - Detect the video format based on the file metadata (`.tbc.db` for TBC, `.meta` for CVBS)
     - Create a new project
@@ -49,8 +49,8 @@ The application supports the following video file formats:
 
 - `.tbc` - Composite TBC video files
 - `.tbcy` / `.tbcc` - Y/C TBC video files (luma and chroma; both files required as a pair)
-- `.composite` - Composite CVBS video files
-- `.y` / `.c` - Y/C CVBS video files (both files required as a pair)
+- `.cvbs` - Composite CVBS video files
+- `.cvbsy` / `.cvbsc` - Y/C CVBS video files (both files required as a pair)
 
 ### Tips
 

--- a/docs/gui-user-guide/stages/sink-core-stages.md
+++ b/docs/gui-user-guide/stages/sink-core-stages.md
@@ -131,12 +131,12 @@ For each field the stage reads the two caption bytes embedded in VBI Line 21, ac
 **Use this stage when:**
 
 * You want to archive or exchange a processed CVBS signal in the standard CVBS file format.
-* You want to produce a `.composite` or `.y`/`.c` output that can be re-opened by the CVBS Source stage.
+* You want to produce a `.cvbs` or `.cvbsy`/`.cvbsc` output that can be re-opened by the CVBS Source stage.
 * You need to write associated dropout, audio, EFM, or AC3 sidecars alongside the video.
 
 **What it does**
 
-This stage writes processed frame data using the selected sample encoding, and a `.meta` SQLite sidecar. The output signal type follows the project type automatically: a composite project is written as a single `.composite` file and a Y/C project as a `.y`/`.c` pair (per the CVBS file format naming convention) — Y/C cannot be derived from a composite signal, so this is not a choice. The `.meta` file records the signal type and the selected `sample_encoding_preset`, and always carries `signal_state_preset = 'STANDARD_TBC_LOCKED'`. The signal state is not user-configurable — it reflects the pipeline invariant that only locked, standard-state signals appear at this point.
+This stage writes processed frame data using the selected sample encoding, and a `.meta` SQLite sidecar. The output signal type follows the project type automatically: a composite project is written as a single `.cvbs` file and a Y/C project as a `.cvbsy`/`.cvbsc` pair (per the CVBS file format naming convention) — Y/C cannot be derived from a composite signal, so this is not a choice. The `.meta` file records the signal type and the selected `sample_encoding_preset`, and always carries `signal_state_preset = 'STANDARD_TBC_LOCKED'`. The signal state is not user-configurable — it reflects the pipeline invariant that only locked, standard-state signals appear at this point.
 
 Associated sidecars are written automatically when the upstream source provides them:
 
@@ -150,7 +150,7 @@ A CVBS file written by this stage can be round-tripped back through the CVBS Sou
 **Parameters**
 
 * `output_path` (string)
-    - Base path for output files. A trailing `.composite`, `.y`, or `.c` extension is stripped when present.
+    - Base path for output files. A trailing `.cvbs`, `.cvbsy`, or `.cvbsc` extension is stripped when present.
     - Required.
 
 * `sample_encoding` (string)

--- a/docs/gui-user-guide/stages/source-stages.md
+++ b/docs/gui-user-guide/stages/source-stages.md
@@ -81,11 +81,11 @@ Associated audio (analogue `.pcm`), EFM disc data (`.efm`), and AC3 RF symbols (
 
 **Use this stage when:**
 
-* Your source is a CVBS file (`.composite`, or a `.y`/`.c` pair for Y/C projects) rather than a TBC capture
+* Your source is a CVBS file (`.cvbs`, or a `.cvbsy`/`.cvbsc` pair for Y/C projects) rather than a TBC capture
 
 **What it does**
 
-This stage reads CVBS payloads from `.composite` files (or `.y`/`.c` pairs) and normalises them to the CVBS_U10_4FSC 10-bit domain. By default the video system, sample encoding, and signal state are read from the `.meta` SQLite sidecar; because the CVBS file format declares metadata optional, the sample encoding can also be selected manually so that sources without a sidecar can be used.
+This stage reads CVBS payloads from `.cvbs` files (or `.cvbsy`/`.cvbsc` pairs) and normalises them to the CVBS_U10_4FSC 10-bit domain. By default the video system, sample encoding, and signal state are read from the `.meta` SQLite sidecar; because the CVBS file format declares metadata optional, the sample encoding can also be selected manually so that sources without a sidecar can be used.
 
 Only the `STANDARD_TBC_LOCKED` signal-state preset is accepted. Files with any other signal state are rejected with a clear error before any frame data is returned. When a sample encoding is selected manually the sidecar is ignored: the signal is assumed to be TBC-locked and the frame count is measured from the file size.
 
@@ -105,10 +105,10 @@ Associated dropout, audio, EFM, and AC3 sidecars are loaded automatically if pre
 The file-path parameters offered match the project's source type: a composite project shows only the CVBS file path, while a Y/C project shows only the Y (luma) and C (chroma) paths.
 
 * `input_path` (file path)
-    - Path to the composite data file (`.composite`). Composite projects only.
+    - Path to the composite data file (`.cvbs`). Composite projects only.
 
 * `y_path` / `c_path` (file paths)
-    - Paths to the luma (`.y`) and chroma (`.c`) channel files. Y/C projects only; set together.
+    - Paths to the luma (`.cvbsy`) and chroma (`.cvbsc`) channel files. Y/C projects only; set together.
 
 * `sample_encoding` (string)
     - `From metadata` (default) reads the encoding from the `.meta` sidecar.

--- a/orc-tests/core/functional/contracts/multi_track_audio_roundtrip_test.cpp
+++ b/orc-tests/core/functional/contracts/multi_track_audio_roundtrip_test.cpp
@@ -206,7 +206,7 @@ void run_roundtrip(orc::VideoSystem system, size_t frame_count,
   ASSERT_TRUE(write_result.success) << write_result.status_message;
   EXPECT_EQ(write_result.frames_written, frame_count);
 
-  EXPECT_TRUE(std::filesystem::exists(base + ".composite"));
+  EXPECT_TRUE(std::filesystem::exists(base + ".cvbs"));
   ASSERT_TRUE(std::filesystem::exists(base + ".meta"));
   // Single-digit channel pair naming (CVBS spec v1.4.0); the legacy
   // two-digit names must not appear.
@@ -227,7 +227,7 @@ void run_roundtrip(orc::VideoSystem system, size_t frame_count,
 
   // --- Read back with the real cvbs_source stage ---
   const std::map<std::string, orc::ParameterValue> parameters{
-      {"input_path", base + ".composite"}};
+      {"input_path", base + ".cvbs"}};
   ASSERT_TRUE(source.set_parameters(parameters));
 
   orc::ObservationContext observation_context;

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -441,6 +441,7 @@ orc_add_core_unit_tests(
 
         observation/observation_store_test.cpp
         observation/observation_store_persistence_test.cpp
+        observation/store_backed_observation_context_test.cpp
         observation/observation_invalidation_test.cpp
         observation/observer_pass_test.cpp
         observation/observation_scheduler_test.cpp

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -457,4 +457,5 @@ orc_add_core_unit_tests(
                 preview_types/preview_helpers_test.cpp
                 preview_types/preview_navigation_hint_test.cpp
                 preview_types/preview_view_registry_test.cpp
+                preview_types/node_representation_resolution_test.cpp
         )

--- a/orc-tests/core/unit/contracts/project_to_dag_contract_test.cpp
+++ b/orc-tests/core/unit/contracts/project_to_dag_contract_test.cpp
@@ -125,7 +125,7 @@ TEST(ProjectToDagContractTest,
       orc::project_io::add_node(project, "PAL_CVBS_Source", 0.0, 0.0);
 
   std::map<std::string, orc::ParameterValue> params = {
-      {"input_path", std::string("fixtures/test.composite")},
+      {"input_path", std::string("fixtures/test.cvbs")},
       {"use_metadata", false},
       {"sample_encoding", std::string("CVBS_TPG21_4FSC")}};
 

--- a/orc-tests/core/unit/observation/observation_scheduler_test.cpp
+++ b/orc-tests/core/unit/observation/observation_scheduler_test.cpp
@@ -560,6 +560,175 @@ TEST(ObservationScheduler, PoolDoesNotChunkStatefulItems) {
 }
 
 // ---------------------------------------------------------------------------
+// Enqueue-time deduplication
+//
+// A playing preview re-plans its prefetch window on every frame advance, so
+// overlapping plans are routine. Without dedup the same not-yet-observed frame
+// is enqueued on each move and rendered several times over by different
+// workers.
+// ---------------------------------------------------------------------------
+
+// Frames observed, in call order.
+std::vector<FrameID> observed_frames(const MockTaskRunner& runner) {
+  std::vector<FrameID> out;
+  for (const auto& call : runner.calls()) {
+    out.push_back(call.frame);
+  }
+  return out;
+}
+
+// Contiguous-range item helper.
+ObservationWorkItem range_item(NodeID node, NodeFingerprint fingerprint,
+                               FrameID first, FrameID last,
+                               ObservationPriority priority) {
+  ObservationWorkItem item;
+  item.node_id = node;
+  item.fingerprint = std::move(fingerprint);
+  item.frames = FrameIDRange{first, last};
+  item.priority = priority;
+  return item;
+}
+
+TEST(ObservationScheduler, DropsFramesAlreadyQueuedAtTheSamePriority) {
+  MockTaskRunner* runner = nullptr;
+  auto scheduler = make_scheduler(&runner);
+
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 0, 9, ObservationPriority::kPrefetch));
+  // Overlapping window: only the leading edge (10-14) is new work.
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 5, 14, ObservationPriority::kPrefetch));
+
+  while (scheduler->process_one_for_testing()) {
+  }
+
+  const auto frames = observed_frames(*runner);
+  ASSERT_EQ(frames.size(), 15u);  // 15 frames, each exactly once
+  for (FrameID f = 0; f < 15; ++f) {
+    EXPECT_EQ(frames[f], f);
+  }
+}
+
+TEST(ObservationScheduler, EnqueuesOnlyTheGapsAroundPendingWork) {
+  MockTaskRunner* runner = nullptr;
+  auto scheduler = make_scheduler(&runner);
+
+  // A pending item in the middle of a later, wider request.
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 5, 6, ObservationPriority::kPrefetch));
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 0, 9, ObservationPriority::kPrefetch));
+
+  while (scheduler->process_one_for_testing()) {
+  }
+
+  auto frames = observed_frames(*runner);
+  ASSERT_EQ(frames.size(), 10u);
+  std::sort(frames.begin(), frames.end());
+  for (FrameID f = 0; f < 10; ++f) {
+    EXPECT_EQ(frames[f], f);
+  }
+}
+
+TEST(ObservationScheduler, FullyCoveredItemEnqueuesNothing) {
+  MockTaskRunner* runner = nullptr;
+  auto scheduler = make_scheduler(&runner);
+
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 0, 9, ObservationPriority::kPrefetch));
+  const std::size_t queued = scheduler->queued_count();
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 2, 5, ObservationPriority::kPrefetch));
+
+  EXPECT_EQ(scheduler->queued_count(), queued);
+
+  while (scheduler->process_one_for_testing()) {
+  }
+  EXPECT_EQ(runner->call_count(), 10u);
+}
+
+TEST(ObservationScheduler, LowerPriorityWorkNeverSuppressesUrgentWork) {
+  MockTaskRunner* runner = nullptr;
+  auto scheduler = make_scheduler(&runner);
+
+  // A queued sweep must not swallow an interactive request for the same frame:
+  // that frame would inherit the sweep's latency.
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 0, 9, ObservationPriority::kSweep));
+  scheduler->submit(
+      frame_item(NodeID(1), fp("v1"), 5, ObservationPriority::kInteractive));
+
+  while (scheduler->process_one_for_testing()) {
+  }
+
+  const auto frames = observed_frames(*runner);
+  ASSERT_EQ(frames.size(), 11u);
+  EXPECT_EQ(frames.front(), 5u);  // interactive ran first
+  EXPECT_EQ(std::count(frames.begin(), frames.end(), 5u), 2);
+}
+
+TEST(ObservationScheduler, SweepIsSuppressedByPendingPrefetchOfSameFrames) {
+  MockTaskRunner* runner = nullptr;
+  auto scheduler = make_scheduler(&runner);
+
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 4, 6, ObservationPriority::kPrefetch));
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 0, 9, ObservationPriority::kSweep));
+
+  while (scheduler->process_one_for_testing()) {
+  }
+
+  auto frames = observed_frames(*runner);
+  ASSERT_EQ(frames.size(), 10u);
+  std::sort(frames.begin(), frames.end());
+  for (FrameID f = 0; f < 10; ++f) {
+    EXPECT_EQ(frames[f], f);
+  }
+}
+
+TEST(ObservationScheduler, DifferentFingerprintIsNotADuplicate) {
+  MockTaskRunner* runner = nullptr;
+  auto scheduler = make_scheduler(&runner);
+
+  // Same node and frames, different content identity: both must run.
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 0, 3, ObservationPriority::kPrefetch));
+  scheduler->submit(
+      range_item(NodeID(1), fp("v2"), 0, 3, ObservationPriority::kPrefetch));
+
+  while (scheduler->process_one_for_testing()) {
+  }
+  EXPECT_EQ(runner->call_count(), 8u);
+}
+
+TEST(ObservationScheduler, DropsFramesAlreadyInFlight) {
+  MockTaskRunner* runner = nullptr;
+  auto scheduler = make_scheduler(&runner);
+  runner->arm_gate();  // block inside the first observe_frame
+
+  scheduler->start();
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 0, 9, ObservationPriority::kPrefetch));
+  runner->wait_until_entered(1);  // 0-9 is off the queue and in flight
+
+  // The overlapping window must still see 0-9 as pending, not as free work.
+  scheduler->submit(
+      range_item(NodeID(1), fp("v1"), 5, 14, ObservationPriority::kPrefetch));
+
+  runner->release();
+  runner->wait_until_entered(15);  // let both items drain before stopping
+  scheduler->stop();
+
+  auto frames = observed_frames(*runner);
+  ASSERT_EQ(frames.size(), 15u);
+  std::sort(frames.begin(), frames.end());
+  for (FrameID f = 0; f < 15; ++f) {
+    EXPECT_EQ(frames[f], f);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Task 4.3 — scheduling policy (scripted + default)
 // ---------------------------------------------------------------------------
 

--- a/orc-tests/core/unit/observation/observation_test_doubles.h
+++ b/orc-tests/core/unit/observation/observation_test_doubles.h
@@ -31,6 +31,14 @@ class FakeVideoFrameRepresentation final : public VideoFrameRepresentation {
   // Returned for every frame when set (e.g. to mark the content as padding).
   std::optional<FrameDescriptor> descriptor;
 
+  // Returned from get_video_parameters() when set; unset means "no video
+  // parameters", which makes observer applicability filtering fail open.
+  std::optional<SourceParameters> video_parameters;
+
+  std::optional<SourceParameters> get_video_parameters() const override {
+    return video_parameters;
+  }
+
   FrameIDRange frame_range() const override { return {0, 0}; }
   size_t frame_count() const override { return 1; }
   bool has_frame(FrameID id) const override { return id == 0; }

--- a/orc-tests/core/unit/observation/observer_pass_test.cpp
+++ b/orc-tests/core/unit/observation/observer_pass_test.cpp
@@ -237,6 +237,96 @@ TEST(RunFrameObserverPassPadding, NonPaddingDescriptorStillRunsObservers) {
 }
 
 // ---------------------------------------------------------------------------
+// Applicability — observers structurally inapplicable to the source's video
+// system are skipped outright: no run, no records (padding markers included)
+// ---------------------------------------------------------------------------
+
+TEST(RunFrameObserverPassApplicability, InapplicableObserverNeverRunsOrStores) {
+  SpyObservationService spy;
+  // "teletext" is PAL-only in the standard registry; "white_snr" applies to
+  // every system. The spy service runs whatever it is asked to run — the skip
+  // decision under test lives in the pass itself.
+  spy.observers = {make_observer_info("teletext", "1.0.0"),
+                   make_observer_info("white_snr", "1.0.0")};
+  ObservationStore store;
+  FakeVideoFrameRepresentation vfr;
+  SourceParameters params;
+  params.system = VideoSystem::NTSC;
+  vfr.video_parameters = params;
+  const NodeFingerprint fp{"fp"};
+  const FrameID frame = 0;
+
+  ObservationContext ctx;
+  run_frame_observer_pass(spy, spy.observers, vfr, frame, &fp, &store, ctx);
+
+  EXPECT_EQ(spy.total_runs, 1);
+  EXPECT_EQ(spy.runs_by_id.count("teletext"), 0u);
+  EXPECT_EQ(spy.runs_by_id.at("white_snr"), 1);
+
+  // No records under the skipped observer — coverage probes filtered by the
+  // same predicate must not find (or demand) them.
+  for (FieldID::value_type f = 0; f < 2; ++f) {
+    EXPECT_FALSE(store.has({fp, FieldID(f), "teletext", "1.0.0"}))
+        << "field " << f;
+    EXPECT_TRUE(store.has({fp, FieldID(f), "white_snr", "1.0.0"}))
+        << "field " << f;
+  }
+}
+
+TEST(RunFrameObserverPassApplicability, NoVideoParametersFailsOpen) {
+  SpyObservationService spy;
+  spy.observers = {make_observer_info("teletext", "1.0.0")};
+  ObservationStore store;
+  FakeVideoFrameRepresentation vfr;  // video_parameters unset
+  const NodeFingerprint fp{"fp"};
+
+  ObservationContext ctx;
+  run_frame_observer_pass(spy, spy.observers, vfr, 0, &fp, &store, ctx);
+  EXPECT_EQ(spy.total_runs, 1);  // filtering fails open — observer runs
+}
+
+TEST(RunFrameObserverPassApplicability, ApplicableSystemStillRuns) {
+  SpyObservationService spy;
+  spy.observers = {make_observer_info("teletext", "1.0.0")};
+  ObservationStore store;
+  FakeVideoFrameRepresentation vfr;
+  SourceParameters params;
+  params.system = VideoSystem::PAL;
+  vfr.video_parameters = params;
+  const NodeFingerprint fp{"fp"};
+
+  ObservationContext ctx;
+  run_frame_observer_pass(spy, spy.observers, vfr, 0, &fp, &store, ctx);
+  EXPECT_EQ(spy.total_runs, 1);
+  EXPECT_TRUE(store.has({fp, FieldID(0), "teletext", "1.0.0"}));
+}
+
+TEST(RunFrameObserverPassApplicability, PaddingStoresNoPadRecordWhenSkipped) {
+  SpyObservationService spy;
+  spy.observers = {make_observer_info("teletext", "1.0.0"),
+                   make_observer_info("white_snr", "1.0.0")};
+  ObservationStore store;
+  FakeVideoFrameRepresentation vfr;
+  mark_as_padding(vfr);
+  SourceParameters params;
+  params.system = VideoSystem::NTSC;
+  vfr.video_parameters = params;
+  const NodeFingerprint fp{"fp"};
+
+  ObservationContext ctx;
+  run_frame_observer_pass(spy, spy.observers, vfr, 0, &fp, &store, ctx);
+  EXPECT_EQ(spy.total_runs, 0);
+
+  for (FieldID::value_type f = 0; f < 2; ++f) {
+    EXPECT_FALSE(store.has({fp, FieldID(f), "teletext", "1.0.0"}))
+        << "field " << f;
+    const auto rec = store.get({fp, FieldID(f), "white_snr", "1.0.0"});
+    ASSERT_TRUE(rec.has_value()) << "field " << f;
+    EXPECT_EQ(*rec, pad_record()) << "field " << f;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Pass-through aliasing — a frame's content known under several provenances
 // (own node first, then byte-identical upstream nodes) shares one observation
 // ---------------------------------------------------------------------------

--- a/orc-tests/core/unit/observation/store_backed_observation_context_test.cpp
+++ b/orc-tests/core/unit/observation/store_backed_observation_context_test.cpp
@@ -1,0 +1,207 @@
+/*
+ * File:        store_backed_observation_context_test.cpp
+ * Module:      orc-core tests
+ * Purpose:     Unit tests for the store-backed read-through observation
+ *              context used by triggered sinks
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "store_backed_observation_context.h"
+
+#include <gtest/gtest.h>
+#include <orc/stage/observation/observation_context.h>
+
+#include <string>
+#include <vector>
+
+namespace orc {
+namespace {
+
+constexpr FieldID::value_type kFieldsPerFrame = 2;
+
+NodeFingerprint fp(const std::string& v) { return NodeFingerprint{v}; }
+
+ObserverInfo stateless_observer(const std::string& id) {
+  ObserverInfo info;
+  info.id = id;
+  info.version = "1.0.0";
+  info.stateless = true;
+  return info;
+}
+
+ObserverInfo stateful_observer(const std::string& id) {
+  ObserverInfo info = stateless_observer(id);
+  info.stateless = false;
+  return info;
+}
+
+ObservationRecord record_with(const std::string& ns, const std::string& key,
+                              int32_t value) {
+  ObservationRecord record;
+  record[ns][key] = value;
+  return record;
+}
+
+ObservationRecordKey key_of(const NodeFingerprint& fingerprint, FieldID field,
+                            const ObserverInfo& observer) {
+  return ObservationRecordKey{fingerprint, field, observer.id,
+                              observer.version};
+}
+
+class StoreBackedObservationContextTest : public ::testing::Test {
+ protected:
+  ObservationStore store_;
+  ObservationContext inner_;
+  NodeFingerprint fingerprint_ = fp("node-a");
+  FrameIDRange range_{0, 3};  // frames 0-3 → fields 0-7
+
+  // Store a record for both fields of @p frame under @p observer.
+  void store_frame(const ObserverInfo& observer, FrameID frame, int32_t value) {
+    const FieldID top(frame * kFieldsPerFrame);
+    const FieldID bottom(frame * kFieldsPerFrame + 1);
+    store_.put(key_of(fingerprint_, top, observer),
+               record_with(observer.id, "value", value));
+    store_.put(key_of(fingerprint_, bottom, observer),
+               record_with(observer.id, "value", value + 1));
+  }
+};
+
+TEST_F(StoreBackedObservationContextTest,
+       ReadLoadsTheTouchedFieldAndOnlyThatField) {
+  const auto observer = stateless_observer("white_snr");
+  store_frame(observer, 0, 10);
+  store_frame(observer, 1, 20);
+  StoreBackedObservationContext context(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+
+  EXPECT_TRUE(context.has(FieldID(0), "white_snr", "value"));
+  const auto value = context.get(FieldID(0), "white_snr", "value");
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(std::get<int32_t>(*value), 10);
+
+  // Only the touched field materialised in the inner context.
+  EXPECT_TRUE(inner_.has(FieldID(0), "white_snr", "value"));
+  EXPECT_FALSE(inner_.has(FieldID(2), "white_snr", "value"));
+}
+
+TEST_F(StoreBackedObservationContextTest, MissingFieldReadsAsAbsent) {
+  const auto observer = stateless_observer("white_snr");
+  StoreBackedObservationContext context(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+
+  EXPECT_FALSE(context.has(FieldID(4), "white_snr", "value"));
+  EXPECT_FALSE(context.get(FieldID(4), "white_snr", "value").has_value());
+}
+
+TEST_F(StoreBackedObservationContextTest,
+       ClearedFieldIsNotResurrectedByALaterRead) {
+  const auto observer = stateless_observer("white_snr");
+  store_frame(observer, 0, 10);
+  StoreBackedObservationContext context(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+
+  ASSERT_TRUE(context.has(FieldID(0), "white_snr", "value"));
+  context.clear_field(FieldID(0));
+  EXPECT_FALSE(context.has(FieldID(0), "white_snr", "value"));
+
+  // A field cleared before ever being read stays gone too: the sink decided
+  // it is done with the field, whatever the store still holds.
+  context.clear_field(FieldID(1));
+  EXPECT_FALSE(context.has(FieldID(1), "white_snr", "value"));
+}
+
+TEST_F(StoreBackedObservationContextTest, ClearWipesAndStopsAllLoading) {
+  const auto observer = stateless_observer("white_snr");
+  store_frame(observer, 0, 10);
+  store_frame(observer, 1, 20);
+  StoreBackedObservationContext context(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+
+  ASSERT_TRUE(context.has(FieldID(0), "white_snr", "value"));
+  context.clear();
+
+  EXPECT_FALSE(context.has(FieldID(0), "white_snr", "value"));
+  EXPECT_FALSE(context.has(FieldID(2), "white_snr", "value"));
+}
+
+TEST_F(StoreBackedObservationContextTest,
+       SetMergesWithStoredRecordsOfTheSameField) {
+  const auto observer = stateless_observer("white_snr");
+  store_frame(observer, 0, 10);
+  StoreBackedObservationContext context(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+
+  // Writing to a field first must not hide its stored records: the load
+  // happens before the write, exactly as the eager pre-load behaved.
+  context.set(FieldID(0), "other", "computed", true);
+
+  EXPECT_TRUE(context.has(FieldID(0), "white_snr", "value"));
+  EXPECT_TRUE(context.has(FieldID(0), "other", "computed"));
+}
+
+TEST_F(StoreBackedObservationContextTest,
+       StatefulObserverLoadsOnlyWhenEveryFrameIsCovered) {
+  const auto observer = stateful_observer("closed_caption");
+  // Frames 0-2 covered, frame 3 missing → nothing may load.
+  store_frame(observer, 0, 10);
+  store_frame(observer, 1, 20);
+  store_frame(observer, 2, 30);
+  StoreBackedObservationContext partial(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+  EXPECT_FALSE(partial.has(FieldID(0), "closed_caption", "value"));
+
+  // With the last frame stored, the stream is complete and loads per field.
+  store_frame(observer, 3, 40);
+  ObservationContext fresh_inner;
+  StoreBackedObservationContext complete(fresh_inner, store_, fingerprint_,
+                                         {observer}, range_);
+  EXPECT_TRUE(complete.has(FieldID(0), "closed_caption", "value"));
+  EXPECT_TRUE(complete.has(FieldID(7), "closed_caption", "value"));
+}
+
+TEST_F(StoreBackedObservationContextTest,
+       FieldOutsideTheRangeDelegatesWithoutLoading) {
+  const auto observer = stateless_observer("white_snr");
+  const FieldID outside(99);
+  store_.put(key_of(fingerprint_, outside, observer),
+             record_with("white_snr", "value", 5));
+  StoreBackedObservationContext context(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+
+  EXPECT_FALSE(context.has(outside, "white_snr", "value"));
+  inner_.set(outside, "manual", "flag", true);
+  EXPECT_TRUE(context.has(outside, "manual", "flag"));
+}
+
+TEST_F(StoreBackedObservationContextTest,
+       GetKeysAndNamespacesAndAllObservationsSeeStoredRecords) {
+  const auto observer = stateless_observer("white_snr");
+  store_frame(observer, 0, 10);
+  StoreBackedObservationContext context(inner_, store_, fingerprint_,
+                                        {observer}, range_);
+
+  const auto namespaces = context.get_namespaces(FieldID(0));
+  ASSERT_EQ(namespaces.size(), 1u);
+  EXPECT_EQ(namespaces[0], "white_snr");
+  const auto keys = context.get_keys(FieldID(0), "white_snr");
+  ASSERT_EQ(keys.size(), 1u);
+  EXPECT_EQ(keys[0], "value");
+  const auto all = context.get_all_observations(FieldID(1));
+  ASSERT_EQ(all.count("white_snr"), 1u);
+  EXPECT_EQ(std::get<int32_t>(all.at("white_snr").at("value")), 11);
+}
+
+TEST_F(StoreBackedObservationContextTest,
+       EmptyFingerprintNeverTouchesTheStore) {
+  const auto observer = stateless_observer("white_snr");
+  store_frame(observer, 0, 10);
+  StoreBackedObservationContext context(inner_, store_, NodeFingerprint{},
+                                        {observer}, range_);
+
+  EXPECT_FALSE(context.has(FieldID(0), "white_snr", "value"));
+}
+
+}  // namespace
+}  // namespace orc

--- a/orc-tests/core/unit/observers/core_observation_service_test.cpp
+++ b/orc-tests/core/unit/observers/core_observation_service_test.cpp
@@ -144,6 +144,99 @@ TEST(CoreObservationService, CreateObserver_HandleForwardsToObserver) {
   handle->process_frame(vfr, FrameID(0), context);
 }
 
+// ---------------------------------------------------------------------------
+// Applicability (standard_observer_applies / filter_applicable_observers)
+// ---------------------------------------------------------------------------
+
+SourceParameters params_for(VideoSystem system) {
+  SourceParameters params;
+  params.system = system;
+  return params;
+}
+
+// Independent restatement of the applicability contract (Observer::applies_to
+// per observer): teletext is PAL-only, fm_code/white_flag are NTSC-only,
+// everything else applies to every system. A drift in either direction fails
+// this test.
+const std::map<std::string, std::set<VideoSystem>> kExpectedApplicability{
+    {"white_snr", {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}},
+    {"black_psnr", {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}},
+    {"burst_level", {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}},
+    {"closed_caption",
+     {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}},
+    {"biphase", {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}},
+    {"colour_frame_phase",
+     {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}},
+    {"disc_quality", {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}},
+    {"fm_code", {VideoSystem::NTSC}},
+    {"white_flag", {VideoSystem::NTSC}},
+    {"teletext", {VideoSystem::PAL}},
+};
+
+TEST(StandardObserverApplies, MatchesApplicabilityContract) {
+  for (const auto& [id, systems] : kExpectedApplicability) {
+    for (const VideoSystem system :
+         {VideoSystem::PAL, VideoSystem::NTSC, VideoSystem::PAL_M}) {
+      EXPECT_EQ(standard_observer_applies(id, params_for(system)),
+                systems.count(system) != 0)
+          << "id=" << id << " system=" << static_cast<int>(system);
+    }
+  }
+}
+
+TEST(StandardObserverApplies, UnknownIdIsAlwaysApplicable) {
+  // Observers injected by a test service must never be filtered.
+  EXPECT_TRUE(standard_observer_applies("not_a_registry_id",
+                                        params_for(VideoSystem::PAL)));
+  EXPECT_TRUE(standard_observer_applies("", params_for(VideoSystem::NTSC)));
+}
+
+TEST(FilterApplicableObservers, DropsInapplicableObserversPerSystem) {
+  CoreObservationService service;
+  const auto all = service.available_observers();
+
+  const auto id_set = [](const std::vector<ObserverInfo>& infos) {
+    std::set<std::string> ids;
+    for (const auto& info : infos) {
+      ids.insert(info.id);
+    }
+    return ids;
+  };
+
+  auto pal_expected = kExpectedObserverIds;
+  pal_expected.erase("fm_code");
+  pal_expected.erase("white_flag");
+  EXPECT_EQ(
+      id_set(filter_applicable_observers(all, params_for(VideoSystem::PAL))),
+      pal_expected);
+
+  auto ntsc_expected = kExpectedObserverIds;
+  ntsc_expected.erase("teletext");
+  EXPECT_EQ(
+      id_set(filter_applicable_observers(all, params_for(VideoSystem::NTSC))),
+      ntsc_expected);
+}
+
+TEST(FilterApplicableObservers, FailsOpenWithoutVideoParameters) {
+  CoreObservationService service;
+  const auto all = service.available_observers();
+  const auto filtered = filter_applicable_observers(all, std::nullopt);
+  ASSERT_EQ(filtered.size(), all.size());
+  for (size_t i = 0; i < all.size(); ++i) {
+    EXPECT_EQ(filtered[i].id, all[i].id);
+  }
+}
+
+TEST(FilterApplicableObservers, KeepsUnknownObserverIds) {
+  ObserverInfo custom;
+  custom.id = "test_only_observer";
+  custom.version = "1.0.0";
+  const auto filtered =
+      filter_applicable_observers({custom}, params_for(VideoSystem::NTSC));
+  ASSERT_EQ(filtered.size(), 1u);
+  EXPECT_EQ(filtered[0].id, "test_only_observer");
+}
+
 }  // namespace
 }  // namespace tests
 }  // namespace orc

--- a/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
+++ b/orc-tests/core/unit/presenters/filtergraph_import_test.cpp
@@ -375,7 +375,7 @@ TEST(FiltergraphImportTest, FormatIsSetBeforeParameterDescriptorsAreFetched) {
   }
 
   const auto result = import_filtergraph_into_project(
-      presenter, "NTSC_CVBS_Source=input_path=a.composite, video_sink");
+      presenter, "NTSC_CVBS_Source=input_path=a.cvbs, video_sink");
 
   EXPECT_TRUE(result.ok);
 }
@@ -505,8 +505,8 @@ TEST(FiltergraphImportTest, ConflictingVideoFormatsFailWithoutMutation) {
 
   const auto result = import_filtergraph_into_project(
       presenter,
-      "NTSC_CVBS_Source=input_path=a.composite[x]; "
-      "PAL_CVBS_Source=input_path=b.composite[y]; [x][y] video_sink");
+      "NTSC_CVBS_Source=input_path=a.cvbs[x]; "
+      "PAL_CVBS_Source=input_path=b.cvbs[y]; [x][y] video_sink");
 
   EXPECT_FALSE(result.ok);
 }

--- a/orc-tests/core/unit/preview_types/node_representation_resolution_test.cpp
+++ b/orc-tests/core/unit/preview_types/node_representation_resolution_test.cpp
@@ -1,0 +1,240 @@
+/*
+ * File:        node_representation_resolution_test.cpp
+ * Module:      orc-tests/core/unit/preview_types
+ * Purpose:     Resolving a node's VideoFrameRepresentation costs a DAG
+ *              execution and nothing more — no frame render, no observer pass
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include <gtest/gtest.h>
+#include <orc/stage/artifact.h>
+#include <orc/stage/observation/observation_context.h>
+#include <orc/stage/stage.h>
+#include <orc/stage/video_frame_representation.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dag_frame_renderer.h"
+#include "preview_renderer.h"
+
+namespace orc {
+namespace {
+
+// A VFR that counts the calls the observer pass makes. run_frame_observer_pass
+// begins by reading the frame's descriptor (the padding-frame check), so a
+// non-zero descriptor count is a reliable marker that observers ran.
+class ProbeVfr final : public VideoFrameRepresentation, public Artifact {
+ public:
+  ProbeVfr(const std::string& id, size_t frames)
+      : Artifact(ArtifactID(id), Provenance{}), frames_(frames) {}
+
+  std::string type_name() const override { return "VideoFrameRepresentation"; }
+
+  FrameIDRange frame_range() const override {
+    return {0, static_cast<FrameID>(frames_ == 0 ? 0 : frames_ - 1)};
+  }
+  size_t frame_count() const override { return frames_; }
+  bool has_frame(FrameID id) const override { return id < frames_; }
+
+  std::optional<FrameDescriptor> get_frame_descriptor(
+      FrameID /*id*/) const override {
+    ++descriptor_calls;
+    return std::nullopt;
+  }
+  const sample_type* get_frame(FrameID /*id*/) const override {
+    ++frame_calls;
+    return nullptr;
+  }
+  std::vector<sample_type> get_frame_copy(FrameID /*id*/) const override {
+    return {};
+  }
+
+  mutable int descriptor_calls = 0;
+  mutable int frame_calls = 0;
+
+ private:
+  size_t frames_;
+};
+
+// Source with two outputs, so a sink's edge index is distinguishable: output 0
+// carries one frame, output 1 carries two.
+class TwoOutputSource final : public DAGStage {
+ public:
+  std::string version() const override { return "1.0.0"; }
+  NodeTypeInfo get_node_type_info() const override {
+    return NodeTypeInfo(NodeType::SOURCE, "two_output_source",
+                        "two_output_source", "", 0, 0, 2, 2,
+                        VideoFormatCompatibility::ALL);
+  }
+  std::vector<ArtifactPtr> execute(
+      const std::vector<ArtifactPtr>& /*inputs*/,
+      const std::map<std::string, ParameterValue>& /*parameters*/,
+      ObservationContext& /*ctx*/) override {
+    ++executes;
+    out0 = std::make_shared<ProbeVfr>("branch_0", 1);
+    out1 = std::make_shared<ProbeVfr>("branch_1", 2);
+    return {out0, out1};
+  }
+  size_t required_input_count() const override { return 0; }
+  size_t output_count() const override { return 2; }
+
+  int executes = 0;
+  std::shared_ptr<ProbeVfr> out0;
+  std::shared_ptr<ProbeVfr> out1;
+};
+
+class Sink final : public DAGStage {
+ public:
+  std::string version() const override { return "1.0.0"; }
+  NodeTypeInfo get_node_type_info() const override {
+    return NodeTypeInfo(NodeType::SINK, "probe_sink", "probe_sink", "", 1, 1, 0,
+                        0, VideoFormatCompatibility::ALL);
+  }
+  std::vector<ArtifactPtr> execute(
+      const std::vector<ArtifactPtr>& /*inputs*/,
+      const std::map<std::string, ParameterValue>& /*parameters*/,
+      ObservationContext& /*ctx*/) override {
+    return {};
+  }
+  size_t required_input_count() const override { return 1; }
+  size_t output_count() const override { return 0; }
+};
+
+DAGNode make_node(NodeID id, DAGStagePtr stage, std::vector<NodeID> inputs,
+                  std::vector<size_t> input_indices) {
+  DAGNode node;
+  node.node_id = id;
+  node.stage = std::move(stage);
+  node.input_node_ids = std::move(inputs);
+  node.input_indices = std::move(input_indices);
+  return node;
+}
+
+// Source at node 1; sink at node 2 fed from the given source output.
+std::shared_ptr<DAG> build_dag(size_t connected_output,
+                               std::shared_ptr<TwoOutputSource> source) {
+  auto dag = std::make_shared<DAG>();
+  dag->add_node(make_node(NodeID(1), std::move(source), {}, {}));
+  dag->add_node(make_node(NodeID(2), std::make_shared<Sink>(), {NodeID(1)},
+                          {connected_output}));
+  return dag;
+}
+
+// ---------------------------------------------------------------------------
+// resolve_node_vfr
+// ---------------------------------------------------------------------------
+
+TEST(ResolveNodeVfr, ResolvesANodesOwnFirstOutput) {
+  auto source = std::make_shared<TwoOutputSource>();
+  auto dag = build_dag(1, source);
+  DAGExecutor executor;
+  const auto outputs = executor.execute_to_node(*dag, NodeID(1));
+
+  const auto resolved = resolve_node_vfr(*dag, outputs, NodeID(1));
+  EXPECT_EQ(resolved.status, NodeVfrResolution::kOk);
+  EXPECT_EQ(resolved.source_node, NodeID(1));
+  EXPECT_EQ(resolved.output_index, 0u);
+  EXPECT_FALSE(resolved.substituted_upstream);
+  ASSERT_TRUE(resolved.representation);
+  EXPECT_EQ(resolved.representation->frame_count(), 1u);
+}
+
+// A sink produces no output of its own, so resolution substitutes the upstream
+// output its edge names — not output 0, which may be a different branch.
+TEST(ResolveNodeVfr, SinkSubstitutesTheConnectedUpstreamOutput) {
+  auto source = std::make_shared<TwoOutputSource>();
+  auto dag = build_dag(1, source);
+  DAGExecutor executor;
+  const auto outputs = executor.execute_to_node(*dag, NodeID(2));
+
+  const auto resolved = resolve_node_vfr(*dag, outputs, NodeID(2));
+  EXPECT_EQ(resolved.status, NodeVfrResolution::kOk);
+  EXPECT_TRUE(resolved.substituted_upstream);
+  EXPECT_EQ(resolved.source_node, NodeID(1));
+  EXPECT_EQ(resolved.output_index, 1u);
+  ASSERT_TRUE(resolved.representation);
+  EXPECT_EQ(resolved.representation->frame_count(), 2u);
+}
+
+TEST(ResolveNodeVfr, ReportsANodeThatProducedNothing) {
+  auto source = std::make_shared<TwoOutputSource>();
+  auto dag = build_dag(0, source);
+  const std::map<NodeID, std::vector<ArtifactPtr>> empty;
+
+  EXPECT_EQ(resolve_node_vfr(*dag, empty, NodeID(1)).status,
+            NodeVfrResolution::kNoOutput);
+  EXPECT_EQ(resolve_node_vfr(*dag, empty, NodeID(2)).status,
+            NodeVfrResolution::kSinkWithoutUpstream);
+}
+
+// ---------------------------------------------------------------------------
+// PreviewRenderer metadata probes
+// ---------------------------------------------------------------------------
+
+// Metadata queries (video parameters, audio pairs, line samples) only need the
+// node's artifact. Obtaining it by rendering frame 0 also ran the full observer
+// pass over that frame — recomputed every time and discarded, since this
+// renderer has no observation store to serve it from or write it to.
+TEST(PreviewRendererRepresentation, ProbeRunsNoObserverPass) {
+  auto source = std::make_shared<TwoOutputSource>();
+  auto dag = build_dag(0, source);
+  PreviewRenderer renderer(dag);
+
+  auto repr = renderer.get_representation_at_node(NodeID(1));
+  ASSERT_TRUE(repr);
+
+  const auto* probe = dynamic_cast<const ProbeVfr*>(repr.get());
+  ASSERT_TRUE(probe);
+  EXPECT_EQ(probe->descriptor_calls, 0)
+      << "observer pass ran for a metadata-only query";
+  EXPECT_EQ(probe->frame_calls, 0);
+}
+
+// Repeat probes must not re-execute the DAG per call.
+TEST(PreviewRendererRepresentation, RepeatProbesDoNotReExecuteTheDag) {
+  auto source = std::make_shared<TwoOutputSource>();
+  auto dag = build_dag(0, source);
+  PreviewRenderer renderer(dag);
+
+  for (int i = 0; i < 5; ++i) {
+    ASSERT_TRUE(renderer.get_representation_at_node(NodeID(1)));
+  }
+  EXPECT_EQ(source->executes, 1)
+      << "each probe executed the DAG again instead of reusing the executor's "
+         "artifact cache";
+}
+
+// The metadata path and the preview path must resolve the same artifact for a
+// sink, or a query would describe a different branch than the preview shows.
+TEST(PreviewRendererRepresentation, SinkResolvesTheSameOutputAsThePreview) {
+  auto source = std::make_shared<TwoOutputSource>();
+  auto dag = build_dag(/*connected_output=*/1, source);
+  PreviewRenderer renderer(dag);
+
+  auto repr = renderer.get_representation_at_node(NodeID(2));
+  ASSERT_TRUE(repr);
+  EXPECT_EQ(repr->frame_count(), 2u)
+      << "sink resolved upstream output 0 rather than the connected output 1";
+
+  DAGFrameRenderer frame_renderer(dag);
+  const auto rendered = frame_renderer.render_frame_at_node(NodeID(2), 0);
+  ASSERT_TRUE(rendered.is_valid) << rendered.error_message;
+  ASSERT_TRUE(rendered.representation);
+  EXPECT_EQ(rendered.representation->frame_count(), repr->frame_count());
+
+  // The render path does run the observer pass, which proves the descriptor
+  // counter ProbeRunsNoObserverPass asserts on is a live signal rather than one
+  // that never moves.
+  const auto* rendered_probe =
+      dynamic_cast<const ProbeVfr*>(rendered.representation.get());
+  ASSERT_TRUE(rendered_probe);
+  EXPECT_GT(rendered_probe->descriptor_calls, 0);
+}
+
+}  // namespace
+}  // namespace orc

--- a/orc-tests/core/unit/project/project_format_test.cpp
+++ b/orc-tests/core/unit/project/project_format_test.cpp
@@ -449,7 +449,7 @@ dag:
       parameters:
         input_path:
           type: string
-          value: "/path/to/file.composite"
+          value: "/path/to/file.cvbs"
   edges: []
 )yaml";
 
@@ -490,7 +490,7 @@ dag:
       parameters:
         input_path:
           type: string
-          value: "/path/to/file.composite"
+          value: "/path/to/file.cvbs"
   edges: []
 )yaml";
 
@@ -642,7 +642,7 @@ dag:
       parameters:
         input_path:
           type: string
-          value: "/path/to/file.composite"
+          value: "/path/to/file.cvbs"
   edges: []
 )yaml";
 

--- a/orc-tests/core/unit/stages/cvbs_sink/cvbs_sink_stage_test.cpp
+++ b/orc-tests/core/unit/stages/cvbs_sink/cvbs_sink_stage_test.cpp
@@ -89,7 +89,7 @@ TEST(CVBSSinkStageTest, Descriptor_OutputPathIsCompositeFile) {
   const auto* desc = find_descriptor(descriptors, "output_path");
   ASSERT_NE(desc, nullptr);
   EXPECT_EQ(desc->type, orc::ParameterType::FILE_PATH);
-  EXPECT_EQ(desc->file_extension_hint, ".composite");
+  EXPECT_EQ(desc->file_extension_hint, ".cvbs");
   EXPECT_TRUE(desc->constraints.required);
   ASSERT_TRUE(desc->constraints.default_value.has_value());
   EXPECT_EQ(std::get<std::string>(*desc->constraints.default_value), "");
@@ -126,13 +126,13 @@ TEST(CVBSSinkStageTest, Descriptor_OutputPathHintFollowsProjectType) {
   const auto* composite_desc =
       find_descriptor(composite_descriptors, "output_path");
   ASSERT_NE(composite_desc, nullptr);
-  EXPECT_EQ(composite_desc->file_extension_hint, ".composite");
+  EXPECT_EQ(composite_desc->file_extension_hint, ".cvbs");
 
   const auto yc_descriptors = stage.get_parameter_descriptors(
       orc::VideoSystem::PAL, orc::SourceType::YC);
   const auto* yc_desc = find_descriptor(yc_descriptors, "output_path");
   ASSERT_NE(yc_desc, nullptr);
-  EXPECT_EQ(yc_desc->file_extension_hint, ".y");
+  EXPECT_EQ(yc_desc->file_extension_hint, ".cvbsy");
 }
 
 TEST(CVBSSinkStageTest, Descriptor_CaptureNotesIsOptionalString) {
@@ -168,7 +168,7 @@ TEST(CVBSSinkStageTest, Trigger_FailsWhenInputIsNotVideoFrameRepresentation) {
   MockObservationContext observation_context;
 
   const bool result =
-      stage.trigger({nullptr}, {{"output_path", std::string("out.composite")}},
+      stage.trigger({nullptr}, {{"output_path", std::string("out.cvbs")}},
                     observation_context);
 
   EXPECT_FALSE(result);
@@ -200,7 +200,7 @@ TEST(CVBSSinkStageTest, Trigger_FailsWithoutCallingDepsOnUnknownEncoding) {
 
   const bool result =
       stage.trigger({vfr},
-                    {{"output_path", std::string("out.composite")},
+                    {{"output_path", std::string("out.cvbs")},
                      {"sample_encoding", std::string("RAW_S16_40M")}},
                     observation_context);
 
@@ -229,13 +229,12 @@ TEST(CVBSSinkStageTest, Trigger_PassesDefaultConfigToDeps) {
         return orc::CVBSSinkWriteResult{true, 42, "Success: 42 frames written"};
       });
 
-  const bool result =
-      stage.trigger({vfr}, {{"output_path", std::string("out.composite")}},
-                    observation_context);
+  const bool result = stage.trigger(
+      {vfr}, {{"output_path", std::string("out.cvbs")}}, observation_context);
 
   EXPECT_TRUE(result);
   EXPECT_EQ(stage.get_trigger_status(), "Success: 42 frames written");
-  EXPECT_EQ(seen.output_base_path, "out.composite");
+  EXPECT_EQ(seen.output_base_path, "out.cvbs");
   EXPECT_EQ(seen.sample_encoding, orc::CVBSSampleEncoding::U10_4FSC);
   EXPECT_EQ(seen.signal_type, "composite");
   EXPECT_EQ(seen.capture_notes, "");
@@ -314,9 +313,8 @@ TEST(CVBSSinkStageTest, Trigger_UsesDepsSeamAndPropagatesFailure) {
       .WillOnce(
           Return(orc::CVBSSinkWriteResult{false, 0, "Cancelled by user"}));
 
-  const bool result =
-      stage.trigger({vfr}, {{"output_path", std::string("out.composite")}},
-                    observation_context);
+  const bool result = stage.trigger(
+      {vfr}, {{"output_path", std::string("out.cvbs")}}, observation_context);
 
   EXPECT_FALSE(result);
   EXPECT_EQ(stage.get_trigger_status(), "Cancelled by user");
@@ -421,12 +419,17 @@ TEST(CVBSSinkEncodeTest, EncodeS164FSC_UsesBlankingOffsetAndScalesBy32) {
 }
 
 TEST(CVBSSinkEncodeTest, DeriveOutputBase_StripsKnownPayloadExtensions) {
-  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.composite"), "/tmp/out");
-  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.y"), "/tmp/out");
-  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.c"), "/tmp/out");
   EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.cvbs"), "/tmp/out");
+  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.cvbsy"), "/tmp/out");
+  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.cvbsc"), "/tmp/out");
   EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out"), "/tmp/out");
   EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.meta"), "/tmp/out.meta");
+  // Only the current payload extensions are stripped; the superseded ones are
+  // left in place as an ordinary part of the base name.
+  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.composite"),
+            "/tmp/out.composite");
+  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.y"), "/tmp/out.y");
+  EXPECT_EQ(orc::derive_cvbs_output_base("/tmp/out.c"), "/tmp/out.c");
 }
 
 // ---------------------------------------------------------------------------

--- a/orc-tests/core/unit/stages/cvbs_source/cvbs_source_stage_test.cpp
+++ b/orc-tests/core/unit/stages/cvbs_source/cvbs_source_stage_test.cpp
@@ -269,7 +269,7 @@ void expect_user_data_error(DAGStage& stage,
 }
 
 const std::map<std::string, ParameterValue> kDefaultParams{
-    {"input_path", std::string("/fake/video.composite")}};
+    {"input_path", std::string("/fake/video.cvbs")}};
 
 }  // namespace
 
@@ -385,10 +385,10 @@ TEST(CVBSSourceStageParamTest, SetGet_InputPath_RoundTrips) {
   auto deps = std::make_shared<FakeCVBSSourceStageDeps>("PAL");
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/test/video.composite")}};
+      {"input_path", std::string("/test/video.cvbs")}};
   ASSERT_TRUE(stage.set_parameters(p));
   auto got = stage.get_parameters();
-  EXPECT_EQ(std::get<std::string>(got["input_path"]), "/test/video.composite");
+  EXPECT_EQ(std::get<std::string>(got["input_path"]), "/test/video.cvbs");
 }
 
 TEST(CVBSSourceStageParamTest, SetParameters_RejectsUnknownKey) {
@@ -415,7 +415,7 @@ TEST(CVBSSourceStageStatusTest, SetParameters_ShowsRed_WhenFileNotAccessible) {
   deps->input_file_valid = false;
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")}};
+      {"input_path", std::string("/fake/video.cvbs")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Red);
 }
@@ -426,7 +426,7 @@ TEST(CVBSSourceStageStatusTest,
   deps->metadata_available = false;
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")}};
+      {"input_path", std::string("/fake/video.cvbs")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Yellow);
 }
@@ -436,7 +436,7 @@ TEST(CVBSSourceStageStatusTest,
   auto deps = std::make_shared<FakeCVBSSourceStageDeps>("PAL");
   NTSCCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")}};
+      {"input_path", std::string("/fake/video.cvbs")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Red);
 }
@@ -446,7 +446,7 @@ TEST(CVBSSourceStageStatusTest,
   auto deps = std::make_shared<FakeCVBSSourceStageDeps>("NTSC");
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")}};
+      {"input_path", std::string("/fake/video.cvbs")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Red);
 }
@@ -456,7 +456,7 @@ TEST(CVBSSourceStageStatusTest,
   auto deps = std::make_shared<FakeCVBSSourceStageDeps>("PAL");
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")}};
+      {"input_path", std::string("/fake/video.cvbs")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Green);
 }
@@ -466,7 +466,7 @@ TEST(CVBSSourceStageStatusTest,
   auto deps = std::make_shared<FakeCVBSSourceStageDeps>("NTSC");
   NTSCCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")}};
+      {"input_path", std::string("/fake/video.cvbs")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Green);
 }
@@ -477,7 +477,7 @@ TEST(CVBSSourceStageStatusTest,
   deps->metadata_available = false;
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Green);
@@ -489,7 +489,7 @@ TEST(CVBSSourceStageStatusTest,
   deps->metadata_available = false;
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("From metadata")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Yellow);
@@ -501,7 +501,7 @@ TEST(CVBSSourceStageStatusTest,
   deps->input_file_valid = false;
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   ASSERT_TRUE(stage.set_parameters(p));
   EXPECT_EQ(stage.get_configuration_status(), ConfigurationStatus::Red);
@@ -583,7 +583,7 @@ TEST(CVBSSourceManualEncodingTest, LoadsWithoutMetadata) {
   deps->metadata_available = false;
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   auto vfr = execute_and_get_vfr(stage, p);
   ASSERT_NE(vfr, nullptr);
@@ -597,7 +597,7 @@ TEST(CVBSSourceManualEncodingTest, FrameCountMeasuredFromPayloadSize) {
       static_cast<size_t>(kPalFrameSamples) * 3, kPalBlanking);
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   auto vfr = execute_and_get_vfr(stage, p);
   ASSERT_NE(vfr, nullptr);
@@ -611,7 +611,7 @@ TEST(CVBSSourceManualEncodingTest, MetadataIsIgnoredWhenManualEncodingSet) {
   deps->metadata_record.signal_state_preset = "STANDARD_RAW";
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   auto vfr = execute_and_get_vfr(stage, p);
   ASSERT_NE(vfr, nullptr);
@@ -625,7 +625,7 @@ TEST(CVBSSourceManualEncodingTest, NormalisesSelectedEncoding) {
   deps->payload_words.assign(static_cast<size_t>(kPalFrameSamples), 0u);
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_S16_4FSC")}};
   auto vfr = execute_and_get_vfr(stage, p);
   ASSERT_NE(vfr, nullptr);
@@ -638,7 +638,7 @@ TEST(CVBSSourceManualEncodingTest, RejectsUnknownManualEncoding) {
   auto deps = std::make_shared<FakeCVBSSourceStageDeps>("PAL");
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("RAW_S16_40M")}};
   expect_user_data_error(stage, p, "RAW_S16_40M");
 }
@@ -648,7 +648,7 @@ TEST(CVBSSourceManualEncodingTest, FromMetadataValue_StillRequiresMetadata) {
   deps->metadata_available = false;
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("From metadata")}};
   expect_user_data_error(stage, p, "metadata");
 }
@@ -662,7 +662,7 @@ TEST(CVBSSourceManualEncodingTest, AudioWithoutMetadata_GetsDerivedName) {
       std::vector<int32_t>(1920 * 2, int32_t{0});
   PALCVBSSourceStage stage(deps);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   auto vfr = execute_and_get_vfr(stage, p);
   ASSERT_NE(vfr, nullptr);
@@ -680,7 +680,7 @@ TEST(CVBSSourceManualEncodingTest, EncodingChangeInvalidatesCache) {
   ObservationContext obs;
   auto r1 = stage.execute(inputs, kDefaultParams, obs);
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   auto r2 = stage.execute(inputs, p, obs);
   ASSERT_EQ(r1.size(), 1u);
@@ -1404,7 +1404,7 @@ TEST(CVBSSidecarAudioTest, ManualEncodingMode_DoesNotWarnAboutMissingRows) {
   std::vector<ArtifactPtr> inputs;
   ObservationContext obs;
   std::map<std::string, ParameterValue> p{
-      {"input_path", std::string("/fake/video.composite")},
+      {"input_path", std::string("/fake/video.cvbs")},
       {"sample_encoding", std::string("CVBS_U16_4FSC")}};
   auto results = stage.execute(inputs, p, obs);
   ASSERT_EQ(results.size(), 1u);

--- a/orc-tests/core/unit/stages/tbc_source/pal_tbc_converter_test.cpp
+++ b/orc-tests/core/unit/stages/tbc_source/pal_tbc_converter_test.cpp
@@ -21,9 +21,11 @@
 #include <gtest/gtest.h>
 #include <orc/stage/cvbs_signal_constants.h>
 
+#include <cmath>
 #include <cstdint>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace orc_unit_test {
@@ -86,6 +88,55 @@ TEST(PalTBCConverterTest,
   const int16_t result = orc::PalTBCConverter::tbc_to_cvbs(
       static_cast<uint16_t>(kRefBlanking - 1000), kRefBlanking, kRefWhite);
   EXPECT_LT(result, static_cast<int16_t>(orc::kPalBlanking));
+}
+
+// The level map folds the frame-constant division into a single scale factor
+// so the per-sample path is one multiply-add (see tbc_level_scale.h). That is
+// deliberately not bit-identical to dividing per sample, so the contract the
+// implementation owes callers is an accuracy bound, not an exact value: every
+// sample must land within 1 LSB of the exact rational mapping.
+TEST(PalTBCConverterTest, LevelMapping_WithinOneLsbOfExactRational) {
+  // Nominal ld-decode levels plus off-nominal pairs, since these come from
+  // per-capture metadata and vary.
+  const std::pair<int32_t, int32_t> level_pairs[] = {{kRefBlanking, kRefWhite},
+                                                     {16384, 54016},
+                                                     {16000, 53000},
+                                                     {17200, 55000},
+                                                     {15000, 60000},
+                                                     {20000, 50000}};
+
+  for (const auto& [blanking, white] : level_pairs) {
+    const orc::TbcLevelScale levels =
+        orc::PalTBCConverter::level_scale(blanking, white);
+    const int32_t span = orc::kPalWhite - orc::kPalBlanking;
+    const int32_t den = white - blanking;
+
+    // Whole 16-bit input domain, so no sample value can hide a larger error.
+    for (int32_t sample = 0; sample <= 0xFFFF; ++sample) {
+      // Exact rational mapping, rounded half away from zero, in integers.
+      const int64_t num = static_cast<int64_t>(sample - blanking) * span;
+      const int64_t exact = (num >= 0 ? (2 * num + den) / (2 * den)
+                                      : -((-2 * num + den) / (2 * den))) +
+                            orc::kPalBlanking;
+      const int32_t mapped = levels.map(static_cast<uint16_t>(sample));
+      ASSERT_LE(std::abs(mapped - static_cast<int32_t>(exact)), 1)
+          << "sample " << sample << " with blanking=" << blanking
+          << " white=" << white << ": mapped " << mapped << ", exact " << exact;
+    }
+  }
+}
+
+// The single-sample convenience overload and the map used for whole frames
+// must agree, or a spot check would disagree with the frame it came from.
+TEST(PalTBCConverterTest, LevelMapping_SingleSampleOverloadMatchesLevelScale) {
+  const orc::TbcLevelScale levels =
+      orc::PalTBCConverter::level_scale(kRefBlanking, kRefWhite);
+  for (int32_t sample = 0; sample <= 0xFFFF; sample += 7) {
+    EXPECT_EQ(orc::PalTBCConverter::tbc_to_cvbs(static_cast<uint16_t>(sample),
+                                                kRefBlanking, kRefWhite),
+              levels.map(static_cast<uint16_t>(sample)))
+        << "sample " << sample;
+  }
 }
 
 // ============================================================================

--- a/orc/cli/orc_cli.cpp
+++ b/orc/cli/orc_cli.cpp
@@ -153,7 +153,7 @@ void print_usage(const char* program_name) {
   std::cerr << "      --filters dropout_correct --sink "
                "video_sink=output_path=a.mp4\n";
   std::cerr << "  " << program_name
-            << " -i \"NTSC_CVBS_Source=input_path=a.composite\" -o video_sink"
+            << " -i \"NTSC_CVBS_Source=input_path=a.cvbs\" -o video_sink"
                "=output_path=a.mp4\n";
   std::cerr << "  " << program_name
             << " --source tbc_source=input_path=a.tbc --sink video_sink "

--- a/orc/core/CMakeLists.txt
+++ b/orc/core/CMakeLists.txt
@@ -80,6 +80,10 @@ add_library(orc-core SHARED
     # Provenance-keyed observation store (survives DAG rebuilds)
     observation_store.cpp
 
+    # Read-through context over the store (per-field lazy loading for
+    # triggered sinks)
+    store_backed_observation_context.cpp
+
     # SQLite-backed observation sidecar (survives application restarts)
     sqlite_observation_persistence.cpp
 

--- a/orc/core/core_observation_service.cpp
+++ b/orc/core/core_observation_service.cpp
@@ -140,4 +140,43 @@ bool CoreObservationService::run_observer(
   return true;
 }
 
+bool standard_observer_applies(const std::string& observer_id,
+                               const SourceParameters& params) {
+  // One shared instance per registry entry, created on first use (magic
+  // statics make the initialisation thread-safe). applies_to() is const, pure
+  // and thread-safe by contract, so sharing is safe; process_frame() is never
+  // called on these instances.
+  static const auto& instances = *[] {
+    auto* arr =
+        new std::array<std::unique_ptr<Observer>, kObserverRegistry.size()>();
+    for (std::size_t i = 0; i < kObserverRegistry.size(); ++i) {
+      (*arr)[i] = kObserverRegistry[i].factory();
+    }
+    return arr;
+  }();
+  for (std::size_t i = 0; i < kObserverRegistry.size(); ++i) {
+    if (observer_id == kObserverRegistry[i].id) {
+      return instances[i]->applies_to(params);
+    }
+  }
+  // Unknown (e.g. test-injected) observers are never filtered.
+  return true;
+}
+
+std::vector<ObserverInfo> filter_applicable_observers(
+    const std::vector<ObserverInfo>& observers,
+    const std::optional<SourceParameters>& params) {
+  if (!params.has_value()) {
+    return observers;  // fail open — see the header contract
+  }
+  std::vector<ObserverInfo> applicable;
+  applicable.reserve(observers.size());
+  for (const auto& observer : observers) {
+    if (standard_observer_applies(observer.id, *params)) {
+      applicable.push_back(observer);
+    }
+  }
+  return applicable;
+}
+
 }  // namespace orc

--- a/orc/core/dag_frame_renderer.cpp
+++ b/orc/core/dag_frame_renderer.cpp
@@ -62,6 +62,18 @@ void run_frame_observer_pass(const IObservationService& service,
   const FieldID field_top(frame_id * kFieldsPerFrame);
   const FieldID field_bottom(frame_id * kFieldsPerFrame + 1);
 
+  // Observers structurally inapplicable to this source (e.g. teletext on
+  // NTSC, fm_code/white_flag on PAL) are skipped outright: no run, no store
+  // probes, no records. Every coverage probe (runner fast path, presenter
+  // store_has_frame/sweep markers) filters by the same predicate, so the
+  // absent records never read as missing coverage. Applicability fails open
+  // when the representation carries no video parameters.
+  const auto video_params = representation.get_video_parameters();
+  const auto observer_applies = [&video_params](const ObserverInfo& observer) {
+    return !video_params.has_value() ||
+           standard_observer_applies(observer.id, *video_params);
+  };
+
   // Padding frames (frame_map / source_align gap fill, or source fields the
   // TBC metadata marks as pad) carry no measurable signal, so running the
   // observers over their synthetic content would store spurious measurements
@@ -81,6 +93,9 @@ void run_frame_observer_pass(const IObservationService& service,
       ObservationRecord pad_record;
       pad_record[kPaddingObservationNamespace][kPaddingObservationKey] = true;
       for (const auto& observer : observers) {
+        if (!observer_applies(observer)) {
+          continue;
+        }
         for (const auto& fingerprint : fingerprints) {
           for (const FieldID field : {field_top, field_bottom}) {
             const ObservationRecordKey key{fingerprint, field, observer.id,
@@ -97,6 +112,9 @@ void run_frame_observer_pass(const IObservationService& service,
   }
 
   for (const auto& observer : observers) {
+    if (!observer_applies(observer)) {
+      continue;
+    }
     if (!caching) {
       // No provenance available: run directly into the target context, exactly
       // as the renderer did before the store existed.
@@ -220,6 +238,24 @@ void DAGFrameRenderer::ensure_node_index() const {
 bool DAGFrameRenderer::has_node(NodeID node_id) const {
   ensure_node_index();
   return node_index_.find(node_id) != node_index_.end();
+}
+
+std::optional<SourceParameters> DAGFrameRenderer::get_video_parameters_at_node(
+    NodeID node_id) {
+  if (!has_node(node_id)) {
+    return std::nullopt;
+  }
+  try {
+    auto node_outputs = executor_->execute_to_node(*dag_, node_id);
+    const ResolvedNodeVfr resolved =
+        resolve_node_vfr(*dag_, node_outputs, node_id);
+    if (resolved.status != NodeVfrResolution::kOk) {
+      return std::nullopt;
+    }
+    return resolved.representation->get_video_parameters();
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
 }
 
 void DAGFrameRenderer::update_dag(std::shared_ptr<const DAG> new_dag) {

--- a/orc/core/dag_frame_renderer.cpp
+++ b/orc/core/dag_frame_renderer.cpp
@@ -295,6 +295,75 @@ FrameRenderResult DAGFrameRenderer::render_frame_at_node(NodeID node_id,
   return result;
 }
 
+ResolvedNodeVfr resolve_node_vfr(
+    const DAG& dag,
+    const std::map<NodeID, std::vector<ArtifactPtr>>& node_outputs,
+    NodeID node_id) {
+  ResolvedNodeVfr resolved;
+  resolved.source_node = node_id;
+
+  auto it = node_outputs.find(node_id);
+  std::size_t output_index = 0;
+
+  if (it == node_outputs.end() || it->second.empty()) {
+    const auto& dag_nodes = dag.nodes();
+    auto dag_it = std::find_if(
+        dag_nodes.begin(), dag_nodes.end(),
+        [&node_id](const auto& n) { return n.node_id == node_id; });
+
+    bool is_sink = false;
+    if (dag_it != dag_nodes.end() && dag_it->stage) {
+      const auto ntype = dag_it->stage->get_node_type_info().type;
+      is_sink = (ntype == NodeType::SINK || ntype == NodeType::ANALYSIS_SINK);
+    }
+    if (!is_sink) {
+      resolved.status = NodeVfrResolution::kNoOutput;
+      return resolved;
+    }
+
+    // Sink stages produce no output by design. Fall back to the upstream node
+    // its edge names so the host can show a pass-through preview (and answer
+    // metadata queries) without any boilerplate in the plugin.
+    if (dag_it != dag_nodes.end() && !dag_it->input_node_ids.empty()) {
+      const NodeID upstream_id = dag_it->input_node_ids[0];
+      // The edge's output index, not output 0: a multi-output stage's output 0
+      // is not necessarily the one the sink consumes, and substituting it would
+      // resolve a different branch than the sink is actually fed.
+      const std::size_t upstream_output =
+          dag_it->input_indices.empty() ? 0 : dag_it->input_indices[0];
+      auto up_it = node_outputs.find(upstream_id);
+      if (up_it != node_outputs.end() &&
+          upstream_output < up_it->second.size()) {
+        auto up_vfr = std::dynamic_pointer_cast<VideoFrameRepresentation>(
+            up_it->second[upstream_output]);
+        if (up_vfr) {
+          it = up_it;
+          output_index = upstream_output;
+          resolved.source_node = upstream_id;
+          resolved.substituted_upstream = true;
+        }
+      }
+    }
+
+    if (it == node_outputs.end() || it->second.size() <= output_index) {
+      resolved.status = NodeVfrResolution::kSinkWithoutUpstream;
+      return resolved;
+    }
+  }
+
+  auto vfr = std::dynamic_pointer_cast<VideoFrameRepresentation>(
+      it->second[output_index]);
+  if (!vfr) {
+    resolved.status = NodeVfrResolution::kNotRepresentation;
+    return resolved;
+  }
+
+  resolved.status = NodeVfrResolution::kOk;
+  resolved.representation = std::move(vfr);
+  resolved.output_index = output_index;
+  return resolved;
+}
+
 FrameRenderResult DAGFrameRenderer::execute_to_node(NodeID node_id,
                                                     FrameID frame_id) {
   FrameRenderResult result;
@@ -308,84 +377,45 @@ FrameRenderResult DAGFrameRenderer::execute_to_node(NodeID node_id,
   try {
     auto node_outputs = executor_->execute_to_node(*dag_, node_id);
 
-    auto it = node_outputs.find(node_id);
-    // Which of the located node's outputs carries this node's frames. Always 0
-    // for the node's own output; a sink substituting its input's output (below)
-    // takes the one the edge actually connects to.
-    size_t output_index = 0;
-    if (it == node_outputs.end() || it->second.empty()) {
-      // Check whether this is a sink (which produces no output by design).
-      bool is_sink = false;
-      const auto& dag_nodes = dag_->nodes();
-      auto dag_it = std::find_if(
-          dag_nodes.begin(), dag_nodes.end(),
-          [&node_id](const auto& n) { return n.node_id == node_id; });
-      if (dag_it != dag_nodes.end() && dag_it->stage) {
-        auto ntype = dag_it->stage->get_node_type_info().type;
-        is_sink = (ntype == NodeType::SINK || ntype == NodeType::ANALYSIS_SINK);
-      }
-
-      if (is_sink) {
-        // Sink stages produce no output by design. Fall back to the nearest
-        // upstream node that does produce a VFR so the host can show a
-        // pass-through preview without requiring any boilerplate in the plugin.
-        if (dag_it != dag_nodes.end() && !dag_it->input_node_ids.empty()) {
-          const NodeID& upstream_id = dag_it->input_node_ids[0];
-          // The edge feeding this sink names an output of the upstream node;
-          // a multi-output stage's output 0 is not necessarily the one the
-          // sink consumes, and substituting it would observe (and preview) a
-          // different branch than the sink is actually fed.
-          const size_t upstream_output =
-              dag_it->input_indices.empty() ? 0 : dag_it->input_indices[0];
-          auto up_it = node_outputs.find(upstream_id);
-          if (up_it != node_outputs.end() &&
-              upstream_output < up_it->second.size()) {
-            auto up_vfr = std::dynamic_pointer_cast<VideoFrameRepresentation>(
-                up_it->second[upstream_output]);
-            if (up_vfr) {
-              ORC_LOG_DEBUG(
-                  "DAGFrameRenderer: sink node '{}' — using upstream node "
-                  "'{}' output {} for preview",
-                  node_id.to_string(), upstream_id.to_string(),
-                  upstream_output);
-              it = up_it;
-              output_index = upstream_output;
-            }
-          }
-        }
-
-        if (it == node_outputs.end() || it->second.size() <= output_index) {
-          ORC_LOG_DEBUG(
-              "DAGFrameRenderer: sink node '{}' has no upstream VFR for "
-              "preview",
-              node_id.to_string());
-          result.is_valid = false;
-          result.error_message =
-              fmt::format("Node '{}' produced no output", node_id);
-          return result;
-        }
-      } else {
+    const ResolvedNodeVfr resolved =
+        resolve_node_vfr(*dag_, node_outputs, node_id);
+    switch (resolved.status) {
+      case NodeVfrResolution::kNoOutput:
         ORC_LOG_ERROR("DAGFrameRenderer: node '{}' produced no output",
                       node_id.to_string());
         result.is_valid = false;
         result.error_message =
             fmt::format("Node '{}' produced no output", node_id);
         return result;
-      }
+      case NodeVfrResolution::kSinkWithoutUpstream:
+        ORC_LOG_DEBUG(
+            "DAGFrameRenderer: sink node '{}' has no upstream VFR for preview",
+            node_id.to_string());
+        result.is_valid = false;
+        result.error_message =
+            fmt::format("Node '{}' produced no output", node_id);
+        return result;
+      case NodeVfrResolution::kNotRepresentation:
+        ORC_LOG_ERROR(
+            "DAGFrameRenderer: node '{}' output is not a "
+            "VideoFrameRepresentation",
+            node_id.to_string());
+        result.is_valid = false;
+        result.error_message = "Node '" + node_id.to_string() +
+                               "' did not produce a VideoFrameRepresentation";
+        return result;
+      case NodeVfrResolution::kOk:
+        break;
     }
 
-    auto vfr = std::dynamic_pointer_cast<VideoFrameRepresentation>(
-        it->second[output_index]);
-    if (!vfr) {
-      ORC_LOG_ERROR(
-          "DAGFrameRenderer: node '{}' output is not a "
-          "VideoFrameRepresentation",
-          node_id.to_string());
-      result.is_valid = false;
-      result.error_message = "Node '" + node_id.to_string() +
-                             "' did not produce a VideoFrameRepresentation";
-      return result;
+    if (resolved.substituted_upstream) {
+      ORC_LOG_DEBUG(
+          "DAGFrameRenderer: sink node '{}' — using upstream node '{}' output "
+          "{} for preview",
+          node_id.to_string(), resolved.source_node.to_string(),
+          resolved.output_index);
     }
+    const VideoFrameRepresentationPtr& vfr = resolved.representation;
 
     if (!vfr->has_frame(frame_id)) {
       ORC_LOG_WARN(

--- a/orc/core/include/core_observation_service.h
+++ b/orc/core/include/core_observation_service.h
@@ -12,8 +12,10 @@
 #include <orc/stage/frame_id.h>
 #include <orc/stage/observation/observation_context_interface.h>
 #include <orc/stage/observation/observation_service_interface.h>
+#include <orc/stage/orc_source_parameters.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -45,5 +47,24 @@ class CoreObservationService final : public IObservationService {
                     FrameID frame_id,
                     IObservationContext& context) const override;
 };
+
+// True when the standard observer identified by @p observer_id can ever
+// produce observations for a source with video parameters @p params (e.g.
+// "teletext" is PAL-only, "fm_code"/"white_flag" are NTSC-only). Core-private
+// applicability query — deliberately NOT part of the SDK service surface.
+// Unknown ids (e.g. observers injected by a test service) are always
+// applicable. Thread-safe.
+bool standard_observer_applies(const std::string& observer_id,
+                               const SourceParameters& params);
+
+// The subset of @p observers applicable to @p params. A disengaged @p params
+// (video parameters unavailable) applies every observer: filtering must fail
+// open, because the observer pass, the runner's store fast path and the
+// presenter's coverage probes all have to agree on the same set — a site that
+// filtered while another did not would make frames look permanently
+// uncovered. Thread-safe.
+std::vector<ObserverInfo> filter_applicable_observers(
+    const std::vector<ObserverInfo>& observers,
+    const std::optional<SourceParameters>& params);
 
 }  // namespace orc

--- a/orc/core/include/dag_frame_renderer.h
+++ b/orc/core/include/dag_frame_renderer.h
@@ -56,6 +56,12 @@ inline constexpr char kPaddingObservationKey[] = "is_pad";
 // kPaddingObservationKey = true) for every observer, replacing any stale
 // record that measured the synthetic padding content.
 //
+// Observers structurally inapplicable to the source's video system (per
+// standard_observer_applies(), e.g. teletext outside PAL) are skipped
+// outright — no run, no store probes and no records, padding markers
+// included. Coverage probes must filter by the same predicate; see
+// filter_applicable_observers().
+//
 // When either @p fingerprint or @p store is null the observers always run and
 // nothing is stored — behaviour identical to the pre-store renderer.
 //
@@ -195,6 +201,13 @@ class DAGFrameRenderer {
 
   // True if node_id exists in the current DAG.
   bool has_node(NodeID node_id) const;
+
+  // Video parameters of the representation produced at @p node_id. Executes
+  // the DAG structurally (artifact graph only — representations are lazy): no
+  // frame samples are decoded and no observers run. Returns nullopt when the
+  // node does not exist, produces no video representation, or execution
+  // fails. Used to decide observer applicability before any render.
+  std::optional<SourceParameters> get_video_parameters_at_node(NodeID node_id);
 
   // -------------------------------------------------------------------------
   // DAG Change Tracking

--- a/orc/core/include/dag_frame_renderer.h
+++ b/orc/core/include/dag_frame_renderer.h
@@ -90,6 +90,43 @@ void run_frame_observer_pass(const IObservationService& service,
                              ObservationStore* store,
                              IObservationContext& context);
 
+// ---------------------------------------------------------------------------
+// Node output resolution
+// ---------------------------------------------------------------------------
+
+// Why resolve_node_vfr() did or did not find a representation.
+enum class NodeVfrResolution {
+  kOk,                   // representation is set
+  kNoOutput,             // a non-sink node produced no output at all
+  kSinkWithoutUpstream,  // a sink whose edge names no usable upstream VFR
+  kNotRepresentation,    // the located artifact is not a VFR
+};
+
+struct ResolvedNodeVfr {
+  NodeVfrResolution status = NodeVfrResolution::kNoOutput;
+  VideoFrameRepresentationPtr representation;
+  // The node the artifact actually came from — the queried node, unless a sink
+  // substitution took the upstream one.
+  NodeID source_node;
+  std::size_t output_index = 0;
+  bool substituted_upstream = false;
+};
+
+// Locates the VideoFrameRepresentation carrying @p node_id's frames within
+// @p node_outputs (as returned by DAGExecutor::execute_to_node).
+//
+// A sink stage produces no output by design, so this substitutes the upstream
+// output the sink's edge actually names — output 0 is not necessarily the one
+// the sink consumes, and substituting it would resolve a different branch than
+// the sink is fed. Every caller that needs a node's representation goes through
+// here, so a metadata query and a preview can never resolve different
+// artifacts. Resolution is pure map lookup: it renders no frame and runs no
+// observers.
+ResolvedNodeVfr resolve_node_vfr(
+    const DAG& dag,
+    const std::map<NodeID, std::vector<ArtifactPtr>>& node_outputs,
+    NodeID node_id);
+
 // Exception thrown during DAG frame rendering.
 class DAGFrameRenderError : public std::runtime_error {
  public:

--- a/orc/core/include/observation_scheduler.h
+++ b/orc/core/include/observation_scheduler.h
@@ -34,6 +34,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -156,8 +157,10 @@ class IObservationTaskRunner {
    * @param fingerprint  Provenance used to key stored records.
    * @param frame_id     Frame to observe.
    * @param observer_ids Requested observer set. Advisory: an implementation
-   *                     may observe the full standard set and rely on the
-   *                     store's read-through to skip already-present records.
+   *                     may observe the full standard set (less observers
+   *                     inapplicable to the node's video system, per
+   *                     standard_observer_applies) and rely on the store's
+   *                     read-through to skip already-present records.
    * @return True when the frame was actually computed (rendered/observed);
    *         false when every requested record was already stored and the call
    *         was a no-op. Drives the workload's computed-vs-checked split so
@@ -594,6 +597,17 @@ class RendererObservationTaskRunner final : public IObservationTaskRunner {
   // pre-check the store and skip rendering a frame whose observations are all
   // already present (e.g. computed by a parallel chunk covering the same node).
   std::vector<std::pair<std::string, std::string>> observer_keys_;
+  // Per-node subsets of observer_keys_ applicable to the node's video system
+  // (standard_observer_applies), computed on first use — the observer pass
+  // writes no records for inapplicable observers, so the fast path must not
+  // demand their keys. Single worker thread by contract (no locking); cleared
+  // on update_dag().
+  std::unordered_map<NodeID, std::vector<std::pair<std::string, std::string>>>
+      node_observer_keys_;
+
+  // Cached lookup into node_observer_keys_, filtering on first use.
+  const std::vector<std::pair<std::string, std::string>>& observer_keys_for(
+      NodeID node_id);
 };
 
 /**
@@ -601,8 +615,9 @@ class RendererObservationTaskRunner final : public IObservationTaskRunner {
  *        changed-node re-observation.
  *
  * Emits ONE work item per (node, range) covering the full observer set. The
- * production runner observes the complete standard set per frame regardless of
- * a work item's observer_ids (each observer is constructed fresh per frame, so
+ * production runner observes the complete standard set applicable to the
+ * node's video system per frame regardless of a work item's observer_ids
+ * (each observer is constructed fresh per frame, so
  * stored records never depend on processing order); a separate ascending-order
  * item for the stateful observers would double the enqueued workload and race
  * the chunked items into rendering the same frames twice.

--- a/orc/core/include/observation_scheduler.h
+++ b/orc/core/include/observation_scheduler.h
@@ -243,6 +243,11 @@ class IObservationSchedulingPolicy {
  * work preempts prefetch preempts sweep; within a class, FIFO. Stateful items
  * are observed in ascending frame order.
  *
+ * Enqueued work is deduplicated against what is already queued or in flight for
+ * the same node + fingerprint, so overlapping plans (a prefetch window
+ * re-planned on every preview move) cannot make several workers render the same
+ * frame.
+ *
  * DAG changes: on_dag_changed() atomically adopts the new fingerprint map,
  * drops every queued item whose node fingerprint no longer matches, and aborts
  * the in-flight item if it became stale. Requeuing new work against the new map
@@ -324,9 +329,12 @@ class ObservationScheduler {
   // ---- Direct submission ---------------------------------------------------
 
   /// Enqueue one work item. Ignored (dropped) if the scheduler is stopping.
+  /// Frames already queued or in flight for the same node + fingerprint at an
+  /// equal or higher priority are dropped from the item first; an item every
+  /// frame of which is already pending enqueues nothing.
   void submit(ObservationWorkItem item);
 
-  /// Enqueue a batch of work items in order.
+  /// Enqueue a batch of work items in order, each deduplicated as in submit().
   void submit_batch(std::vector<ObservationWorkItem> items);
 
   // ---- Policy-driven events ------------------------------------------------
@@ -410,6 +418,10 @@ class ObservationScheduler {
     bool has_in_flight = false;
     NodeID in_flight_node;
     NodeFingerprint in_flight_fingerprint;
+    // Frame range and priority of the in-flight item, so enqueue-time
+    // deduplication can see work a worker has already taken off the queue.
+    FrameIDRange in_flight_frames;
+    ObservationPriority in_flight_priority = ObservationPriority::kSweep;
     // DAG generation this worker's runner has adopted; lags dag_generation_
     // until the worker applies the pending update before its next item.
     std::uint64_t applied_generation = 0;
@@ -447,6 +459,30 @@ class ObservationScheduler {
 
   void enqueue_locked(ObservationWorkItem item);
   void purge_stale_locked();
+
+  /**
+   * @brief Sub-ranges of @p item's frames that no pending work already covers.
+   *
+   * Overlapping plans are the norm: a playing preview re-plans its prefetch
+   * window on every frame advance, so the same not-yet-observed frames would
+   * otherwise be enqueued again on each move and rendered several times over by
+   * different workers. Coverage is counted from queued items and from items a
+   * worker has already taken in flight, matched on node + fingerprint (a
+   * different fingerprint is different content, never a duplicate).
+   *
+   * Only work at an equal or higher priority suppresses: a queued sweep must
+   * never swallow a prefetch or interactive request for the same frame, or that
+   * frame would inherit the sweep's latency.
+   *
+   * Returns the whole range when nothing overlaps, and an empty vector when the
+   * item is fully covered. Caller holds mutex_.
+   */
+  std::vector<FrameIDRange> uncovered_ranges_locked(
+      const ObservationWorkItem& item) const;
+
+  // Drop frames already pending, then chunk and enqueue what remains. Caller
+  // holds mutex_.
+  void submit_item_locked(const ObservationWorkItem& item);
 
   ProgressCallback progress_callback() const;
   CompletionCallback completion_callback() const;

--- a/orc/core/include/preview_renderer.h
+++ b/orc/core/include/preview_renderer.h
@@ -331,9 +331,20 @@ class PreviewRenderer {
   /// concurrently.
   mutable std::map<NodeID, uint64_t> first_field_offset_cache_;
 
-  /// Ensure node has been executed (execute on-demand if needed)
-  void ensure_node_executed(const NodeID& node_id,
-                            bool disable_cache = false) const;
+  /// Ensure node has been executed (execute on-demand if needed). Returns the
+  /// executor's node -> outputs map so callers that need the node's artifact
+  /// can take it from here rather than rendering a frame to get at it.
+  std::map<NodeID, std::vector<ArtifactPtr>> ensure_node_executed(
+      const NodeID& node_id, bool disable_cache = false) const;
+
+  /// The VideoFrameRepresentation at @p node_id, obtained by executing the DAG
+  /// to that node and resolving its output artifact — no frame is rendered and
+  /// no observer pass runs, because none of the callers need either. Sinks
+  /// resolve to the upstream output their edge names (see resolve_node_vfr).
+  /// Returns nullptr when the node has no representation, or when it has one
+  /// with no frame 0 (which is what the previous render-based probe reported,
+  /// and what makes get_representation_at_node() fall back upstream).
+  VideoFrameRepresentationPtr representation_at(const NodeID& node_id) const;
 
   /// Field line counts of the frame being previewed at a node, or nullopt when
   /// the node has no representation to measure.

--- a/orc/core/include/store_backed_observation_context.h
+++ b/orc/core/include/store_backed_observation_context.h
@@ -1,0 +1,129 @@
+/*
+ * File:        store_backed_observation_context.h
+ * Module:      orc-core
+ * Purpose:     Observation context that loads stored records per field on
+ *              first access instead of pre-loading a whole recording
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+// Host-internal (wraps ObservationStore). Only orc-core and orc-presenters may
+// include this header; GUI/CLI code must go through presenters.
+#if defined(ORC_GUI_BUILD)
+#error \
+    "GUI code cannot include core/include/store_backed_observation_context.h. Use a presenter instead."
+#endif
+#if defined(ORC_CLI_BUILD)
+#error \
+    "CLI code cannot include core/include/store_backed_observation_context.h. Use a presenter instead."
+#endif
+
+#include <orc/stage/frame_id.h>
+#include <orc/stage/observation/observation_context_interface.h>
+#include <orc/stage/observation/observation_service_interface.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "observation_store.h"
+
+namespace orc {
+
+/**
+ * @brief Read-through IObservationContext over an ObservationStore.
+ *
+ * A triggered sink walks its input range once, reading each frame's stored
+ * observations and (for a well-behaved sink) clearing them as it goes. Loading
+ * every stored record of the recording into the context before the sink
+ * starts — as the host previously did — costs memory proportional to the
+ * recording: several GB for a 600k-frame source with a dense observation
+ * namespace. This context instead materialises a field's records on the first
+ * read or write that touches the field, so peak memory follows the sink's
+ * working set, and the store's own LRU budget with sidecar read-through
+ * governs residency of everything else.
+ *
+ * Loading rules mirror the eager pre-load they replace:
+ *  - Stateless observers load per field.
+ *  - Stateful observers load only when the store covers every frame of the
+ *    range (all-or-nothing, so a per-frame skip can never break a cross-frame
+ *    stream's continuity). Coverage is checked once per observer, with
+ *    presence-only probes that leave the store's LRU untouched.
+ *  - A cleared field is never re-loaded: cleared data is gone, exactly as it
+ *    was when the whole recording was pre-loaded up front.
+ *
+ * Writes, schema registration and everything else delegate to the wrapped
+ * inner context, so a caller that persists the inner context afterwards sees
+ * what a pre-loaded run would have left there.
+ *
+ * Thread safety: none; confine an instance to the trigger thread (the
+ * wrapped ObservationStore is itself thread-safe).
+ */
+class StoreBackedObservationContext : public IObservationContext {
+ public:
+  /**
+   * @param inner       Context that actually holds the observations; must
+   *                    outlive this object.
+   * @param store       Store the records are loaded from; must outlive this
+   *                    object.
+   * @param fingerprint Provenance of the node whose output the records key on.
+   * @param observers   Observers whose records are candidates for loading.
+   * @param frame_range Frames of the triggered input; fields outside the
+   *                    derived range are delegated without loading.
+   */
+  StoreBackedObservationContext(IObservationContext& inner,
+                                ObservationStore& store,
+                                NodeFingerprint fingerprint,
+                                std::vector<ObserverInfo> observers,
+                                FrameIDRange frame_range);
+
+  void set(FieldID field_id, const std::string& namespace_,
+           const std::string& key, const ObservationValue& value) override;
+  std::optional<ObservationValue> get(FieldID field_id,
+                                      const std::string& namespace_,
+                                      const std::string& key) const override;
+  bool has(FieldID field_id, const std::string& namespace_,
+           const std::string& key) const override;
+  std::vector<std::string> get_keys(
+      FieldID field_id, const std::string& namespace_) const override;
+  std::vector<std::string> get_namespaces(FieldID field_id) const override;
+  std::map<std::string, std::map<std::string, ObservationValue>>
+  get_all_observations(FieldID field_id) const override;
+  void clear() override;
+  void clear_field(FieldID field_id) override;
+  void register_schema(const std::vector<ObservationKey>& keys) override;
+  void clear_schema() override;
+
+ private:
+  // Index of @p field_id in loaded_, or SIZE_MAX when the field lies outside
+  // the derived range and is never loaded.
+  size_t slot_of(FieldID field_id) const;
+
+  // Load every eligible observer's stored record for @p field_id into the
+  // inner context, once per field.
+  void ensure_loaded(FieldID field_id) const;
+
+  // Whether @p observer (stateful) has a stored record for every field of the
+  // range. Computed once per observer id, with presence-only probes.
+  bool stateful_fully_covered(const ObserverInfo& observer) const;
+
+  // Held as pointers (never null; the constructor takes references) so the
+  // class stays movable and can travel in a std::optional.
+  IObservationContext* inner_;
+  ObservationStore* store_;
+  NodeFingerprint fingerprint_;
+  std::vector<ObserverInfo> observers_;
+  FrameIDRange frame_range_;
+
+  // Mutable: reads materialise state (documented single-thread confinement).
+  mutable std::vector<bool> loaded_;
+  mutable std::map<std::string, bool> stateful_covered_;
+  // Set once clear() wipes the context: nothing loads afterwards, matching
+  // the pre-load-then-clear behaviour this class replaces.
+  mutable bool cleared_ = false;
+};
+
+}  // namespace orc

--- a/orc/core/observation_scheduler.cpp
+++ b/orc/core/observation_scheduler.cpp
@@ -158,10 +158,7 @@ void ObservationScheduler::submit(ObservationWorkItem item) {
     if (stop_requested_) {
       return;
     }
-    for (auto& chunk :
-         chunk_item(item, static_cast<unsigned>(workers_.size()))) {
-      enqueue_locked(std::move(chunk));
-    }
+    submit_item_locked(item);
   }
   cv_.notify_all();
   emit_workload();
@@ -174,15 +171,89 @@ void ObservationScheduler::submit_batch(
     if (stop_requested_) {
       return;
     }
-    for (auto& item : items) {
-      for (auto& chunk :
-           chunk_item(item, static_cast<unsigned>(workers_.size()))) {
-        enqueue_locked(std::move(chunk));
-      }
+    // Enqueued as we go, so a later item in the same batch is deduplicated
+    // against the earlier ones too.
+    for (const auto& item : items) {
+      submit_item_locked(item);
     }
   }
   cv_.notify_all();
   emit_workload();
+}
+
+std::vector<FrameIDRange> ObservationScheduler::uncovered_ranges_locked(
+    const ObservationWorkItem& item) const {
+  if (item.frames.empty()) {
+    return {};
+  }
+
+  // Collect the pending ranges that overlap this item at an equal or higher
+  // priority (numerically <=, see ObservationPriority).
+  const int limit = static_cast<int>(item.priority);
+  std::vector<FrameIDRange> covering;
+  const auto note = [&](const FrameIDRange& range) {
+    if (range.empty() || range.last < item.frames.first ||
+        range.first > item.frames.last) {
+      return;  // disjoint
+    }
+    covering.push_back(range);
+  };
+
+  for (int p = 0; p <= limit && p < kPriorityClasses; ++p) {
+    for (const auto& queued : queues_[p]) {
+      if (queued.node_id != item.node_id ||
+          queued.fingerprint != item.fingerprint) {
+        continue;
+      }
+      note(queued.frames);
+    }
+  }
+  for (const auto& worker : workers_) {
+    if (!worker->has_in_flight ||
+        static_cast<int>(worker->in_flight_priority) > limit ||
+        worker->in_flight_node != item.node_id ||
+        worker->in_flight_fingerprint != item.fingerprint) {
+      continue;
+    }
+    // The whole in-flight range counts: frames it has already observed are
+    // done, and the rest this worker will reach without being re-enqueued.
+    note(worker->in_flight_frames);
+  }
+
+  if (covering.empty()) {
+    return {item.frames};
+  }
+
+  std::sort(covering.begin(), covering.end(),
+            [](const FrameIDRange& a, const FrameIDRange& b) {
+              return a.first < b.first;
+            });
+
+  // Walk the sorted cover and emit the gaps left inside the item's range.
+  std::vector<FrameIDRange> gaps;
+  FrameID cursor = item.frames.first;
+  for (const auto& range : covering) {
+    if (range.first > cursor) {
+      gaps.push_back(FrameIDRange{cursor, range.first - 1});
+    }
+    if (range.last >= item.frames.last) {
+      return gaps;  // covered to the end; no wrap-around on range.last + 1
+    }
+    cursor = std::max(cursor, range.last + 1);
+  }
+  gaps.push_back(FrameIDRange{cursor, item.frames.last});
+  return gaps;
+}
+
+void ObservationScheduler::submit_item_locked(const ObservationWorkItem& item) {
+  for (const FrameIDRange& range : uncovered_ranges_locked(item)) {
+    ObservationWorkItem part = item;
+    part.frames = range;
+    for (auto& chunk :
+         chunk_item(part, static_cast<unsigned>(workers_.size()))) {
+      enqueue_locked(std::move(chunk));
+    }
+  }
 }
 
 void ObservationScheduler::enqueue_locked(ObservationWorkItem item) {
@@ -464,6 +535,8 @@ ObservationScheduler::NextAction ObservationScheduler::take_next(
         worker->has_in_flight = true;
         worker->in_flight_node = action.item.node_id;
         worker->in_flight_fingerprint = action.item.fingerprint;
+        worker->in_flight_frames = action.item.frames;
+        worker->in_flight_priority = action.item.priority;
         worker->cancel.store(false);
         ++in_flight_count_;
         return action;

--- a/orc/core/observation_scheduler.cpp
+++ b/orc/core/observation_scheduler.cpp
@@ -712,17 +712,21 @@ RendererObservationTaskRunner::~RendererObservationTaskRunner() = default;
 bool RendererObservationTaskRunner::observe_frame(
     NodeID node_id, const NodeFingerprint& fingerprint, FrameID frame_id,
     const std::vector<std::string>& /*observer_ids*/) {
-  // Fast path: if every observer's records for both fields of this frame are
-  // already stored, there is nothing to compute — skip the expensive render.
-  // Observation is per-frame independent (a fresh observer runs each frame), so
-  // a store hit is authoritative regardless of which chunk/worker produced it.
-  // has_stored() is presence-only: probing a warm sweep must not drag every
-  // record through the sidecar into the memory LRU just to prove it exists.
+  // Fast path: if every applicable observer's records for both fields of this
+  // frame are already stored, there is nothing to compute — skip the expensive
+  // render. Observation is per-frame independent (a fresh observer runs each
+  // frame), so a store hit is authoritative regardless of which chunk/worker
+  // produced it. has_stored() is presence-only: probing a warm sweep must not
+  // drag every record through the sidecar into the memory LRU just to prove it
+  // exists. The key set is filtered to the node's video system because the
+  // renderer's observer pass writes no records for inapplicable observers
+  // (standard_observer_applies) — demanding those keys here would defeat the
+  // fast path on every frame.
   if (store_ && !fingerprint.value.empty() && !observer_keys_.empty()) {
     const FieldID field_top(frame_id * 2);
     const FieldID field_bottom(frame_id * 2 + 1);
     bool all_present = true;
-    for (const auto& [id, version] : observer_keys_) {
+    for (const auto& [id, version] : observer_keys_for(node_id)) {
       if (!store_->has_stored({fingerprint, field_top, id, version}) ||
           !store_->has_stored({fingerprint, field_bottom, id, version})) {
         all_present = false;
@@ -746,11 +750,32 @@ bool RendererObservationTaskRunner::observe_frame(
   return true;
 }
 
+const std::vector<std::pair<std::string, std::string>>&
+RendererObservationTaskRunner::observer_keys_for(NodeID node_id) {
+  const auto it = node_observer_keys_.find(node_id);
+  if (it != node_observer_keys_.end()) {
+    return it->second;
+  }
+  auto keys = observer_keys_;
+  // Applicability fails open: without video parameters the full set is kept,
+  // matching the observer pass's own fallback.
+  if (const auto params = renderer_->get_video_parameters_at_node(node_id)) {
+    keys.erase(std::remove_if(keys.begin(), keys.end(),
+                              [&params](const auto& key) {
+                                return !standard_observer_applies(key.first,
+                                                                  *params);
+                              }),
+               keys.end());
+  }
+  return node_observer_keys_.emplace(node_id, std::move(keys)).first->second;
+}
+
 void RendererObservationTaskRunner::update_dag(
     std::shared_ptr<const DAG> dag,
     std::shared_ptr<const NodeFingerprintMap> fingerprints) {
   renderer_->update_dag(std::move(dag));
   renderer_->set_observation_store(store_, std::move(fingerprints));
+  node_observer_keys_.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/orc/core/observers/fm_code_observer.cpp
+++ b/orc/core/observers/fm_code_observer.cpp
@@ -26,8 +26,9 @@ void FmCodeObserver::process_frame(
   }
   const auto& vp = vp_opt.value();
 
-  // FM code is NTSC-only
-  if (vp.system != VideoSystem::NTSC) {
+  // FM code is NTSC-only (see applies_to()); callers normally skip the
+  // observer entirely, this early-return is defence in depth.
+  if (!applies_to(vp)) {
     return;
   }
 

--- a/orc/core/observers/fm_code_observer.h
+++ b/orc/core/observers/fm_code_observer.h
@@ -29,6 +29,11 @@ class FmCodeObserver : public Observer {
   std::string observer_name() const override { return "FmCodeObserver"; }
   std::string observer_version() const override { return "1.0.0"; }
 
+  // LaserDisc FM code lives on NTSC line 10 only.
+  bool applies_to(const SourceParameters& params) const override {
+    return params.system == VideoSystem::NTSC;
+  }
+
   void process_frame(const VideoFrameRepresentation& representation,
                      FrameID frame_id, IObservationContext& context) override;
 

--- a/orc/core/observers/observer.h
+++ b/orc/core/observers/observer.h
@@ -12,6 +12,7 @@
 #include <orc/stage/frame_id.h>
 #include <orc/stage/observation/observation_context.h>
 #include <orc/stage/observation/observation_schema.h>
+#include <orc/stage/orc_source_parameters.h>
 #include <orc/stage/video_frame_representation.h>
 
 #include <string>
@@ -72,6 +73,28 @@ class Observer {
    * @return Version string (e.g., "1.0.0")
    */
   virtual std::string observer_version() const = 0;
+
+  /**
+   * @brief Whether this observer can ever produce observations for a source
+   *
+   * Applicability is a pure function of the source's video parameters (e.g.
+   * teletext is PAL-only, FM code is NTSC-only); it must not depend on frame
+   * content. The observer pass and every coverage probe use this predicate to
+   * skip both the observer run and its per-field store records, so an
+   * observer returning false here must also produce no observations from
+   * process_frame() for the same parameters (the internal early-return stays
+   * as defence in depth).
+   *
+   * Thread-safety: must be const, side-effect free, and safe to call
+   * concurrently on a shared instance.
+   *
+   * @param params Source video parameters
+   * @return true when the observer applies to the source (the default)
+   */
+  virtual bool applies_to(const SourceParameters& params) const {
+    (void)params;
+    return true;
+  }
 
   /**
    * @brief Process a single frame and populate observation context

--- a/orc/core/observers/teletext_observer.cpp
+++ b/orc/core/observers/teletext_observer.cpp
@@ -88,9 +88,10 @@ void TeletextObserver::process_frame(
   }
   const auto& vp = vp_opt.value();
 
-  // ETSI EN 300 706 System B on 625-line PAL is the only supported system
-  // (design scope); other systems produce no observations.
-  if (vp.system != VideoSystem::PAL) {
+  // Non-PAL systems produce no observations (see applies_to()); callers
+  // normally skip the observer entirely, this early-return is defence in
+  // depth.
+  if (!applies_to(vp)) {
     return;
   }
 

--- a/orc/core/observers/teletext_observer.cpp
+++ b/orc/core/observers/teletext_observer.cpp
@@ -16,6 +16,7 @@
 #include <orc/support/teletext_slicer.h>
 #include <teletext_observer.h>
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -30,9 +31,20 @@ namespace {
 constexpr size_t kFirstCandidateFieldLine = 5;
 constexpr size_t kLastCandidateFieldLine = 21;
 
-// Observation key for a candidate field line's recovered packet.
-std::string t42_key(size_t field_line) {
-  return "t42_" + std::to_string(field_line);
+// Observation key for a candidate field line's recovered packet. Built once:
+// process_frame() asks per recovered line of every field it observes.
+const std::string& t42_key(size_t field_line) {
+  static const auto keys = [] {
+    std::array<std::string,
+               kLastCandidateFieldLine - kFirstCandidateFieldLine + 1>
+        built;
+    for (size_t line = kFirstCandidateFieldLine;
+         line <= kLastCandidateFieldLine; ++line) {
+      built[line - kFirstCandidateFieldLine] = "t42_" + std::to_string(line);
+    }
+    return built;
+  }();
+  return keys[field_line - kFirstCandidateFieldLine];
 }
 
 // Observers take no configuration, so the one slicer setup here has to serve

--- a/orc/core/observers/teletext_observer.h
+++ b/orc/core/observers/teletext_observer.h
@@ -53,6 +53,12 @@ class TeletextObserver : public Observer {
   // Mixing the two would let the older, unweighted copies win.
   std::string observer_version() const override { return "1.2.0"; }
 
+  // ETSI EN 300 706 System B on 625-line PAL is the only supported system
+  // (design scope).
+  bool applies_to(const SourceParameters& params) const override {
+    return params.system == VideoSystem::PAL;
+  }
+
   void process_frame(const VideoFrameRepresentation& representation,
                      FrameID frame_id, IObservationContext& context) override;
 

--- a/orc/core/observers/white_flag_observer.cpp
+++ b/orc/core/observers/white_flag_observer.cpp
@@ -26,8 +26,9 @@ void WhiteFlagObserver::process_frame(
   }
   const auto& vp = vp_opt.value();
 
-  // White flag is NTSC-only
-  if (vp.system != VideoSystem::NTSC) {
+  // White flag is NTSC-only (see applies_to()); callers normally skip the
+  // observer entirely, this early-return is defence in depth.
+  if (!applies_to(vp)) {
     return;
   }
 

--- a/orc/core/observers/white_flag_observer.h
+++ b/orc/core/observers/white_flag_observer.h
@@ -27,6 +27,11 @@ class WhiteFlagObserver : public Observer {
   std::string observer_name() const override { return "WhiteFlagObserver"; }
   std::string observer_version() const override { return "1.0.0"; }
 
+  // LaserDisc white flag lives on NTSC line 11 only.
+  bool applies_to(const SourceParameters& params) const override {
+    return params.system == VideoSystem::NTSC;
+  }
+
   void process_frame(const VideoFrameRepresentation& representation,
                      FrameID frame_id, IObservationContext& context) override;
 

--- a/orc/core/preview_renderer.cpp
+++ b/orc/core/preview_renderer.cpp
@@ -344,13 +344,10 @@ std::vector<PreviewOutputInfo> PreviewRenderer::get_available_outputs(
             return get_capability_preview_outputs(capability);
           }
 
-          // Signal-domain: render from the VFR produced by the DAG executor.
-          if (has_signal_domain_type(capability) && frame_renderer_) {
-            auto vfr_result = frame_renderer_->render_frame_at_node(
-                node_id, static_cast<FrameID>(0));
-            if (vfr_result.is_valid && vfr_result.representation) {
-              auto options = PreviewHelpers::get_standard_preview_options(
-                  vfr_result.representation);
+          // Signal-domain: describe the VFR produced by the DAG executor.
+          if (has_signal_domain_type(capability)) {
+            if (auto repr = representation_at(node_id)) {
+              auto options = PreviewHelpers::get_standard_preview_options(repr);
               return build_outputs_from_options(node_id, *node_it, options);
             }
           }
@@ -367,17 +364,12 @@ std::vector<PreviewOutputInfo> PreviewRenderer::get_available_outputs(
 
       // Fallback: stages that do not expose their own preview functionality
       // (or whose capability is not yet valid) default to the SDK preview
-      // helper.  Render a pass-through preview from the VFR available at this
-      // node — for sink nodes the frame renderer transparently substitutes the
-      // upstream node's output, so no per-plugin boilerplate is required.
-      if (frame_renderer_) {
-        auto vfr_result = frame_renderer_->render_frame_at_node(
-            node_id, static_cast<FrameID>(0));
-        if (vfr_result.is_valid && vfr_result.representation) {
-          auto options = PreviewHelpers::get_standard_preview_options(
-              vfr_result.representation);
-          return build_outputs_from_options(node_id, *node_it, options);
-        }
+      // helper, described from the VFR available at this node — for sink nodes
+      // resolution transparently substitutes the upstream node's output, so no
+      // per-plugin boilerplate is required.
+      if (auto repr = representation_at(node_id)) {
+        auto options = PreviewHelpers::get_standard_preview_options(repr);
+        return build_outputs_from_options(node_id, *node_it, options);
       }
 
       if (node_type == NodeType::SINK) {
@@ -437,7 +429,7 @@ PreviewRenderResult PreviewRenderer::render_output(const NodeID& node_id,
     if (node_it != dag_nodes.end() && node_it->stage) {
       if (auto* capability_stage = dynamic_cast<const IStagePreviewCapability*>(
               node_it->stage.get())) {
-        ensure_node_executed(node_id, true);
+        const auto node_outputs = ensure_node_executed(node_id, true);
         const StagePreviewCapability capability =
             capability_stage->get_preview_capability();
 
@@ -453,13 +445,15 @@ PreviewRenderResult PreviewRenderer::render_output(const NodeID& node_id,
             }
           }
 
-          // Signal-domain stages: render directly from the DAG VFR output.
-          if (has_signal_domain_type(capability) && frame_renderer_) {
-            auto vfr_result = frame_renderer_->render_frame_at_node(
-                node_id, static_cast<FrameID>(0));
-            if (vfr_result.is_valid && vfr_result.representation) {
+          // Signal-domain stages: render directly from the DAG VFR output. The
+          // representation comes from the execution above — the frame actually
+          // displayed is addressed by |index| inside render_standard_preview,
+          // so rendering frame 0 here only ever served to fetch this handle.
+          if (has_signal_domain_type(capability)) {
+            auto resolved = resolve_node_vfr(*dag_, node_outputs, node_id);
+            if (resolved.representation) {
               result.image = PreviewHelpers::render_standard_preview(
-                  vfr_result.representation, option_id, index, hint,
+                  resolved.representation, option_id, index, hint,
                   capability.geometry.mask_inactive_area);
               result.success = result.image.is_valid();
               if (result.success) render_dropouts(result.image);
@@ -481,18 +475,14 @@ PreviewRenderResult PreviewRenderer::render_output(const NodeID& node_id,
 
       // Fallback: stages without their own preview functionality default to the
       // SDK preview helper.  Render a pass-through preview from the VFR
-      // available at this node (for sink nodes the frame renderer substitutes
-      // the upstream node's output).
-      if (frame_renderer_) {
-        auto vfr_result = frame_renderer_->render_frame_at_node(
-            node_id, static_cast<FrameID>(0));
-        if (vfr_result.is_valid && vfr_result.representation) {
-          result.image = PreviewHelpers::render_standard_preview(
-              vfr_result.representation, option_id, index, hint);
-          result.success = result.image.is_valid();
-          if (result.success) render_dropouts(result.image);
-          return result;
-        }
+      // available at this node (for sink nodes resolution substitutes the
+      // upstream node's output).
+      if (auto repr = representation_at(node_id)) {
+        result.image = PreviewHelpers::render_standard_preview(repr, option_id,
+                                                               index, hint);
+        result.success = result.image.is_valid();
+        if (result.success) render_dropouts(result.image);
+        return result;
       }
     }
   }
@@ -638,7 +628,8 @@ void PreviewRenderer::set_execution_progress_callback(
 
 VideoFrameRepresentationPtr PreviewRenderer::get_representation_at_node(
     const NodeID& node_id) const {
-  if (!dag_ || !frame_renderer_) {
+  // No frame_renderer_ check: resolution goes through the executor now.
+  if (!dag_) {
     return nullptr;
   }
 
@@ -665,18 +656,18 @@ VideoFrameRepresentationPtr PreviewRenderer::get_representation_at_node(
       continue;
     }
 
-    ensure_node_executed(current);
-
-    auto result =
-        frame_renderer_->render_frame_at_node(current, static_cast<FrameID>(0));
-    if (result.is_valid && result.representation) {
+    // Resolve the node's artifact straight from the executor. Rendering a frame
+    // to get at it cost a second DAG execution plus a full observer pass over
+    // frame 0 whose results nobody reads — this renderer has no observation
+    // store, so that pass could neither be served from nor written to it.
+    if (auto repr = representation_at(current)) {
       if (current != node_id) {
         ORC_LOG_DEBUG(
             "get_representation_at_node: falling back from '{}' to upstream "
             "node '{}'",
             node_id.to_string(), current.to_string());
       }
-      return result.representation;
+      return repr;
     }
 
     for (const auto& input_node_id : node_it->second->input_node_ids) {
@@ -971,10 +962,11 @@ FrameFieldsResult PreviewRenderer::get_frame_fields(
 // Stage preview support
 // ============================================================================
 
-void PreviewRenderer::ensure_node_executed(const NodeID& node_id,
-                                           bool disable_cache) const {
+std::map<NodeID, std::vector<ArtifactPtr>>
+PreviewRenderer::ensure_node_executed(const NodeID& node_id,
+                                      bool disable_cache) const {
   if (!dag_) {
-    return;
+    return {};
   }
 
   // For sink nodes, we need to execute their inputs to populate cached_input_
@@ -986,7 +978,7 @@ void PreviewRenderer::ensure_node_executed(const NodeID& node_id,
 
   if (node_it == dag_nodes.end()) {
     ORC_LOG_ERROR("Node '{}' not found in DAG", node_id.to_string());
-    return;
+    return {};
   }
 
   bool is_sink = (node_it->stage &&
@@ -1004,7 +996,8 @@ void PreviewRenderer::ensure_node_executed(const NodeID& node_id,
     const_cast<DAGExecutor&>(dag_executor_).set_cache_enabled(false);
   }
 
-  const_cast<DAGExecutor&>(dag_executor_).execute_to_node(*dag_, node_id);
+  auto node_outputs =
+      const_cast<DAGExecutor&>(dag_executor_).execute_to_node(*dag_, node_id);
 
   // Restore previous cache state if it was changed
   if (disable_cache) {
@@ -1022,6 +1015,22 @@ void PreviewRenderer::ensure_node_executed(const NodeID& node_id,
         "cached_output_ set",
         node_id.to_string());
   }
+
+  return node_outputs;
+}
+
+VideoFrameRepresentationPtr PreviewRenderer::representation_at(
+    const NodeID& node_id) const {
+  if (!dag_) {
+    return nullptr;
+  }
+  const auto node_outputs = ensure_node_executed(node_id);
+  auto resolved = resolve_node_vfr(*dag_, node_outputs, node_id);
+  if (!resolved.representation ||
+      !resolved.representation->has_frame(static_cast<FrameID>(0))) {
+    return nullptr;
+  }
+  return resolved.representation;
 }
 
 std::vector<PreviewOutputInfo> PreviewRenderer::get_capability_preview_outputs(
@@ -1128,12 +1137,8 @@ std::vector<PreviewOutputInfo> PreviewRenderer::build_outputs_from_options(
   }
 
   bool has_separate_channels = false;
-  if (frame_renderer_) {
-    auto vfr_probe = frame_renderer_->render_frame_at_node(
-        stage_node_id, static_cast<FrameID>(0));
-    if (vfr_probe.is_valid && vfr_probe.representation) {
-      has_separate_channels = vfr_probe.representation->has_separate_channels();
-    }
+  if (auto repr = representation_at(stage_node_id)) {
+    has_separate_channels = repr->has_separate_channels();
   }
 
   const std::string stage_name =

--- a/orc/core/store_backed_observation_context.cpp
+++ b/orc/core/store_backed_observation_context.cpp
@@ -1,0 +1,160 @@
+/*
+ * File:        store_backed_observation_context.cpp
+ * Module:      orc-core
+ * Purpose:     Observation context that loads stored records per field on
+ *              first access instead of pre-loading a whole recording
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "store_backed_observation_context.h"
+
+#include <cstddef>
+#include <utility>
+
+namespace orc {
+
+namespace {
+
+// Derived field id convention used throughout the host: field = frame * 2 +
+// field_idx (top field 0, bottom field 1).
+constexpr FieldID::value_type kFieldsPerFrame = 2;
+
+}  // namespace
+
+StoreBackedObservationContext::StoreBackedObservationContext(
+    IObservationContext& inner, ObservationStore& store,
+    NodeFingerprint fingerprint, std::vector<ObserverInfo> observers,
+    FrameIDRange frame_range)
+    : inner_(&inner),
+      store_(&store),
+      fingerprint_(std::move(fingerprint)),
+      observers_(std::move(observers)),
+      frame_range_(frame_range) {
+  if (!frame_range_.empty()) {
+    loaded_.resize(frame_range_.count() * kFieldsPerFrame, false);
+  }
+}
+
+size_t StoreBackedObservationContext::slot_of(FieldID field_id) const {
+  const FieldID::value_type first_field = frame_range_.first * kFieldsPerFrame;
+  const FieldID::value_type value = field_id.value();
+  if (frame_range_.empty() || value < first_field ||
+      value - first_field >= loaded_.size()) {
+    return SIZE_MAX;
+  }
+  return static_cast<size_t>(value - first_field);
+}
+
+void StoreBackedObservationContext::ensure_loaded(FieldID field_id) const {
+  if (cleared_ || fingerprint_.value.empty()) {
+    return;
+  }
+  const size_t slot = slot_of(field_id);
+  if (slot == SIZE_MAX || loaded_[slot]) {
+    return;
+  }
+  // Marked before loading: a field whose records are absent has still been
+  // asked about, and asking the store again cannot change the answer.
+  loaded_[slot] = true;
+
+  for (const auto& observer : observers_) {
+    if (!observer.stateless && !stateful_fully_covered(observer)) {
+      continue;
+    }
+    store_->load_into({fingerprint_, field_id, observer.id, observer.version},
+                      *inner_);
+  }
+}
+
+bool StoreBackedObservationContext::stateful_fully_covered(
+    const ObserverInfo& observer) const {
+  const auto it = stateful_covered_.find(observer.id);
+  if (it != stateful_covered_.end()) {
+    return it->second;
+  }
+  bool covered = true;
+  for (FrameID frame = frame_range_.first;; ++frame) {
+    const FieldID top(frame * kFieldsPerFrame);
+    const FieldID bottom(frame * kFieldsPerFrame + 1);
+    if (!store_->has_stored(
+            {fingerprint_, top, observer.id, observer.version}) ||
+        !store_->has_stored(
+            {fingerprint_, bottom, observer.id, observer.version})) {
+      covered = false;
+      break;
+    }
+    if (frame == frame_range_.last) {
+      break;
+    }
+  }
+  stateful_covered_.emplace(observer.id, covered);
+  return covered;
+}
+
+void StoreBackedObservationContext::set(FieldID field_id,
+                                        const std::string& namespace_,
+                                        const std::string& key,
+                                        const ObservationValue& value) {
+  // Load before writing so a stored record and a freshly-computed value merge
+  // exactly as they did when everything was pre-loaded up front.
+  ensure_loaded(field_id);
+  inner_->set(field_id, namespace_, key, value);
+}
+
+std::optional<ObservationValue> StoreBackedObservationContext::get(
+    FieldID field_id, const std::string& namespace_,
+    const std::string& key) const {
+  ensure_loaded(field_id);
+  return inner_->get(field_id, namespace_, key);
+}
+
+bool StoreBackedObservationContext::has(FieldID field_id,
+                                        const std::string& namespace_,
+                                        const std::string& key) const {
+  ensure_loaded(field_id);
+  return inner_->has(field_id, namespace_, key);
+}
+
+std::vector<std::string> StoreBackedObservationContext::get_keys(
+    FieldID field_id, const std::string& namespace_) const {
+  ensure_loaded(field_id);
+  return inner_->get_keys(field_id, namespace_);
+}
+
+std::vector<std::string> StoreBackedObservationContext::get_namespaces(
+    FieldID field_id) const {
+  ensure_loaded(field_id);
+  return inner_->get_namespaces(field_id);
+}
+
+std::map<std::string, std::map<std::string, ObservationValue>>
+StoreBackedObservationContext::get_all_observations(FieldID field_id) const {
+  ensure_loaded(field_id);
+  return inner_->get_all_observations(field_id);
+}
+
+void StoreBackedObservationContext::clear() {
+  inner_->clear();
+  cleared_ = true;
+}
+
+void StoreBackedObservationContext::clear_field(FieldID field_id) {
+  // Mark the field loaded so a later read does not resurrect the cleared
+  // records from the store.
+  const size_t slot = slot_of(field_id);
+  if (slot != SIZE_MAX) {
+    loaded_[slot] = true;
+  }
+  inner_->clear_field(field_id);
+}
+
+void StoreBackedObservationContext::register_schema(
+    const std::vector<ObservationKey>& keys) {
+  inner_->register_schema(keys);
+}
+
+void StoreBackedObservationContext::clear_schema() { inner_->clear_schema(); }
+
+}  // namespace orc

--- a/orc/gui/main.cpp
+++ b/orc/gui/main.cpp
@@ -426,6 +426,12 @@ int main(int argc, char* argv[]) {
           ORC_LOG_INFO("Creating quick project from TBC file: {}",
                        filePath.toStdString());
           load_startup_file(filePath, true);
+        } else if (filePath.endsWith(".cvbs", Qt::CaseInsensitive) ||
+                   filePath.endsWith(".cvbsy", Qt::CaseInsensitive) ||
+                   filePath.endsWith(".cvbsc", Qt::CaseInsensitive)) {
+          ORC_LOG_INFO("Creating quick project from CVBS file: {}",
+                       filePath.toStdString());
+          load_startup_file(filePath, true);
         } else if (filePath.endsWith(".orcprj", Qt::CaseInsensitive)) {
           ORC_LOG_INFO("Opening project from command line: {}",
                        filePath.toStdString());

--- a/orc/gui/mainwindow.cpp
+++ b/orc/gui/mainwindow.cpp
@@ -1255,10 +1255,10 @@ void MainWindow::onQuickProject() {
   // Open file dialog to select TBC, TBCC, TBCY, or CVBS file
   QString filename = QFileDialog::getOpenFileName(
       this, "Quick Project - Select Video File", getLastSourceDirectory(),
-      "Video Files (*.tbc *.tbcc *.tbcy *.composite *.y *.c);;"
+      "Video Files (*.tbc *.tbcc *.tbcy *.cvbs *.cvbsy *.cvbsc);;"
       "TBC Files (*.tbc);;TBCC Files (*.tbcc);;TBCY Files (*.tbcy);;"
-      "CVBS Composite Files (*.composite);;"
-      "CVBS YC Files (*.y *.c);;All Files (*)");
+      "CVBS Composite Files (*.cvbs);;"
+      "CVBS YC Files (*.cvbsy *.cvbsc);;All Files (*)");
 
   if (filename.isEmpty()) {
     ORC_LOG_DEBUG("Quick project creation cancelled");
@@ -1665,37 +1665,28 @@ void MainWindow::quickProject(const QString& filename) {
       return;
     }
     secondary_file = tbcc_path.toStdString();
-  } else if (ext == "composite") {
+  } else if (ext == "cvbs") {
     is_cvbs = true;
     source_type = orc::SourceType::Composite;
-  } else if (ext == "y") {
+  } else if (ext == "cvbsy" || ext == "cvbsc") {
+    // Dual-file YC CVBS pair (CVBS file format spec, File Naming Convention).
     is_cvbs = true;
     source_type = orc::SourceType::YC;
-    QString c_path = base_path + ".c";
-    if (!QFileInfo::exists(c_path)) {
+    const bool selected_luma = (ext == "cvbsy");
+    const QString companion_path =
+        base_path + (selected_luma ? ".cvbsc" : ".cvbsy");
+    if (!QFileInfo::exists(companion_path)) {
       QMessageBox::warning(
           this, "Missing File",
-          QString("Could not find corresponding C (chroma) file: %1")
-              .arg(c_path));
+          QString("Could not find corresponding %1 file: %2")
+              .arg(selected_luma ? "C (chroma)" : "Y (luma)", companion_path));
       return;
     }
-    secondary_file = c_path.toStdString();
-  } else if (ext == "c") {
-    is_cvbs = true;
-    source_type = orc::SourceType::YC;
-    QString y_path = base_path + ".y";
-    if (!QFileInfo::exists(y_path)) {
-      QMessageBox::warning(
-          this, "Missing File",
-          QString("Could not find corresponding Y (luma) file: %1")
-              .arg(y_path));
-      return;
-    }
-    secondary_file = y_path.toStdString();
+    secondary_file = companion_path.toStdString();
   } else {
     QMessageBox::warning(
         this, "Invalid File",
-        QString("Please provide a .tbc, .tbcc, .tbcy, .composite, .y, or .c "
+        QString("Please provide a .tbc, .tbcc, .tbcy, .cvbs, .cvbsy, or .cvbsc "
                 "file. Got: %1")
             .arg(ext));
     return;
@@ -2030,9 +2021,12 @@ void MainWindow::quickProject(const QString& filename) {
         return;
       }
     } else {
-      // CVBS YC: single source stage with both y_path and c_path, wired to sink
-      const std::string y_file = (ext == "y") ? primary_file : secondary_file;
-      const std::string c_file = (ext == "c") ? primary_file : secondary_file;
+      // CVBS YC: single source stage with both y_path and c_path, wired to
+      // sink. A .cvbsy selection makes the chosen file the luma one; a .cvbsc
+      // selection makes it the chroma one and the companion the luma.
+      const bool selected_luma = (ext == "cvbsy");
+      const std::string y_file = selected_luma ? primary_file : secondary_file;
+      const std::string c_file = selected_luma ? secondary_file : primary_file;
 
       ORC_LOG_INFO("Adding CVBS YC source stage: {}", source_stage_name);
       orc::NodeID source_node_id;

--- a/orc/gui/stageparameterdialog.cpp
+++ b/orc/gui/stageparameterdialog.cpp
@@ -426,7 +426,8 @@ void StageParameterDialog::build_ui(
                 if (current_path.isEmpty()) return;
 
                 // Determine the extension pair and strip it to get the base
-                // path. tbc_source uses .tbcy/.tbcc; CVBS source uses .y/.c.
+                // path. tbc_source uses .tbcy/.tbcc; CVBS source uses
+                // .cvbsy/.cvbsc.
                 QString base_path = current_path;
                 QString y_ext, c_ext;
                 if (base_path.endsWith(".tbcy", Qt::CaseInsensitive) ||
@@ -434,11 +435,11 @@ void StageParameterDialog::build_ui(
                   base_path = base_path.left(base_path.length() - 5);
                   y_ext = ".tbcy";
                   c_ext = ".tbcc";
-                } else if (base_path.endsWith(".y", Qt::CaseInsensitive) ||
-                           base_path.endsWith(".c", Qt::CaseInsensitive)) {
-                  base_path = base_path.left(base_path.length() - 2);
-                  y_ext = ".y";
-                  c_ext = ".c";
+                } else if (base_path.endsWith(".cvbsy", Qt::CaseInsensitive) ||
+                           base_path.endsWith(".cvbsc", Qt::CaseInsensitive)) {
+                  base_path = base_path.left(base_path.length() - 6);
+                  y_ext = ".cvbsy";
+                  c_ext = ".cvbsc";
                 } else {
                   y_ext = ".tbcy";
                   c_ext = ".tbcc";

--- a/orc/plugins/stages/cvbs_sink/CMakeLists.txt
+++ b/orc/plugins/stages/cvbs_sink/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CVBS Sink Stage Plugin
 #
-# Writes CVBS file-format family output (.composite or .y/.c payload, .meta
+# Writes CVBS file-format family output (.cvbs or .cvbsy/.cvbsc payload, .meta
 # sidecar, and dropout/audio/EFM/AC3 extension sidecars).
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/orc/plugins/stages/cvbs_sink/cvbs_sink_encode.h
+++ b/orc/plugins/stages/cvbs_sink/cvbs_sink_encode.h
@@ -90,12 +90,11 @@ inline uint16_t encode_cvbs_u10_sample(int16_t value,
 }
 
 // Derive the CVBS output base path (no extension) from a user-supplied
-// output path: one trailing payload extension (.composite, .y, .c) or the
-// legacy .cvbs extension is stripped when present. The sink appends
-// .composite/.y/.c and the sidecar extensions to this base.
+// output path: one trailing payload extension (.cvbs, .cvbsy, .cvbsc — CVBS
+// file format spec, File Naming Convention) is stripped when present. The
+// sink appends .cvbs/.cvbsy/.cvbsc and the sidecar extensions to this base.
 inline std::string derive_cvbs_output_base(const std::string& output_path) {
-  static const char* kStrippableExtensions[] = {".composite", ".cvbs", ".y",
-                                                ".c"};
+  static const char* kStrippableExtensions[] = {".cvbs", ".cvbsy", ".cvbsc"};
   for (const char* ext : kStrippableExtensions) {
     const std::string suffix(ext);
     if (output_path.size() > suffix.size() &&

--- a/orc/plugins/stages/cvbs_sink/cvbs_sink_stage.cpp
+++ b/orc/plugins/stages/cvbs_sink/cvbs_sink_stage.cpp
@@ -50,7 +50,7 @@ NodeTypeInfo CVBSSinkStage::get_node_type_info() const {
       NodeType::SINK,
       "CVBSSink",
       "CVBS Sink",
-      "Writes frames to the CVBS file format (.composite or .y/.c payload, "
+      "Writes frames to the CVBS file format (.cvbs or .cvbsy/.cvbsc payload, "
       ".meta sidecar, and dropout/audio/EFM/AC3 sidecars when present)",
       1,
       1,
@@ -75,8 +75,9 @@ std::vector<ParameterDescriptor> CVBSSinkStage::get_parameter_descriptors(
   std::vector<ParameterDescriptor> descriptors;
 
   // The output signal type is not a choice: it follows the project type.
-  // A composite project writes <base>.composite; a Y/C project writes
-  // <base>.y + <base>.c (CVBS file format spec, File Naming Convention).
+  // A composite project writes <base>.cvbs; a Y/C project writes
+  // <base>.cvbsy + <base>.cvbsc (CVBS file format spec, File Naming
+  // Convention).
   const bool yc_project = (source_type == SourceType::YC);
 
   {
@@ -87,13 +88,13 @@ std::vector<ParameterDescriptor> CVBSSinkStage::get_parameter_descriptors(
         std::string(
             "Base path for the output files. The stage appends the payload "
             "extension and .meta automatically based on the project type (") +
-        (yc_project ? ".y/.c for this Y/C project"
-                    : ".composite for this composite project") +
-        "); a trailing .composite/.y/.c extension is stripped when present.";
+        (yc_project ? ".cvbsy/.cvbsc for this Y/C project"
+                    : ".cvbs for this composite project") +
+        "); a trailing .cvbs/.cvbsy/.cvbsc extension is stripped when present.";
     desc.type = ParameterType::FILE_PATH;
     desc.constraints.required = true;
     desc.constraints.default_value = std::string("");
-    desc.file_extension_hint = yc_project ? ".y" : ".composite";
+    desc.file_extension_hint = yc_project ? ".cvbsy" : ".cvbs";
     descriptors.push_back(desc);
   }
 
@@ -188,7 +189,7 @@ bool CVBSSinkStage::trigger(
 
     // The signal type is not user-selectable: it follows the input. A Y/C
     // project produces representations with separate channels and is written
-    // as .y/.c; a composite project is written as .composite.
+    // as .cvbsy/.cvbsc; a composite project is written as .cvbs.
     config.signal_type =
         vfr->has_separate_channels() ? kSignalTypeYC : kSignalTypeComposite;
 

--- a/orc/plugins/stages/cvbs_sink/cvbs_sink_stage_deps.cpp
+++ b/orc/plugins/stages/cvbs_sink/cvbs_sink_stage_deps.cpp
@@ -322,30 +322,18 @@ bool write_extension_sidecar(const std::string& path,
 // Stale output removal
 // ---------------------------------------------------------------------------
 
-// Highest legacy (CVBS spec v1.2.0) container track number swept when
-// removing stale outputs.  The legacy container allowed 16 two-digit track
-// files (_audio_00 … _audio_15), so a previous run of an older writer may
-// have left up to 16.
-constexpr size_t kStaleLegacyAudioFileSweep = 16;
-
 // Remove any output files from a previous run so a re-run never leaves a
 // stale sidecar describing data that is no longer being written.
 void remove_stale_outputs(const std::string& base) {
   static const char* kExtensions[] = {
-      ".composite", ".y",        ".c",   ".meta",    ".dropouts.meta",
-      ".efm",       ".efm.meta", ".ac3", ".ac3.meta"};
+      ".cvbs", ".cvbsy",    ".cvbsc", ".meta",    ".dropouts.meta",
+      ".efm",  ".efm.meta", ".ac3",   ".ac3.meta"};
   std::error_code ec;
   for (const char* ext : kExtensions) {
     std::filesystem::remove(base + ext, ec);
   }
   for (size_t pair = 0; pair < kMaxAudioChannelPairs; ++pair) {
     std::filesystem::remove(cvbs_audio_pair_path(base, pair), ec);
-  }
-  // Legacy v1.2.0 two-digit track files from a previous writer version.
-  for (size_t track = 0; track < kStaleLegacyAudioFileSweep; ++track) {
-    char suffix[16];
-    snprintf(suffix, sizeof(suffix), "_audio_%02zu.wav", track);
-    std::filesystem::remove(base + suffix, ec);
   }
 }
 
@@ -417,14 +405,14 @@ CVBSSinkWriteResult CVBSSinkStageDeps::write_cvbs(
   remove_stale_outputs(base);
 
   // --- Open payload stream(s) ---
-  const std::string primary_path = base + (yc ? ".y" : ".composite");
+  const std::string primary_path = base + (yc ? ".cvbsy" : ".cvbs");
   std::ofstream primary(primary_path, std::ios::binary | std::ios::trunc);
   if (!primary) {
     return {false, 0, "Failed to open output file: " + primary_path};
   }
 
   std::ofstream chroma;
-  const std::string chroma_path = base + ".c";
+  const std::string chroma_path = base + ".cvbsc";
   if (yc) {
     chroma.open(chroma_path, std::ios::binary | std::ios::trunc);
     if (!chroma) {

--- a/orc/plugins/stages/cvbs_sink/cvbs_sink_stage_deps_interface.h
+++ b/orc/plugins/stages/cvbs_sink/cvbs_sink_stage_deps_interface.h
@@ -23,14 +23,14 @@ namespace orc {
 // Validated write request built by CVBSSinkStage from its parameters.
 struct CVBSSinkWriteConfig {
   // Base path for all output files (payload extension already stripped);
-  // the writer appends .composite/.y/.c, .meta, and sidecar extensions.
+  // the writer appends .cvbs/.cvbsy/.cvbsc, .meta, and sidecar extensions.
   std::string output_base_path;
 
   // Output sample encoding; recorded as sample_encoding_preset in the .meta.
   CVBSSampleEncoding sample_encoding{CVBSSampleEncoding::U10_4FSC};
 
   // Derived from the input representation (never user-selected):
-  // "composite" writes <base>.composite; "yc" writes <base>.y + <base>.c.
+  // "composite" writes <base>.cvbs; "yc" writes <base>.cvbsy + <base>.cvbsc.
   std::string signal_type{"composite"};
 
   // Free-text capture_notes for the .meta; omitted when empty.

--- a/orc/plugins/stages/cvbs_sink/instructions.md
+++ b/orc/plugins/stages/cvbs_sink/instructions.md
@@ -1,6 +1,6 @@
 # CVBS Sink
 
-Writes processed CVBS video data to the CVBS file format for archival, interchange, or round-trip testing. The output consists of a `.composite` binary file (or `.y`/`.c` pair) and a `.meta` SQLite sidecar, and can be re-opened by the CVBS Source stage.
+Writes processed CVBS video data to the CVBS file format for archival, interchange, or round-trip testing. The output consists of a `.cvbs` binary file (or `.cvbsy`/`.cvbsc` pair) and a `.meta` SQLite sidecar, and can be re-opened by the CVBS Source stage.
 
 ## When to use
 
@@ -8,7 +8,7 @@ Use this sink at the end of a CVBS processing pipeline when you want to save the
 
 ## What it does
 
-Writes the incoming video stream using the selected sample encoding, plus a `.meta` SQLite sidecar database. The output signal type follows the project type automatically and is not user-selectable: a composite project is written as a single `.composite` file, and a Y/C project is written as a `.y`/`.c` pair (per the CVBS file format naming convention). The sidecar records the video standard preset, the selected `sample_encoding_preset`, the signal type, the frame count, and `signal_state_preset = STANDARD_TBC_LOCKED` (the signal state is fixed: only locked, standard-state signals reach a sink).
+Writes the incoming video stream using the selected sample encoding, plus a `.meta` SQLite sidecar database. The output signal type follows the project type automatically and is not user-selectable: a composite project is written as a single `.cvbs` file, and a Y/C project is written as a `.cvbsy`/`.cvbsc` pair (per the CVBS file format naming convention). The sidecar records the video standard preset, the selected `sample_encoding_preset`, the signal type, the frame count, and `signal_state_preset = STANDARD_TBC_LOCKED` (the signal state is fixed: only locked, standard-state signals reach a sink).
 
 Associated data are written automatically as sidecar files when present in the incoming stream:
 
@@ -20,7 +20,7 @@ Associated data are written automatically as sidecar files when present in the i
 ## Parameters
 
 ### output_path (file path)
-Base path for output files. The stage appends the payload extension (`.composite` for a composite project, `.y`/`.c` for a Y/C project) and `.meta` automatically; a trailing `.composite`, `.y`, or `.c` extension is stripped when present. Required.
+Base path for output files. The stage appends the payload extension (`.cvbs` for a composite project, `.cvbsy`/`.cvbsc` for a Y/C project) and `.meta` automatically; a trailing `.cvbs`, `.cvbsy`, or `.cvbsc` extension is stripped when present. Required.
 
 ### sample_encoding (string)
 Sample encoding of the output data, recorded as `sample_encoding_preset` in the `.meta` file. One of `CVBS_U10_4FSC` (default), `CVBS_U16_4FSC`, `CVBS_TPG21_4FSC`, or `CVBS_S16_4FSC`. `CVBS_U10_4FSC` preserves the internal 10-bit domain losslessly, including headroom values outside 0–1023; the other encodings clamp to their representable domain before scaling, as required by the CVBS file format specification.

--- a/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
+++ b/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
@@ -90,33 +90,86 @@ constexpr uint64_t kAudioBytesPerPair = 6;
 // Sample encoding normalisation
 // ---------------------------------------------------------------------------
 
+// The four sample encodings the CVBS container can declare (file format spec
+// §3.1), resolved from the encoding name once so the per-sample conversion
+// never touches a string. Matching the name inside the sample loop cost a
+// reload of the string's size and data pointer plus up to four literal
+// comparisons for every sample — the compiler cannot hoist them, because the
+// output writes may alias the object holding the name.
+enum class SampleEncoding { kU10, kU16, kTPG21, kS16 };
+
+inline SampleEncoding sample_encoding_from_name(const std::string& encoding) {
+  if (encoding == "CVBS_U10_4FSC") return SampleEncoding::kU10;
+  if (encoding == "CVBS_TPG21_4FSC") return SampleEncoding::kTPG21;
+  if (encoding == "CVBS_S16_4FSC") return SampleEncoding::kS16;
+  // "CVBS_U16_4FSC", and any unknown encoding, which it stands in for.
+  return SampleEncoding::kU16;
+}
+
 // CVBS file format spec §3.1: normalise a raw 16-bit word from any of the
 // four declared sample encodings to the CVBS_U10_4FSC domain (int16_t).
 // No output clamping — headroom values outside [0, 1023] are preserved.
-inline int16_t normalize_to_cvbs_u10(uint16_t raw, const std::string& encoding,
+//
+// Converting a whole run of samples goes through normalize_samples() below,
+// not this directly: the encoding has to be a compile-time constant for the
+// loop to vectorise.
+inline int16_t normalize_to_cvbs_u10(uint16_t raw, SampleEncoding encoding,
                                      int32_t blanking_10bit) {
-  if (encoding == "CVBS_U10_4FSC") {
-    // CVBS file format spec §3.1: int16_t stored bitwise as uint16_t.
-    return static_cast<int16_t>(raw);
+  switch (encoding) {
+    case SampleEncoding::kU10:
+      // CVBS file format spec §3.1: int16_t stored bitwise as uint16_t.
+      return static_cast<int16_t>(raw);
+    case SampleEncoding::kTPG21:
+      // CVBS file format spec §3.1: signed, device offset 508, ×64 scale.
+      return static_cast<int16_t>(
+          static_cast<int32_t>(static_cast<int16_t>(raw)) / 64 + 508);
+    case SampleEncoding::kS16:
+      // CVBS file format spec §3.1: signed, blanking-centred, ×32 scale.
+      return static_cast<int16_t>(
+          static_cast<int32_t>(static_cast<int16_t>(raw)) / 32 +
+          blanking_10bit);
+    case SampleEncoding::kU16:
+      break;
   }
-  if (encoding == "CVBS_U16_4FSC") {
-    // CVBS file format spec §3.1: unsigned value = 10-bit × 64.
-    return static_cast<int16_t>(static_cast<int32_t>(raw) / 64);
-  }
-  if (encoding == "CVBS_TPG21_4FSC") {
-    // CVBS file format spec §3.1: signed, device offset 508, ×64 scale.
-    const int32_t decoded =
-        static_cast<int32_t>(static_cast<int16_t>(raw)) / 64 + 508;
-    return static_cast<int16_t>(decoded);
-  }
-  if (encoding == "CVBS_S16_4FSC") {
-    // CVBS file format spec §3.1: signed, blanking-centred, ×32 scale.
-    const int32_t decoded =
-        static_cast<int32_t>(static_cast<int16_t>(raw)) / 32 + blanking_10bit;
-    return static_cast<int16_t>(decoded);
-  }
-  // Fallback — treat unknown encoding as CVBS_U16_4FSC.
+  // CVBS file format spec §3.1: unsigned value = 10-bit × 64.
   return static_cast<int16_t>(static_cast<int32_t>(raw) / 64);
+}
+
+// Convert |count| raw words into the CVBS_U10_4FSC domain.
+//
+// The encoding is a template parameter so the switch above folds away and each
+// instantiation is a flat loop the vectoriser can take — 16 samples per
+// instruction rather than a per-sample branch. Selecting the instantiation
+// once per call is what makes that possible; dispatching per sample (whether on
+// the encoding name or on the enum) leaves the branch inside the loop.
+template <SampleEncoding kEncoding>
+void normalize_samples_as(const uint16_t* src, size_t count,
+                          int32_t blanking_10bit, int16_t* dst) {
+  for (size_t i = 0; i < count; ++i) {
+    dst[i] = normalize_to_cvbs_u10(src[i], kEncoding, blanking_10bit);
+  }
+}
+
+inline void normalize_samples(const uint16_t* src, size_t count,
+                              SampleEncoding encoding, int32_t blanking_10bit,
+                              int16_t* dst) {
+  switch (encoding) {
+    case SampleEncoding::kU10:
+      normalize_samples_as<SampleEncoding::kU10>(src, count, blanking_10bit,
+                                                 dst);
+      return;
+    case SampleEncoding::kTPG21:
+      normalize_samples_as<SampleEncoding::kTPG21>(src, count, blanking_10bit,
+                                                   dst);
+      return;
+    case SampleEncoding::kS16:
+      normalize_samples_as<SampleEncoding::kS16>(src, count, blanking_10bit,
+                                                 dst);
+      return;
+    case SampleEncoding::kU16:
+      break;
+  }
+  normalize_samples_as<SampleEncoding::kU16>(src, count, blanking_10bit, dst);
 }
 
 // ---------------------------------------------------------------------------
@@ -222,6 +275,7 @@ class CVBSDecodedFrameRepresentation final : public VideoFrameRepresentation,
         deps_(std::move(deps)),
         input_path_(std::move(input_path)),
         sample_encoding_(std::move(sample_encoding)),
+        encoding_(sample_encoding_from_name(sample_encoding_)),
         video_params_(std::move(video_params)),
         ntsc_j_black_level_(ntsc_j_black_level),
         blanking_level_(video_params_.blanking_level),
@@ -403,12 +457,9 @@ class CVBSDecodedFrameRepresentation final : public VideoFrameRepresentation,
     }
     if (raw_words.size() < line_count) return {};
 
-    std::vector<sample_type> result;
-    result.reserve(line_count);
-    for (const uint16_t raw : raw_words) {
-      result.push_back(
-          normalize_to_cvbs_u10(raw, sample_encoding_, blanking_level_));
-    }
+    std::vector<sample_type> result(line_count);
+    normalize_samples(raw_words.data(), line_count, encoding_, blanking_level_,
+                      result.data());
     return result;
   }
 
@@ -475,11 +526,9 @@ class CVBSDecodedFrameRepresentation final : public VideoFrameRepresentation,
                                std::to_string(id) + " in '" + path + "'");
     }
     DecodedFrame result;
-    result.samples.reserve(frame_samples_);
-    for (size_t i = 0; i < frame_samples_; ++i) {
-      result.samples.push_back(normalize_to_cvbs_u10(
-          raw_words[i], sample_encoding_, blanking_level_));
-    }
+    result.samples.resize(frame_samples_);
+    normalize_samples(raw_words.data(), frame_samples_, encoding_,
+                      blanking_level_, result.samples.data());
     return result;
   }
 
@@ -492,6 +541,9 @@ class CVBSDecodedFrameRepresentation final : public VideoFrameRepresentation,
   std::shared_ptr<ICVBSSourceStageDeps> deps_;
   std::string input_path_;
   std::string sample_encoding_;
+  // sample_encoding_ resolved once at construction; the sample loops read this
+  // instead of matching the name per sample.
+  SampleEncoding encoding_;
   SourceParameters video_params_;
   std::optional<int32_t> ntsc_j_black_level_;
   int32_t blanking_level_;

--- a/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
+++ b/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
@@ -1368,13 +1368,13 @@ FixedFormatCVBSSourceStage::get_parameter_descriptors(
     pd.name = "input_path";
     pd.display_name = "CVBS File Path";
     pd.description =
-        "Path to the CVBS composite data file (.composite). "
+        "Path to the CVBS composite data file (.cvbs). "
         "A <basename>.meta sidecar is required unless a sample encoding is "
         "selected manually.";
     pd.type = ParameterType::FILE_PATH;
     pd.constraints.required = false;
     pd.constraints.default_value = std::string("");
-    pd.file_extension_hint = ".composite";
+    pd.file_extension_hint = ".cvbs";
     desc.push_back(pd);
   }
 
@@ -1384,13 +1384,13 @@ FixedFormatCVBSSourceStage::get_parameter_descriptors(
       pd.name = "y_path";
       pd.display_name = "CVBS Y (Luma) File Path";
       pd.description =
-          "Path to the CVBS luma channel file (.y) for YC sources. "
+          "Path to the CVBS luma channel file (.cvbsy) for YC sources. "
           "Set together with c_path; a shared <basename>.meta sidecar is "
           "required unless a sample encoding is selected manually.";
       pd.type = ParameterType::FILE_PATH;
       pd.constraints.required = false;
       pd.constraints.default_value = std::string("");
-      pd.file_extension_hint = ".y";
+      pd.file_extension_hint = ".cvbsy";
       desc.push_back(pd);
     }
 
@@ -1399,12 +1399,12 @@ FixedFormatCVBSSourceStage::get_parameter_descriptors(
       pd.name = "c_path";
       pd.display_name = "CVBS C (Chroma) File Path";
       pd.description =
-          "Path to the CVBS chroma channel file (.c) for YC sources. "
+          "Path to the CVBS chroma channel file (.cvbsc) for YC sources. "
           "Set together with y_path.";
       pd.type = ParameterType::FILE_PATH;
       pd.constraints.required = false;
       pd.constraints.default_value = std::string("");
-      pd.file_extension_hint = ".c";
+      pd.file_extension_hint = ".cvbsc";
       desc.push_back(pd);
     }
   }

--- a/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
+++ b/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
@@ -445,14 +445,19 @@ class CVBSDecodedFrameRepresentation final : public VideoFrameRepresentation,
     std::vector<sample_type> samples;
   };
 
+  // put_if_absent (not put): one representation is shared by every DAG
+  // consumer, so several observation workers can race past the contains()
+  // check and all decode the same frame. Replacing the cached entry would
+  // free the buffer that an earlier thread's get_frame() pointer still refers
+  // to — a 1.4 MB mmap'd block, so the fault is immediate and hard.
   void ensure_frame_cached(FrameID id) const {
     if (frame_cache_.contains(id)) return;
-    frame_cache_.put(id, decode_channel_frame(input_path_, id));
+    frame_cache_.put_if_absent(id, decode_channel_frame(input_path_, id));
   }
 
   void ensure_c_frame_cached(FrameID id) const {
     if (c_frame_cache_.contains(id)) return;
-    c_frame_cache_.put(id, decode_channel_frame(c_path_, id));
+    c_frame_cache_.put_if_absent(id, decode_channel_frame(c_path_, id));
   }
 
   DecodedFrame decode_channel_frame(const std::string& path, FrameID id) const {

--- a/orc/plugins/stages/cvbs_source/cvbs_source_stage.h
+++ b/orc/plugins/stages/cvbs_source/cvbs_source_stage.h
@@ -158,9 +158,9 @@ class ICVBSSourceStageDeps {
 // without output clamping so that headroom is preserved.
 //
 // Parameters:
-//   input_path       – path to the CVBS composite data file (.composite)
-//   y_path           – path to the luma channel file (.y) for YC mode
-//   c_path           – path to the chroma channel file (.c) for YC mode
+//   input_path       – path to the CVBS composite data file (.cvbs)
+//   y_path           – path to the luma channel file (.cvbsy) for YC mode
+//   c_path           – path to the chroma channel file (.cvbsc) for YC mode
 //   sample_encoding  – "From metadata" (default) or an explicit encoding
 //
 // Audio: every <basename>_audio_0.wav … _audio_7.wav sidecar (single-digit

--- a/orc/plugins/stages/cvbs_source/instructions.md
+++ b/orc/plugins/stages/cvbs_source/instructions.md
@@ -1,6 +1,6 @@
 # CVBS Source
 
-Reads composite video from a `.composite` file (or a `.y` / `.c` pair for Y/C captures) and presents the decoded frames as a VideoFrameRepresentation for downstream stages. By default the stage detects the sample encoding and other capture details from the `.meta` SQLite sidecar; because the CVBS file format declares metadata optional, the sample encoding can also be selected manually so that sources without a sidecar can be used. All sample values are normalised to the internal 10-bit CVBS domain before passing data downstream.
+Reads composite video from a `.cvbs` file (or a `.cvbsy` / `.cvbsc` pair for Y/C captures) and presents the decoded frames as a VideoFrameRepresentation for downstream stages. By default the stage detects the sample encoding and other capture details from the `.meta` SQLite sidecar; because the CVBS file format declares metadata optional, the sample encoding can also be selected manually so that sources without a sidecar can be used. All sample values are normalised to the internal 10-bit CVBS domain before passing data downstream.
 
 ## When to use
 
@@ -12,9 +12,9 @@ The file-path parameters offered match the project's source type: a composite pr
 
 | Parameter | Meaning |
 |-----------|---------|
-| CVBS File Path (`input_path`) | Path to the composite data file (`.composite`). Composite projects only. |
-| CVBS Y (Luma) File Path (`y_path`) | Path to the luma channel file (`.y`). Y/C projects only; set together with `c_path`. |
-| CVBS C (Chroma) File Path (`c_path`) | Path to the chroma channel file (`.c`). Y/C projects only; set together with `y_path`. |
+| CVBS File Path (`input_path`) | Path to the composite data file (`.cvbs`). Composite projects only. |
+| CVBS Y (Luma) File Path (`y_path`) | Path to the luma channel file (`.cvbsy`). Y/C projects only; set together with `c_path`. |
+| CVBS C (Chroma) File Path (`c_path`) | Path to the chroma channel file (`.cvbsc`). Y/C projects only; set together with `y_path`. |
 | Sample Encoding (`sample_encoding`) | `From metadata` (default) reads the encoding from the `.meta` sidecar. Selecting `CVBS_U10_4FSC`, `CVBS_U16_4FSC`, `CVBS_TPG21_4FSC`, or `CVBS_S16_4FSC` manually makes the sidecar optional. |
 
 The `lock_audio` parameter has been removed: the pipeline no longer has a free-running audio regime. All audio is carried as 48 kHz synchronous (frame-locked) 24-bit stereo channel pairs — the only audio format the CVBS file format specification (v1.4.0) permits.

--- a/orc/plugins/stages/tbc_source/ntsc_tbc_converter.cpp
+++ b/orc/plugins/stages/tbc_source/ntsc_tbc_converter.cpp
@@ -18,18 +18,7 @@ namespace orc {
 // Level mapping
 // ---------------------------------------------------------------------------
 
-int16_t NtscTBCConverter::tbc_to_cvbs(uint16_t tbc_sample, int32_t tbc_blanking,
-                                      int32_t tbc_white) {
-  // SMPTE 244M-2003: linear mapping from TBC 16-bit domain to CVBS_U10_4FSC.
-  // No output clamping — headroom outside [kNtscSyncTip, kNtscPeak] is
-  // preserved.
-  const double n =
-      static_cast<double>(static_cast<int32_t>(tbc_sample) - tbc_blanking) /
-      static_cast<double>(tbc_white - tbc_blanking);
-  const double cvbs =
-      n * static_cast<double>(kNtscWhite - kNtscBlanking) + kNtscBlanking;
-  return static_cast<int16_t>(std::lround(cvbs));
-}
+// tbc_to_cvbs lives in the header — see the note there on why.
 
 // ---------------------------------------------------------------------------
 // Frame assembly
@@ -61,16 +50,25 @@ std::vector<int16_t> NtscTBCConverter::assemble_frame(
         "NtscTBCConverter::assemble_frame: unexpected field sample counts");
   }
 
-  std::vector<int16_t> frame;
-  frame.reserve(static_cast<size_t>(kNtscFrameSamples));
+  // Sized up front and written through a cursor rather than push_back: the
+  // output length is fixed, so the per-sample capacity check buys nothing.
+  std::vector<int16_t> frame(static_cast<size_t>(kNtscFrameSamples));
+  int16_t* dst = frame.data();
+
+  // Level map built once for the whole frame — the source levels are
+  // constant across it, so the division belongs here and not in the
+  // sample loops.
+  const TbcLevelScale levels = level_scale(tbc_blanking, tbc_white);
 
   // VFR field 1 (top, 263 lines) ← TBC field 1 (odd-scan, first temporal)
-  for (const uint16_t s : tbc_field1) {
-    frame.push_back(tbc_to_cvbs(s, tbc_blanking, tbc_white));
+  for (size_t i = 0; i < exp_f1; ++i) {
+    dst[i] = levels.map(tbc_field1[i]);
   }
+  dst += exp_f1;
+
   // VFR field 2 (bottom, 262 lines) ← TBC field 2 (even-scan, second temporal)
-  for (const uint16_t s : tbc_field2) {
-    frame.push_back(tbc_to_cvbs(s, tbc_blanking, tbc_white));
+  for (size_t i = 0; i < exp_f2; ++i) {
+    dst[i] = levels.map(tbc_field2[i]);
   }
 
   return frame;

--- a/orc/plugins/stages/tbc_source/ntsc_tbc_converter.h
+++ b/orc/plugins/stages/tbc_source/ntsc_tbc_converter.h
@@ -15,6 +15,8 @@
 #include <optional>
 #include <vector>
 
+#include "tbc_level_scale.h"
+
 namespace orc {
 
 // ---------------------------------------------------------------------------
@@ -41,14 +43,30 @@ class NtscTBCConverter {
   // Level mapping
   // -------------------------------------------------------------------------
 
-  // SMPTE 244M-2003: map one TBC 16-bit unsigned sample to CVBS_U10_4FSC.
+  // SMPTE 244M-2003: the linear TBC → CVBS_U10_4FSC level map for NTSC.
   //
   // tbc_blanking / tbc_white are the 16-bit TBC-domain level values from
-  // `.tbc.json.db` (blanking_16b_ire, white_16b_ire).  No output clamping:
-  // headroom below sync tip and above peak white is preserved in the int16_t
-  // result.
+  // `.tbc.json.db` (blanking_16b_ire, white_16b_ire).  Build this once per
+  // frame and map samples through it; see tbc_level_scale.h for why the
+  // division cannot stay in the per-sample path.
+  static TbcLevelScale level_scale(int32_t tbc_blanking, int32_t tbc_white) {
+    return make_tbc_level_scale(tbc_blanking, tbc_white, kNtscBlanking,
+                                kNtscWhite);
+  }
+
+  // Map one TBC 16-bit unsigned sample to CVBS_U10_4FSC.  No output clamping:
+  // headroom below sync tip and above peak white is preserved.
+  //
+  // Convenience overload for single samples — it rebuilds the level map on
+  // every call, so never use it in a loop.
+  //
+  // Defined here, not in the .cpp: the plugins build with default symbol
+  // visibility, so an out-of-line definition is interposable and the compiler
+  // must emit a PLT call per sample — even from its own translation unit.
   static int16_t tbc_to_cvbs(uint16_t tbc_sample, int32_t tbc_blanking,
-                             int32_t tbc_white);
+                             int32_t tbc_white) {
+    return level_scale(tbc_blanking, tbc_white).map(tbc_sample);
+  }
 
   // -------------------------------------------------------------------------
   // Frame assembly

--- a/orc/plugins/stages/tbc_source/pal_m_tbc_converter.cpp
+++ b/orc/plugins/stages/tbc_source/pal_m_tbc_converter.cpp
@@ -18,18 +18,7 @@ namespace orc {
 // Level mapping
 // ---------------------------------------------------------------------------
 
-int16_t PalMTBCConverter::tbc_to_cvbs(uint16_t tbc_sample, int32_t tbc_blanking,
-                                      int32_t tbc_white) {
-  // ITU-R BT.1700-1 Annex 1 Part B: PAL_M uses NTSC signal levels.
-  // Linear mapping: no output clamping — headroom is preserved.
-  const double n =
-      static_cast<double>(static_cast<int32_t>(tbc_sample) - tbc_blanking) /
-      static_cast<double>(tbc_white - tbc_blanking);
-  // kNtscWhite and kNtscBlanking apply to PAL_M (identical numeric values).
-  const double cvbs =
-      n * static_cast<double>(kNtscWhite - kNtscBlanking) + kNtscBlanking;
-  return static_cast<int16_t>(std::lround(cvbs));
-}
+// tbc_to_cvbs lives in the header — see the note there on why.
 
 // ---------------------------------------------------------------------------
 // Frame assembly
@@ -61,16 +50,25 @@ std::vector<int16_t> PalMTBCConverter::assemble_frame(
         "PalMTBCConverter::assemble_frame: unexpected field sample counts");
   }
 
-  std::vector<int16_t> frame;
-  frame.reserve(static_cast<size_t>(kPalMFrameSamples));
+  // Sized up front and written through a cursor rather than push_back: the
+  // output length is fixed, so the per-sample capacity check buys nothing.
+  std::vector<int16_t> frame(static_cast<size_t>(kPalMFrameSamples));
+  int16_t* dst = frame.data();
+
+  // Level map built once for the whole frame — the source levels are
+  // constant across it, so the division belongs here and not in the
+  // sample loops.
+  const TbcLevelScale levels = level_scale(tbc_blanking, tbc_white);
 
   // VFR field 1 (top, 263 lines) ← TBC field 1 (odd-scan, first temporal)
-  for (const uint16_t s : tbc_field1) {
-    frame.push_back(tbc_to_cvbs(s, tbc_blanking, tbc_white));
+  for (size_t i = 0; i < exp_f1; ++i) {
+    dst[i] = levels.map(tbc_field1[i]);
   }
+  dst += exp_f1;
+
   // VFR field 2 (bottom, 262 lines) ← TBC field 2 (even-scan, second temporal)
-  for (const uint16_t s : tbc_field2) {
-    frame.push_back(tbc_to_cvbs(s, tbc_blanking, tbc_white));
+  for (size_t i = 0; i < exp_f2; ++i) {
+    dst[i] = levels.map(tbc_field2[i]);
   }
 
   return frame;

--- a/orc/plugins/stages/tbc_source/pal_m_tbc_converter.h
+++ b/orc/plugins/stages/tbc_source/pal_m_tbc_converter.h
@@ -15,6 +15,8 @@
 #include <optional>
 #include <vector>
 
+#include "tbc_level_scale.h"
+
 namespace orc {
 
 // ---------------------------------------------------------------------------
@@ -45,11 +47,31 @@ class PalMTBCConverter {
   // Level mapping
   // -------------------------------------------------------------------------
 
-  // ITU-R BT.1700-1 Annex 1 Part B: map one TBC 16-bit unsigned sample to
-  // CVBS_U10_4FSC.  Level constants are identical to NTSC (kNtscBlanking,
-  // kNtscWhite).  No output clamping.
+  // ITU-R BT.1700-1 Annex 1 Part B: the linear TBC → CVBS_U10_4FSC level map
+  // for PAL_M.  Level constants are identical to NTSC.
+  //
+  // tbc_blanking / tbc_white are the 16-bit TBC-domain level values from
+  // `.tbc.json.db` (blanking_16b_ire, white_16b_ire).  Build this once per
+  // frame and map samples through it; see tbc_level_scale.h for why the
+  // division cannot stay in the per-sample path.
+  static TbcLevelScale level_scale(int32_t tbc_blanking, int32_t tbc_white) {
+    return make_tbc_level_scale(tbc_blanking, tbc_white, kNtscBlanking,
+                                kNtscWhite);
+  }
+
+  // Map one TBC 16-bit unsigned sample to CVBS_U10_4FSC.  No output clamping:
+  // headroom below sync tip and above peak white is preserved.
+  //
+  // Convenience overload for single samples — it rebuilds the level map on
+  // every call, so never use it in a loop.
+  //
+  // Defined here, not in the .cpp: the plugins build with default symbol
+  // visibility, so an out-of-line definition is interposable and the compiler
+  // must emit a PLT call per sample — even from its own translation unit.
   static int16_t tbc_to_cvbs(uint16_t tbc_sample, int32_t tbc_blanking,
-                             int32_t tbc_white);
+                             int32_t tbc_white) {
+    return level_scale(tbc_blanking, tbc_white).map(tbc_sample);
+  }
 
   // -------------------------------------------------------------------------
   // Frame assembly

--- a/orc/plugins/stages/tbc_source/pal_tbc_converter.cpp
+++ b/orc/plugins/stages/tbc_source/pal_tbc_converter.cpp
@@ -19,31 +19,21 @@ namespace orc {
 // Level mapping
 // ---------------------------------------------------------------------------
 
-int16_t PalTBCConverter::tbc_to_cvbs(uint16_t tbc_sample, int32_t tbc_blanking,
-                                     int32_t tbc_white) {
-  // EBU Tech. 3280-E: linear mapping from TBC 16-bit domain to CVBS_U10_4FSC.
-  // No output clamping — headroom outside [kPalSyncTip, kPalPeak] is preserved.
-  const double n =
-      static_cast<double>(static_cast<int32_t>(tbc_sample) - tbc_blanking) /
-      static_cast<double>(tbc_white - tbc_blanking);
-  const double cvbs =
-      n * static_cast<double>(kPalWhite - kPalBlanking) + kPalBlanking;
-  return static_cast<int16_t>(std::lround(cvbs));
-}
+// tbc_to_cvbs lives in the header — see the note there on why.
 
 // ---------------------------------------------------------------------------
 // Private helpers: linear interpolation of extra PAL samples
 // ---------------------------------------------------------------------------
 
-// Append 2 linearly-interpolated bridge samples at t=1/3 and t=2/3.
+// Write 2 linearly-interpolated bridge samples at t=1/3 and t=2/3 to |dst|.
 // EBU Tech. 3280-E §1.3.1: the two extra samples on lines 312 and 624 bridge
 // the signal from the last nominal sample to the first sample of the next line.
-static void append_two_extra_samples(std::vector<int16_t>& buf, int16_t last,
-                                     int16_t first_next) {
+static void write_two_extra_samples(int16_t* dst, int16_t last,
+                                    int16_t first_next) {
   const int32_t a = static_cast<int32_t>(last);
   const int32_t b = static_cast<int32_t>(first_next);
-  buf.push_back(static_cast<int16_t>((2 * a + b) / 3));
-  buf.push_back(static_cast<int16_t>((a + 2 * b) / 3));
+  dst[0] = static_cast<int16_t>((2 * a + b) / 3);
+  dst[1] = static_cast<int16_t>((a + 2 * b) / 3);
 }
 
 // ---------------------------------------------------------------------------
@@ -75,60 +65,44 @@ std::vector<int16_t> PalTBCConverter::assemble_frame(
         "PalTBCConverter::assemble_frame: unexpected field sample counts");
   }
 
-  // Pre-convert all field samples to CVBS domain.
-  std::vector<int16_t> cvbs1(expected_field1);
-  std::vector<int16_t> cvbs2(expected_field2);
+  // Flat frame buffer: [CVBS field 1 (313 lines)] [CVBS field 2 (312 lines)]
+  // with 2 extra interpolated samples appended to the last line of each field
+  // (frame-flat lines 312 and 624) per EBU Tech. 3280-E §1.3.1.
+  //
+  // Each field is converted straight into this buffer through a cursor.
+  // Converting into a per-field buffer first and copying it in line by line
+  // cost a value-initialising memset of both (~1.4 MB, overwritten
+  // immediately) plus a second full pass over the frame through 625 range
+  // inserts, and the line loops did no reordering that would have justified
+  // it. The output length is fixed, so a cursor also avoids push_back's
+  // per-sample capacity check.
+  std::vector<int16_t> frame(static_cast<size_t>(kPalFrameSamples));
+  int16_t* dst = frame.data();
 
-  for (size_t i = 0; i < expected_field1; ++i) {
-    cvbs1[i] = tbc_to_cvbs(tbc_field1[i], tbc_blanking, tbc_white);
-  }
-  for (size_t i = 0; i < expected_field2; ++i) {
-    cvbs2[i] = tbc_to_cvbs(tbc_field2[i], tbc_blanking, tbc_white);
-  }
-
-  // Build flat frame buffer: [CVBS field 1 (313 lines)] [CVBS field 2 (312
-  // lines)] with 2 extra interpolated samples appended to the last line of
-  // each field (frame-flat lines 312 and 624) per EBU Tech. 3280-E §1.3.1.
-  std::vector<int16_t> frame;
-  frame.reserve(static_cast<size_t>(kPalFrameSamples));
+  // Level map built once for the whole frame — the source levels are constant
+  // across it, so the division belongs here and not in the sample loops.
+  const TbcLevelScale levels = level_scale(tbc_blanking, tbc_white);
 
   // ---- CVBS field 1: sourced from TBC field 1 (313 lines, odd-scan) ----
-  for (int32_t line = 0; line < kField1Lines; ++line) {
-    const size_t src_start =
-        static_cast<size_t>(line) * static_cast<size_t>(kLineWidth);
-
-    frame.insert(
-        frame.end(), cvbs1.begin() + static_cast<ptrdiff_t>(src_start),
-        cvbs1.begin() + static_cast<ptrdiff_t>(
-                            src_start + static_cast<size_t>(kLineWidth)));
-
-    // Frame-flat line 312 (last of field 1) gets 2 extra bridge samples.
-    if (line == kField1Lines - 1) {
-      const int16_t last_this =
-          cvbs1[src_start + static_cast<size_t>(kLineWidth) - 1];
-      const int16_t first_next = cvbs2[0];  // first sample of CVBS field 2
-      append_two_extra_samples(frame, last_this, first_next);
-    }
+  for (size_t i = 0; i < expected_field1; ++i) {
+    dst[i] = levels.map(tbc_field1[i]);
   }
+  dst += expected_field1;
+
+  // Frame-flat line 312 (last of field 1) gets 2 bridge samples toward the
+  // first sample of field 2.
+  write_two_extra_samples(dst, dst[-1], levels.map(tbc_field2[0]));
+  dst += 2;
 
   // ---- CVBS field 2: sourced from TBC field 2 (312 lines, even-scan) ----
-  for (int32_t line = 0; line < kField2Lines; ++line) {
-    const size_t src_start =
-        static_cast<size_t>(line) * static_cast<size_t>(kLineWidth);
-
-    frame.insert(
-        frame.end(), cvbs2.begin() + static_cast<ptrdiff_t>(src_start),
-        cvbs2.begin() + static_cast<ptrdiff_t>(
-                            src_start + static_cast<size_t>(kLineWidth)));
-
-    // Frame-flat line 624 (last of field 2) gets 2 extra bridge samples.
-    // No following line in this frame; bridge toward the last sample itself.
-    if (line == kField2Lines - 1) {
-      const int16_t last_this =
-          cvbs2[src_start + static_cast<size_t>(kLineWidth) - 1];
-      append_two_extra_samples(frame, last_this, last_this);
-    }
+  for (size_t i = 0; i < expected_field2; ++i) {
+    dst[i] = levels.map(tbc_field2[i]);
   }
+  dst += expected_field2;
+
+  // Frame-flat line 624 (last of field 2) gets 2 extra bridge samples. No
+  // following line in this frame; bridge toward the last sample itself.
+  write_two_extra_samples(dst, dst[-1], dst[-1]);
 
   return frame;
 }

--- a/orc/plugins/stages/tbc_source/pal_tbc_converter.h
+++ b/orc/plugins/stages/tbc_source/pal_tbc_converter.h
@@ -15,6 +15,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "tbc_level_scale.h"
+
 namespace orc {
 
 // ---------------------------------------------------------------------------
@@ -38,14 +40,30 @@ class PalTBCConverter {
   // Level mapping
   // -------------------------------------------------------------------------
 
-  // EBU Tech. 3280-E: map one TBC 16-bit unsigned sample to CVBS_U10_4FSC.
+  // EBU Tech. 3280-E: the linear TBC → CVBS_U10_4FSC level map for PAL.
   //
   // tbc_blanking and tbc_white are the TBC-domain level values read from
-  // `.tbc.json.db` (blanking_16b_ire, white_16b_ire).  No output clamping:
-  // headroom below sync tip and above peak white is preserved in the int16_t
-  // result.
+  // `.tbc.json.db` (blanking_16b_ire, white_16b_ire).  Build this once per
+  // frame and map samples through it; see tbc_level_scale.h for why the
+  // division cannot stay in the per-sample path.
+  static TbcLevelScale level_scale(int32_t tbc_blanking, int32_t tbc_white) {
+    return make_tbc_level_scale(tbc_blanking, tbc_white, kPalBlanking,
+                                kPalWhite);
+  }
+
+  // Map one TBC 16-bit unsigned sample to CVBS_U10_4FSC.  No output clamping:
+  // headroom below sync tip and above peak white is preserved.
+  //
+  // Convenience overload for single samples — it rebuilds the level map on
+  // every call, so never use it in a loop.
+  //
+  // Defined here, not in the .cpp: the plugins build with default symbol
+  // visibility, so an out-of-line definition is interposable and the compiler
+  // must emit a PLT call per sample — even from its own translation unit.
   static int16_t tbc_to_cvbs(uint16_t tbc_sample, int32_t tbc_blanking,
-                             int32_t tbc_white);
+                             int32_t tbc_white) {
+    return level_scale(tbc_blanking, tbc_white).map(tbc_sample);
+  }
 
   // -------------------------------------------------------------------------
   // Frame assembly

--- a/orc/plugins/stages/tbc_source/tbc_level_scale.h
+++ b/orc/plugins/stages/tbc_source/tbc_level_scale.h
@@ -1,0 +1,59 @@
+/*
+ * File:        tbc_level_scale.h
+ * Module:      orc-stage-plugin-tbc-source
+ * Purpose:     Frame-constant linear map from the TBC 16-bit domain to
+ *              CVBS_U10_4FSC
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace orc {
+
+// The TBC → CVBS_U10_4FSC level mapping with the frame-constant division
+// already applied, so converting a frame is one multiply-add per sample.
+//
+// Built once per assemble_frame() call. Computing it per sample — the shape
+// this replaced — cost a double division and a libm std::lround() call on
+// every one of the ~709k samples in a PAL frame, neither of which the
+// vectoriser can touch.
+//
+// Folding the division into `scale` is not bit-identical to dividing per
+// sample: reassociating the multiply-add shifts a small number of samples by
+// one LSB (0 to ~0.03% of a frame, depending on the level pair; never more
+// than 1 LSB). Rounding is unaffected — ties-away-from-zero below agrees with
+// std::lround on every value tested.
+struct TbcLevelScale {
+  double scale = 1.0;
+  double offset = 0.0;
+
+  // Map one TBC 16-bit unsigned sample to CVBS_U10_4FSC. No output clamping:
+  // headroom below sync tip and above peak white is preserved in the int16_t
+  // result.
+  int16_t map(uint16_t tbc_sample) const {
+    // Round to nearest, ties away from zero, without a libm call.
+    const double v = static_cast<double>(tbc_sample) * scale + offset;
+    return static_cast<int16_t>(v < 0.0 ? v - 0.5 : v + 0.5);
+  }
+};
+
+// Build the map from the TBC-domain levels read from `.tbc.json.db`
+// (blanking_16b_ire, white_16b_ire) and the target CVBS_U10_4FSC levels for
+// the video system.
+inline TbcLevelScale make_tbc_level_scale(int32_t tbc_blanking,
+                                          int32_t tbc_white,
+                                          int32_t cvbs_blanking,
+                                          int32_t cvbs_white) {
+  TbcLevelScale levels;
+  levels.scale = static_cast<double>(cvbs_white - cvbs_blanking) /
+                 static_cast<double>(tbc_white - tbc_blanking);
+  levels.offset =
+      static_cast<double>(cvbs_blanking) - tbc_blanking * levels.scale;
+  return levels;
+}
+
+}  // namespace orc

--- a/orc/plugins/stages/teletext_sink/teletext_sink_stage_deps.cpp
+++ b/orc/plugins/stages/teletext_sink/teletext_sink_stage_deps.cpp
@@ -72,6 +72,12 @@ std::string srt_timestamp(int64_t field_index) {
 
 // One emitted packet, held so squashing can rewrite it once every copy of
 // every row has been seen. |empty| marks a keep_empty_packets placeholder.
+//
+// The recovered stream of a long source is tens of millions of these (600k
+// frames × up to 34 candidate lines), so the entry is kept lean: the per-byte
+// confidence — absent entirely for threshold-detected packets, which is every
+// packet of a disc or direct capture — lives in a side pool rather than as a
+// 168-byte float array inside every entry.
 struct StreamEntry {
   std::array<uint8_t, kTeletextPacketBytes> bytes;
   int64_t field_index;
@@ -79,10 +85,17 @@ struct StreamEntry {
   // How sure the recovery chain was of each byte, and whether it could say.
   // Held with the packet because the rewrite pass re-feeds every copy under
   // its original identity: a re-feed that dropped the confidence would replace
-  // a weighted copy with an unweighted one.
+  // a weighted copy with an unweighted one. |confidence_slot| indexes the
+  // confidence pool when |has_confidence| is set.
   bool has_confidence;
-  TeletextPacketConfidence confidence;
+  uint32_t confidence_slot;
 };
+
+// Pooled per-byte confidence, quantised to 8 bits (value × 255). Lossless for
+// the observer path, whose stored observations already quantise to 16 levels
+// (level/15 × 255 = 17 × level exactly); the direct-slicer path loses at most
+// 1/255 of a vote weight per byte.
+using QuantizedPacketConfidence = std::array<uint8_t, kTeletextPacketBytes>;
 
 // Display row a packet is addressed to (X/1 to X/24, ETSI EN 300 706 §9.3.2),
 // or 0 when the MRAG does not decode or the packet is not a displayable row.
@@ -317,6 +330,7 @@ TeletextSinkResult TeletextSinkStageDeps::export_t42(
   squasher_options.max_pages = kSquashPageRunBound;
   TeletextRowSquasher squasher(squasher_options);
   std::vector<StreamEntry> stream;
+  std::vector<QuantizedPacketConfidence> confidence_pool;
   std::optional<TeletextPageDecoder> squash_pass;
   if (squash) {
     squash_pass.emplace();
@@ -338,6 +352,21 @@ TeletextSinkResult TeletextSinkStageDeps::export_t42(
     }
     if (squash) {
       page_decoder->set_row_squasher(&squasher);
+    }
+  }
+
+  // Observation namespace and per-line keys, built once: the loop below runs
+  // per candidate line of every field of the recording, and building the key
+  // strings there would be tens of millions of small allocations.
+  const std::string teletext_namespace = "teletext";
+  std::vector<std::string> t42_keys;
+  if (!slicer) {
+    t42_keys.reserve(static_cast<size_t>(options.last_field_line -
+                                         options.first_field_line) +
+                     1);
+    for (int32_t field_line = options.first_field_line;
+         field_line <= options.last_field_line; ++field_line) {
+      t42_keys.push_back("t42_" + std::to_string(field_line));
     }
   }
 
@@ -448,7 +477,9 @@ TeletextSinkResult TeletextSinkStageDeps::export_t42(
             }
           } else {
             const auto obs = observation_context.get(
-                field_id, "teletext", "t42_" + std::to_string(field_line));
+                field_id, teletext_namespace,
+                t42_keys[static_cast<size_t>(field_line -
+                                             options.first_field_line)]);
             if (obs && std::holds_alternative<std::string>(*obs)) {
               const auto observed =
                   teletext_hex_to_observed_packet(std::get<std::string>(*obs));
@@ -471,17 +502,33 @@ TeletextSinkResult TeletextSinkStageDeps::export_t42(
           if (packet.has_value()) {
             ++result.packets_written;
             field_has_data = true;
-            const TeletextPacketConfidence* weights =
-                has_confidence ? &confidence : nullptr;
             if (squash) {
+              // Quantise the confidence for the pool, then vote on the
+              // dequantised values in both passes so the rewrite re-feeds
+              // exactly the weights this pass used.
+              uint32_t confidence_slot = 0;
+              if (has_confidence) {
+                QuantizedPacketConfidence quantized;
+                for (size_t i = 0; i < kTeletextPacketBytes; ++i) {
+                  quantized[i] = static_cast<uint8_t>(std::lround(
+                      std::clamp(confidence[i], 0.0F, 1.0F) * 255.0F));
+                  confidence[i] =
+                      static_cast<float>(quantized[i]) * (1.0F / 255.0F);
+                }
+                confidence_slot = static_cast<uint32_t>(confidence_pool.size());
+                confidence_pool.push_back(quantized);
+              }
               // The stream index is the copy's identity for the squasher, so
               // the rewrite pass can re-feed it without counting it twice.
-              squash_pass->process_packet(*packet, relative_field_index,
-                                          static_cast<int64_t>(stream.size()),
-                                          weights);
+              squash_pass->process_packet(
+                  *packet, relative_field_index,
+                  static_cast<int64_t>(stream.size()),
+                  has_confidence ? &confidence : nullptr);
               stream.push_back(StreamEntry{*packet, relative_field_index, false,
-                                           has_confidence, confidence});
+                                           has_confidence, confidence_slot});
             } else {
+              const TeletextPacketConfidence* weights =
+                  has_confidence ? &confidence : nullptr;
               writer->write(packet->data(), packet->size());
               if (display_row_of(*packet) != 0) {
                 squash_stats.add_written_row(display_bytes_of(*packet));
@@ -496,8 +543,7 @@ TeletextSinkResult TeletextSinkStageDeps::export_t42(
             ++result.packets_written;
             if (squash) {
               stream.push_back(StreamEntry{kEmptyPacket, relative_field_index,
-                                           true, false,
-                                           TeletextPacketConfidence{}});
+                                           true, false, 0});
             } else {
               writer->write(kEmptyPacket.data(), kEmptyPacket.size());
             }
@@ -558,9 +604,18 @@ TeletextSinkResult TeletextSinkStageDeps::export_t42(
         }
 
         auto out = entry.bytes;
+        TeletextPacketConfidence entry_confidence{};
+        if (entry.has_confidence) {
+          const QuantizedPacketConfidence& quantized =
+              confidence_pool[entry.confidence_slot];
+          for (size_t i = 0; i < kTeletextPacketBytes; ++i) {
+            entry_confidence[i] =
+                static_cast<float>(quantized[i]) * (1.0F / 255.0F);
+          }
+        }
         attributor->process_packet(
             entry.bytes, entry.field_index, static_cast<int64_t>(index),
-            entry.has_confidence ? &entry.confidence : nullptr);
+            entry.has_confidence ? &entry_confidence : nullptr);
         const auto& attribution = attributor->last_row_attribution();
         if (attribution.has_value()) {
           const int row = attributor->last_row_number();

--- a/orc/presenters/src/render_presenter.cpp
+++ b/orc/presenters/src/render_presenter.cpp
@@ -424,6 +424,18 @@ class RenderPresenter::Impl {
   orc::CoreObservationService obs_service_;
   std::vector<orc::ObserverInfo> observers_;
 
+  // Per-fingerprint subsets of observers_ applicable to the node's video
+  // system (standard_observer_applies): the observer pass writes no records
+  // for inapplicable observers, so every coverage probe must demand the same
+  // filtered set or frames would look permanently uncovered. A fingerprint
+  // covers the source's identity and parameters, so an entry can never go
+  // stale; the map is cleared on rebuild only to drop unreachable keys.
+  // Touched only on the coordinator worker thread (like sched_swept_);
+  // other threads receive snapshots (PendingObservationRequest::observers,
+  // the makeSchedContext capture).
+  std::unordered_map<std::string, std::vector<orc::ObserverInfo>>
+      applicable_observers_by_fp_;
+
   // Background scheduler with a dedicated renderer/store on its own worker
   // thread; created on the first DAG build and re-pointed on each rebuild. The
   // shared fingerprint map keys interactive work items and store lookups.
@@ -467,6 +479,10 @@ class RenderPresenter::Impl {
     NodeID node_id{0};
     orc::FrameID frame_id = 0;
     orc::NodeFingerprint fingerprint;
+    // Applicable observer set snapshotted at request time, so the
+    // scheduler-thread resolution probes the same coverage the observer pass
+    // writes without touching the coordinator-thread applicability cache.
+    std::vector<orc::ObserverInfo> observers;
     orc::presenters::ObservationDataReadyCallback callback;
   };
   std::mutex pending_mutex_;
@@ -495,6 +511,33 @@ class RenderPresenter::Impl {
     const auto it = fingerprints_shared_->find(node);
     return it != fingerprints_shared_->end() ? it->second
                                              : orc::NodeFingerprint{};
+  }
+
+  // The subset of observers_ applicable to @p node_id's video parameters,
+  // cached in applicable_observers_by_fp_ (see the member comment for the
+  // consistency and threading contract). Applicability fails open: without a
+  // renderer or video parameters the full set is returned, matching the
+  // observer pass's own fallback.
+  const std::vector<orc::ObserverInfo>& observersForNode(
+      NodeID node_id, const orc::NodeFingerprint& fp) {
+    const auto it = applicable_observers_by_fp_.find(fp.value);
+    if (it != applicable_observers_by_fp_.end()) {
+      return it->second;
+    }
+    std::optional<orc::SourceParameters> params;
+    if (preview_renderer_) {
+      try {
+        if (const auto repr =
+                preview_renderer_->get_representation_at_node(node_id)) {
+          params = repr->get_video_parameters();
+        }
+      } catch (const std::exception&) {
+        params.reset();  // fail open: the full observer set stays in force
+      }
+    }
+    return applicable_observers_by_fp_
+        .emplace(fp.value, orc::filter_applicable_observers(observers_, params))
+        .first->second;
   }
 
   // Point the current renderer's executor at execution_progress_ (or clear it
@@ -551,12 +594,32 @@ class RenderPresenter::Impl {
     // Coverage probe for small plans (prefetch): presence-only, so probing a
     // warm window costs hash lookups / sidecar EXISTS queries, not record
     // loads. The context is consumed synchronously inside the scheduler's
-    // policy call on this thread, so capturing `this` is safe.
+    // policy call on this thread, so capturing `this` is safe; the per-node
+    // applicable observer sets are still snapshotted so the lambda never
+    // touches the coordinator-thread applicability cache.
     if (obs_store_) {
       auto store = obs_store_;
       auto fingerprints = fingerprints_shared_;
+      // Applicable observer set per node the policy may probe. The probe must
+      // demand exactly the records the observer pass writes (inapplicable
+      // observers store nothing), or covered frames would look uncovered.
+      std::unordered_map<NodeID, std::vector<orc::ObserverInfo>> node_observers;
+      const auto collect = [this,
+                            &node_observers](const std::vector<NodeID>& nodes) {
+        for (const NodeID node : nodes) {
+          if (node_observers.count(node) != 0) {
+            continue;
+          }
+          const orc::NodeFingerprint fp = fingerprintOf(node);
+          if (!fp.value.empty()) {
+            node_observers.emplace(node, observersForNode(node, fp));
+          }
+        }
+      };
+      collect(ctx.nodes_of_interest);
+      collect(ctx.changed_nodes);
       auto observers = observers_;
-      ctx.frame_observed = [store, fingerprints, observers](
+      ctx.frame_observed = [store, fingerprints, observers, node_observers](
                                NodeID node, orc::FrameID frame) {
         if (!fingerprints) {
           return false;
@@ -565,7 +628,10 @@ class RenderPresenter::Impl {
         if (it == fingerprints->end() || it->second.value.empty()) {
           return false;
         }
-        return store_frame_is_stored(*store, observers, it->second, frame);
+        const auto obs_it = node_observers.find(node);
+        const auto& node_obs =
+            obs_it != node_observers.end() ? obs_it->second : observers;
+        return store_frame_is_stored(*store, node_obs, it->second, frame);
       };
     }
     return ctx;
@@ -605,8 +671,12 @@ class RenderPresenter::Impl {
   // marker's observer-version stamp matches the current inventory AND a spot
   // probe of the first and last frames still finds records (detects a sidecar
   // GC that removed the fingerprint's records after the marker was written; GC
-  // removes whole fingerprints, so any frame probe suffices).
-  bool sweepMarkerValid(const orc::NodeFingerprint& fp, std::uint64_t total) {
+  // removes whole fingerprints, so any frame probe suffices). @p observers is
+  // the node's applicable set — the sweep stored exactly those records, so the
+  // probe must demand no more (and a probe against a sidecar swept by an older
+  // build, which stored the full set, still hits on the subset).
+  bool sweepMarkerValid(const orc::NodeFingerprint& fp, std::uint64_t total,
+                        const std::vector<orc::ObserverInfo>& observers) {
     if (!obs_persistence_ || !obs_store_ || total == 0) {
       return false;
     }
@@ -614,8 +684,8 @@ class RenderPresenter::Impl {
         observer_versions_stamp_) {
       return false;
     }
-    return store_frame_is_stored(*obs_store_, observers_, fp, 0) &&
-           store_frame_is_stored(*obs_store_, observers_, fp, total - 1);
+    return store_frame_is_stored(*obs_store_, observers, fp, 0) &&
+           store_frame_is_stored(*obs_store_, observers, fp, total - 1);
   }
 
   // Register a whole-node sweep of @p total frames at @p fp so its completions
@@ -689,7 +759,7 @@ class RenderPresenter::Impl {
     if (total == 0) {
       return;
     }
-    if (sweepMarkerValid(fp, total)) {
+    if (sweepMarkerValid(fp, total, observersForNode(node_id, fp))) {
       sched_swept_[node_id] = fp;  // completed in an earlier session
       return;
     }
@@ -711,6 +781,7 @@ class RenderPresenter::Impl {
       bool available;
       orc::NodeFingerprint fingerprint;
       orc::FrameID frame_id;
+      std::vector<orc::ObserverInfo> observers;
     };
     std::vector<Delivery> deliveries;
     {
@@ -723,18 +794,23 @@ class RenderPresenter::Impl {
           ++it;
           continue;
         }
+        // Probe against the request's applicable observer snapshot: the
+        // observer pass stores nothing for inapplicable observers, so
+        // demanding the full set would leave the request waiting forever.
         const bool present =
-            obs_store_ && store_has_frame(*obs_store_, observers_,
+            obs_store_ && store_has_frame(*obs_store_, it->observers,
                                           it->fingerprint, it->frame_id);
         if (present) {
           deliveries.push_back({std::move(it->callback), it->request_id, true,
-                                it->fingerprint, it->frame_id});
+                                it->fingerprint, it->frame_id,
+                                std::move(it->observers)});
           it = pending_requests_.erase(it);
         } else if (!completion.succeeded) {
           // The observation attempt for this target ended (failed/cancelled)
           // without records: report the miss so the caller stops waiting.
           deliveries.push_back({std::move(it->callback), it->request_id, false,
-                                it->fingerprint, it->frame_id});
+                                it->fingerprint, it->frame_id,
+                                std::move(it->observers)});
           it = pending_requests_.erase(it);
         } else {
           // A successful completion for a different frame of the same node:
@@ -749,7 +825,7 @@ class RenderPresenter::Impl {
       }
       if (d.available && obs_store_) {
         orc::ObservationContext ctx;
-        load_frame_from_store(*obs_store_, observers_, d.fingerprint,
+        load_frame_from_store(*obs_store_, d.observers, d.fingerprint,
                               d.frame_id, ctx);
         d.callback(d.request_id, true, &ctx);
       } else {
@@ -996,6 +1072,11 @@ class RenderPresenter::Impl {
     field_renderer_ = std::make_unique<orc::DAGFrameRenderer>(dag);
     field_renderer_->set_observation_store(obs_store_, fingerprints);
 
+    // A fingerprint's applicable observer set can never go stale (provenance
+    // covers the source parameters), but unreachable fingerprints would
+    // accumulate — drop them with the rebuild.
+    applicable_observers_by_fp_.clear();
+
     preview_view_registry_ = orc::PreviewViewRegistry{};
     orc::PreviewViewRegistry::register_default_views(
         preview_view_registry_, dag, preview_renderer_.get());
@@ -1161,7 +1242,7 @@ class RenderPresenter::Impl {
   // through, in which case the caller passes the inner context unchanged.
   std::optional<orc::StoreBackedObservationContext> makeStoreBackedContext(
       NodeID input_node, const orc::VideoFrameRepresentation* vfr,
-      orc::ObservationContext& inner) const {
+      orc::ObservationContext& inner) {
     if (!obs_store_ || vfr == nullptr) {
       return std::nullopt;
     }
@@ -1174,7 +1255,8 @@ class RenderPresenter::Impl {
       return std::nullopt;
     }
     return std::optional<orc::StoreBackedObservationContext>(
-        std::in_place, inner, *obs_store_, fingerprint, observers_, range);
+        std::in_place, inner, *obs_store_, fingerprint,
+        observersForNode(input_node, fingerprint), range);
   }
 
   // Phase 5.3 (write-back): after a sink trigger computes observations, persist
@@ -1200,12 +1282,16 @@ class RenderPresenter::Impl {
       return;
     }
 
+    // Iterate the node's applicable set only: an inapplicable observer never
+    // produces data here, and its records must stay absent so coverage
+    // probes (filtered by the same predicate) stay coherent.
+    const auto& observers = observersForNode(input_node, fingerprint);
     const auto persist_field = [&](orc::FieldID field) {
       const auto all_obs = ctx.get_all_observations(field);
       if (all_obs.empty()) {
         return;
       }
-      for (const auto& observer : observers_) {
+      for (const auto& observer : observers) {
         const orc::ObservationRecordKey key{fingerprint, field, observer.id,
                                             observer.version};
         if (obs_store_->has(key)) {
@@ -1275,10 +1361,12 @@ class RenderPresenter::Impl {
     }
     obs_store_->warm_start({fingerprint});
 
-    // Frames the store does not fully cover yet.
+    // Frames the store does not fully cover yet, judged against the node's
+    // applicable observer set (inapplicable observers store no records).
+    const auto& observers = observersForNode(input_node, fingerprint);
     std::vector<orc::FrameID> missing;
     for (orc::FrameID frame = range.first;; ++frame) {
-      if (!store_has_frame(*obs_store_, observers_, fingerprint, frame)) {
+      if (!store_has_frame(*obs_store_, observers, fingerprint, frame)) {
         missing.push_back(frame);
       }
       if (frame == range.last) {
@@ -1452,12 +1540,14 @@ uint64_t RenderPresenter::requestObservations(
   // here, so clicking through stages does not trigger whole-node sweeps.
   impl_->sweepNodeForObservation(node_id);
 
+  const std::vector<orc::ObserverInfo>& observers =
+      impl_->observersForNode(node_id, fingerprint);
+
   // Store hit: answer synchronously, no render.
-  if (store_has_frame(*impl_->obs_store_, impl_->observers_, fingerprint,
-                      frame_id)) {
+  if (store_has_frame(*impl_->obs_store_, observers, fingerprint, frame_id)) {
     orc::ObservationContext ctx;
-    load_frame_from_store(*impl_->obs_store_, impl_->observers_, fingerprint,
-                          frame_id, ctx);
+    load_frame_from_store(*impl_->obs_store_, observers, fingerprint, frame_id,
+                          ctx);
     if (callback) {
       callback(request_id, true, &ctx);
     }
@@ -1472,6 +1562,7 @@ uint64_t RenderPresenter::requestObservations(
     pending.node_id = node_id;
     pending.frame_id = frame_id;
     pending.fingerprint = fingerprint;
+    pending.observers = observers;
     pending.callback = std::move(callback);
     impl_->pending_requests_.push_back(std::move(pending));
   }

--- a/orc/presenters/src/render_presenter.cpp
+++ b/orc/presenters/src/render_presenter.cpp
@@ -48,6 +48,7 @@
 #include "../core/include/project.h"
 #include "../core/include/project_to_dag.h"
 #include "../core/include/sqlite_observation_persistence.h"
+#include "../core/include/store_backed_observation_context.h"
 #include "analysis_series_decimator.h"
 #include "metrics_presenter.h"
 #include "project_presenter.h"
@@ -1148,74 +1149,32 @@ class RenderPresenter::Impl {
     }
   }
 
-  // Phase 5.3: pre-load a triggered sink's ObservationContext with observations
-  // already held in the provenance-keyed store, so the sink can skip
-  // re-observing covered frames. @p input_node is the node whose output VFR the
-  // sink observes (its content keys the stored records). Stateless observers
-  // are pre-loaded per frame; stateful observers all-or-nothing, so a sink's
-  // per-frame skip can never break a cross-frame stream's continuity.
-  void preloadStoredObservations(NodeID input_node,
-                                 const orc::VideoFrameRepresentation* vfr,
-                                 orc::ObservationContext& ctx) const {
+  // Phase 5.3 (lazy read-through): wrap a triggered sink's ObservationContext
+  // in a store-backed context that materialises each field's stored records on
+  // the first access, so the sink can skip re-observing covered frames without
+  // the whole recording being loaded into memory up front (the eager pre-load
+  // this replaces peaked at GBs on a 600k-frame source). @p input_node is the
+  // node whose output VFR the sink observes (its content keys the stored
+  // records). Stateless observers load per field; stateful observers
+  // all-or-nothing, so a sink's per-frame skip can never break a cross-frame
+  // stream's continuity. Returns nullopt when there is nothing to read
+  // through, in which case the caller passes the inner context unchanged.
+  std::optional<orc::StoreBackedObservationContext> makeStoreBackedContext(
+      NodeID input_node, const orc::VideoFrameRepresentation* vfr,
+      orc::ObservationContext& inner) const {
     if (!obs_store_ || vfr == nullptr) {
-      return;
+      return std::nullopt;
     }
     const orc::NodeFingerprint fingerprint = fingerprintOf(input_node);
     if (fingerprint.value.empty()) {
-      return;
+      return std::nullopt;
     }
     const orc::FrameIDRange range = vfr->frame_range();
     if (range.empty()) {
-      return;
+      return std::nullopt;
     }
-
-    const auto load_frame = [&](const orc::ObserverInfo& observer,
-                                orc::FrameID frame) {
-      const orc::FieldID top(frame * kFieldsPerFrame);
-      const orc::FieldID bottom(frame * kFieldsPerFrame + 1);
-      obs_store_->load_into({fingerprint, top, observer.id, observer.version},
-                            ctx);
-      obs_store_->load_into(
-          {fingerprint, bottom, observer.id, observer.version}, ctx);
-    };
-
-    for (const auto& observer : observers_) {
-      if (observer.stateless) {
-        for (orc::FrameID frame = range.first;; ++frame) {
-          load_frame(observer, frame);
-          if (frame == range.last) {
-            break;
-          }
-        }
-        continue;
-      }
-
-      // Stateful: only pre-load when every frame is covered.
-      bool fully_covered = true;
-      for (orc::FrameID frame = range.first;; ++frame) {
-        const orc::FieldID top(frame * kFieldsPerFrame);
-        const orc::FieldID bottom(frame * kFieldsPerFrame + 1);
-        if (!obs_store_->has(
-                {fingerprint, top, observer.id, observer.version}) ||
-            !obs_store_->has(
-                {fingerprint, bottom, observer.id, observer.version})) {
-          fully_covered = false;
-          break;
-        }
-        if (frame == range.last) {
-          break;
-        }
-      }
-      if (!fully_covered) {
-        continue;
-      }
-      for (orc::FrameID frame = range.first;; ++frame) {
-        load_frame(observer, frame);
-        if (frame == range.last) {
-          break;
-        }
-      }
-    }
+    return std::optional<orc::StoreBackedObservationContext>(
+        std::in_place, inner, *obs_store_, fingerprint, observers_, range);
   }
 
   // Phase 5.3 (write-back): after a sink trigger computes observations, persist
@@ -1887,8 +1846,11 @@ uint64_t RenderPresenter::triggerStage(NodeID node_id,
     // execute_to_node
     orc::ObservationContext& obs_context = executor->get_observation_context();
     // Fill the store in parallel with every observation the sink will read
-    // (skipping frames the background already covered), then seed the context
-    // from the store so the sink's own loop computes nothing.
+    // (skipping frames the background already covered); the sink then reads
+    // through a store-backed context that loads each field on first access,
+    // so its own loop computes nothing and peak memory follows the sink's
+    // working set rather than the recording length.
+    std::optional<orc::StoreBackedObservationContext> store_context;
     if (!target_node->input_node_ids.empty() && !inputs.empty()) {
       auto vfr =
           std::dynamic_pointer_cast<orc::VideoFrameRepresentation>(inputs[0]);
@@ -1896,17 +1858,15 @@ uint64_t RenderPresenter::triggerStage(NodeID node_id,
                                                 vfr.get(), callback)) {
         throw std::runtime_error("Trigger failed: Cancelled by user");
       }
-      // Seeding the sink's context from the store touches ~1M records on a
-      // long source; tell the progress dialog what is happening instead of
-      // sitting silent between the precompute and the sink's own reporting.
-      if (callback) {
-        callback(0, 1, "Loading cached observations…");
-      }
-      impl_->preloadStoredObservations(target_node->input_node_ids[0],
-                                       vfr.get(), obs_context);
+      store_context = impl_->makeStoreBackedContext(
+          target_node->input_node_ids[0], vfr.get(), obs_context);
     }
-    bool success =
-        trigger_stage->trigger(inputs, target_node->parameters, obs_context);
+    orc::IObservationContext& trigger_context =
+        store_context.has_value()
+            ? static_cast<orc::IObservationContext&>(*store_context)
+            : obs_context;
+    bool success = trigger_stage->trigger(inputs, target_node->parameters,
+                                          trigger_context);
 
     // Clear current trigger stage pointer
     impl_->current_trigger_stage_.store(nullptr);
@@ -2006,8 +1966,9 @@ uint64_t RenderPresenter::triggerStage(
     }
 
     orc::ObservationContext& obs_context = executor->get_observation_context();
-    // Phase 5.3: seed the context with cached observations (see the primary
-    // triggerStage overload).
+    // Phase 5.3: read cached observations through a store-backed context (see
+    // the primary triggerStage overload).
+    std::optional<orc::StoreBackedObservationContext> store_context;
     if (!target_node->input_node_ids.empty() && !inputs.empty()) {
       auto vfr =
           std::dynamic_pointer_cast<orc::VideoFrameRepresentation>(inputs[0]);
@@ -2015,16 +1976,15 @@ uint64_t RenderPresenter::triggerStage(
                                                 vfr.get(), callback)) {
         throw std::runtime_error("Trigger failed: Cancelled by user");
       }
-      // Seeding the sink's context from the store touches ~1M records on a
-      // long source; tell the progress dialog what is happening instead of
-      // sitting silent between the precompute and the sink's own reporting.
-      if (callback) {
-        callback(0, 1, "Loading cached observations…");
-      }
-      impl_->preloadStoredObservations(target_node->input_node_ids[0],
-                                       vfr.get(), obs_context);
+      store_context = impl_->makeStoreBackedContext(
+          target_node->input_node_ids[0], vfr.get(), obs_context);
     }
-    bool success = trigger_stage->trigger(inputs, merged_params, obs_context);
+    orc::IObservationContext& trigger_context =
+        store_context.has_value()
+            ? static_cast<orc::IObservationContext&>(*store_context)
+            : obs_context;
+    bool success =
+        trigger_stage->trigger(inputs, merged_params, trigger_context);
 
     impl_->current_trigger_stage_.store(nullptr);
     impl_->trigger_active_.store(false);

--- a/orc/sdk/include/orc/support/teletext_row_squasher.h
+++ b/orc/sdk/include/orc/support/teletext_row_squasher.h
@@ -173,6 +173,13 @@ class TeletextRowSquasher {
     std::vector<TeletextRowBytes> copies;
     std::vector<TeletextRowConfidence> confidences;
     std::vector<int64_t> sources;
+    // Insertion order of each slot. Once the copy bound is reached the oldest
+    // slot is overwritten in place (erasing the front of the parallel vectors
+    // would move every later element on every saturated add), so slot order no
+    // longer says which copy is newest — this does. A replaced copy keeps its
+    // sequence number: re-reading a line is not a new transmission.
+    std::vector<uint64_t> seq;
+    uint64_t next_seq = 0;
   };
   struct PageRows {
     // Index 0 is unused: display rows are numbered from 1 (§9.3.2).

--- a/orc/sdk/src/teletext_page_decoder.cpp
+++ b/orc/sdk/src/teletext_page_decoder.cpp
@@ -348,6 +348,20 @@ void TeletextPageDecoder::terminate_page(int transmission_magazine,
   }
   state.page_open = false;
 
+  // Rendering the snapshot is the expensive part of closing a page — with a
+  // squasher attached it votes over every stored copy of all 24 rows — and a
+  // header packet closes a page every few dozen packets for the whole of a
+  // recording. Skip it when nothing will consume it: no page callback, and
+  // the closed page is not the watched subtitle page (the only page
+  // subtitle_page_completed() acts on).
+  const bool watched_subtitle_page =
+      subtitle_filter_.has_value() &&
+      displayed_magazine(transmission_magazine) == subtitle_filter_->first &&
+      state.page_number == subtitle_filter_->second;
+  if (page_callback_ == nullptr && !watched_subtitle_page) {
+    return;
+  }
+
   TeletextPageSnapshot snapshot = render_snapshot(transmission_magazine, state);
   snapshot.transmission_complete = transmission_complete;
   if (page_callback_) {

--- a/orc/sdk/src/teletext_row_squasher.cpp
+++ b/orc/sdk/src/teletext_row_squasher.cpp
@@ -16,74 +16,9 @@
 #include <orc/support/teletext_row_squasher.h>
 
 #include <algorithm>
+#include <array>
 
 namespace orc {
-
-namespace {
-
-// Pick the winning value for one byte position across |copies|.
-//
-// Odd parity (ETSI EN 300 706 §8.1) detects every single-bit error, so a byte
-// that fails it is known to be corrupt: the vote is held among the
-// parity-clean candidates whenever there are any, and only falls back to all
-// candidates when every copy of this position is damaged. Within that, each
-// copy contributes how sure the recovery chain was of the byte (1 where it
-// cannot say), so a value read cleanly outweighs the same number of copies of
-// one the detector nearly decided the other way. Ties go to the value from the
-// most recently added copy: with only two differing copies there is no majority
-// to find, and the newer transmission is what a plain Level 1 decoder would be
-// showing.
-uint8_t vote(const std::vector<TeletextRowBytes>& copies,
-             const std::vector<TeletextRowConfidence>& confidences,
-             size_t position) {
-  const auto tally = [&](bool parity_clean_only) -> std::optional<uint8_t> {
-    // The candidates are the copies themselves — at most max_copies_per_row of
-    // them — so the vote is counted over those rather than over all 256 byte
-    // values. This runs for every byte of every row of every page rendered,
-    // which a previewer does on each frame it steps, so the difference is not
-    // academic.
-    uint8_t best = 0;
-    double best_weight = 0.0;
-    size_t best_last = 0;
-    bool found = false;
-    for (size_t i = 0; i < copies.size(); ++i) {
-      const uint8_t value = copies[i][position];
-      if (parity_clean_only && !teletext_odd_parity_valid(value)) {
-        continue;
-      }
-      // Every copy holding this same value votes for it, by its confidence in
-      // it; the outer guard already established that the value passes the
-      // parity filter.
-      double weight = 0.0;
-      size_t last_seen = 0;
-      for (size_t j = 0; j < copies.size(); ++j) {
-        if (copies[j][position] != value) {
-          continue;
-        }
-        weight += static_cast<double>(confidences[j][position]);
-        last_seen = j;
-      }
-      if (!found || weight > best_weight ||
-          (weight == best_weight && last_seen > best_last)) {
-        found = true;
-        best = value;
-        best_weight = weight;
-        best_last = last_seen;
-      }
-    }
-    if (!found) {
-      return std::nullopt;
-    }
-    return best;
-  };
-
-  if (const auto clean = tally(/*parity_clean_only=*/true)) {
-    return *clean;
-  }
-  return tally(/*parity_clean_only=*/false).value_or(copies[0][position]);
-}
-
-}  // namespace
 
 void TeletextRowSquasher::add_row(const TeletextPageKey& key, int row,
                                   const TeletextRowBytes& bytes, int64_t source,
@@ -119,17 +54,28 @@ void TeletextRowSquasher::add_row(const TeletextPageKey& key, int row,
         static_cast<size_t>(std::distance(copies.sources.begin(), existing));
     copies.copies[index] = bytes;
     copies.confidences[index] = weights;
-    return;
+    return;  // recency deliberately unchanged: a re-read, not a transmission
   }
 
-  if (copies.sources.size() >= options_.max_copies_per_row) {
-    copies.sources.erase(copies.sources.begin());
-    copies.copies.erase(copies.copies.begin());
-    copies.confidences.erase(copies.confidences.begin());
+  if (copies.sources.size() >= options_.max_copies_per_row &&
+      !copies.sources.empty()) {
+    // Overwrite the oldest slot in place (see RowCopies::seq).
+    size_t oldest = 0;
+    for (size_t i = 1; i < copies.seq.size(); ++i) {
+      if (copies.seq[i] < copies.seq[oldest]) {
+        oldest = i;
+      }
+    }
+    copies.sources[oldest] = source;
+    copies.copies[oldest] = bytes;
+    copies.confidences[oldest] = weights;
+    copies.seq[oldest] = copies.next_seq++;
+    return;
   }
   copies.sources.push_back(source);
   copies.copies.push_back(bytes);
   copies.confidences.push_back(weights);
+  copies.seq.push_back(copies.next_seq++);
 }
 
 std::optional<TeletextRowBytes> TeletextRowSquasher::squashed_row(
@@ -148,9 +94,71 @@ std::optional<TeletextRowBytes> TeletextRowSquasher::squashed_row(
     return copies.copies.front();  // a vote of one is the copy itself
   }
 
+  // Pick the winning value at each byte position across the copies.
+  //
+  // Odd parity (ETSI EN 300 706 §8.1) detects every single-bit error, so a
+  // byte that fails it is known to be corrupt: the vote is held among the
+  // parity-clean candidates whenever there are any, and only falls back to all
+  // candidates when every copy of this position is damaged. Within that, each
+  // copy contributes how sure the recovery chain was of the byte (1 where it
+  // cannot say), so a value read cleanly outweighs the same number of copies of
+  // one the detector nearly decided the other way. Ties go to the value from
+  // the most recently added copy: with only two differing copies there is no
+  // majority to find, and the newer transmission is what a plain Level 1
+  // decoder would be showing.
+  //
+  // This runs for every byte of every row of every page rendered — a previewer
+  // renders per frame stepped, and the sink's rewrite pass asks once per
+  // packet of the whole recording — so the tally is one pass over the copies
+  // per position. The accumulators are per byte value, epoch-marked by
+  // position so nothing is cleared between positions.
+  const size_t copy_count = copies.copies.size();
+  std::array<double, 256> weight_of;
+  std::array<uint64_t, 256> newest_of;
+  std::array<uint8_t, 256> seen_at{};  // epoch marks: position + 1, 0 = never
+  std::array<uint8_t, 256> distinct;   // values seen at this position
+
   TeletextRowBytes result{};
   for (size_t position = 0; position < kTeletextRowBytes; ++position) {
-    result[position] = vote(copies.copies, copies.confidences, position);
+    const uint8_t epoch = static_cast<uint8_t>(position + 1);
+    size_t distinct_count = 0;
+    for (size_t j = 0; j < copy_count; ++j) {
+      const uint8_t value = copies.copies[j][position];
+      if (seen_at[value] != epoch) {
+        seen_at[value] = epoch;
+        weight_of[value] = 0.0;
+        newest_of[value] = 0;
+        distinct[distinct_count++] = value;
+      }
+      weight_of[value] += static_cast<double>(copies.confidences[j][position]);
+      newest_of[value] = std::max(newest_of[value], copies.seq[j]);
+    }
+
+    bool found = false;
+    bool best_clean = false;
+    uint8_t best = 0;
+    double best_weight = 0.0;
+    uint64_t best_newest = 0;
+    for (size_t k = 0; k < distinct_count; ++k) {
+      const uint8_t value = distinct[k];
+      const bool clean = teletext_odd_parity_valid(value);
+      if (found) {
+        if (best_clean && !clean) {
+          continue;  // a value known corrupt never beats a parity-clean one
+        }
+        if (clean == best_clean && !(weight_of[value] > best_weight ||
+                                     (weight_of[value] == best_weight &&
+                                      newest_of[value] > best_newest))) {
+          continue;
+        }
+      }
+      found = true;
+      best = value;
+      best_clean = clean;
+      best_weight = weight_of[value];
+      best_newest = newest_of[value];
+    }
+    result[position] = best;
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Performance work for very long captures (issue #245: LP-VHS maximums, ~300–600k frame
sources), plus the CVBS file format v1.5.0 update.

**CVBS file format v1.5.0** — payload extensions renamed `.composite`/`.y`/`.c` →
`.cvbs`/`.cvbsy`/`.cvbsc` across the CVBS source and sink stages, quick-project file
dialogs and command-line handling, the YC companion-file picker, and the docs. The
sink's stale-output sweep drops the legacy v1.2.0 two-digit audio track files.

**Source throughput** — TBC → CVBS level conversion is now a frame-constant multiply-add
(`tbc_level_scale.h`) instead of a per-sample division plus `std::lround`, for PAL, PAL-M
and NTSC. CVBS sample-encoding normalisation resolves the encoding name once into an enum
and dispatches a templated loop, so the per-sample branch leaves the loop and the
vectoriser can take it. Decoded-frame caches use `put_if_absent` so racing observation
workers can't free a buffer another thread is still reading.

**Observation pipeline** — observers now declare applicability via `Observer::applies_to()`
(teletext is PAL-only, FM code and white flag NTSC-only); the observer pass, the runner's
store fast path and every coverage probe filter on the same predicate, so inapplicable
observers cost neither a run nor store records. The scheduler deduplicates enqueued work
against what is queued or in flight, so a re-planned prefetch window can't have several
workers render the same frame. Triggered sinks read stored observations through a new
`StoreBackedObservationContext` that materialises records per field on first access,
replacing an eager pre-load that peaked at GBs on a 600k-frame source. Node output
resolution moved into a shared `resolve_node_vfr()`, and video parameters can be queried
structurally without rendering a frame or running observers.

**Teletext** — per-line observation keys are built once rather than per recovered line;
packet confidence moved to a quantised side pool (8-bit, lossless for the observer path)
instead of a 168-byte float array in every entry; the row squasher overwrites the oldest
copy slot in place with an explicit sequence number rather than erasing the vector front.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation
- [ ] Other

## Validation

New unit tests cover the observation scheduler's enqueue deduplication, observer-pass
applicability skipping, `StoreBackedObservationContext` lazy loading/clearing semantics,
`standard_observer_applies`/`filter_applicable_observers`, and `resolve_node_vfr()`
including sink upstream substitution. `pal_tbc_converter_test` gains a case pinning the
folded level-scale mapping. The CVBS source/sink stage tests were updated for the v1.5.0
extensions.

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [x] Related docs were updated if needed
- [x] Linked issue (if applicable)

## Related issue

Closes #245
