### PR TITLE
Fix AV1 video sink rate control

### DIFF
--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -128,6 +128,7 @@ orc_add_core_unit_tests(
 
         stages/video_sink/componentframe_test.cpp
         stages/video_sink/vectorscope_analysis_test.cpp
+        stages/video_sink/av1_rate_control_test.cpp
         stages/video_sink/video_sink_stage_defaults_test.cpp
         stages/video_sink/video_sink_stage_safety_test.cpp
         stages/video_sink/comb_test.cpp

--- a/orc-tests/core/unit/stages/video_sink/av1_rate_control_test.cpp
+++ b/orc-tests/core/unit/stages/video_sink/av1_rate_control_test.cpp
@@ -1,0 +1,31 @@
+/*
+ * File:        av1_rate_control_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Unit tests for AV1 rate-control precedence
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include "../../../../orc/plugins/stages/sinks/common/av1_rate_control.h"
+
+#include <gtest/gtest.h>
+
+namespace orc_unit_test {
+
+TEST(Av1RateControlTest, Resolve_LosslessOverridesTargetBitrate) {
+  EXPECT_EQ(orc::resolve_av1_rate_control(true, 8'000'000),
+            orc::Av1RateControl::kLossless);
+}
+
+TEST(Av1RateControlTest, Resolve_ZeroBitrateUsesCrfQuality) {
+  EXPECT_EQ(orc::resolve_av1_rate_control(false, 0),
+            orc::Av1RateControl::kCrfQuality);
+}
+
+TEST(Av1RateControlTest, Resolve_NonZeroBitrateUsesTargetBitrate) {
+  EXPECT_EQ(orc::resolve_av1_rate_control(false, 8'000'000),
+            orc::Av1RateControl::kTargetBitrate);
+}
+
+}  // namespace orc_unit_test

--- a/orc-tests/core/unit/stages/video_sink/video_sink_stage_test.cpp
+++ b/orc-tests/core/unit/stages/video_sink/video_sink_stage_test.cpp
@@ -107,6 +107,21 @@ TEST(VideoSinkStageTest, ParameterDescriptors_KeyEncoderControlsOffFormat) {
   }
 }
 
+TEST(VideoSinkStageTest, ParameterDescriptors_Av1EnablesRateControls) {
+  orc::VideoSinkStage stage;
+  const auto descriptors = stage.get_parameter_descriptors(
+      orc::VideoSystem::NTSC, orc::SourceType::Composite);
+
+  for (const auto* name : {"encoder_crf", "encoder_bitrate"}) {
+    const auto* descriptor = find_parameter(descriptors, name);
+    ASSERT_NE(descriptor, nullptr) << name;
+    ASSERT_TRUE(descriptor->constraints.depends_on.has_value()) << name;
+    EXPECT_TRUE(has_string(descriptor->constraints.depends_on->required_values,
+                           "mp4-av1"))
+        << name;
+  }
+}
+
 TEST(VideoSinkStageTest, Decoder_OptionsIncludeNtscPathsForCompositeAndYc) {
   orc::VideoSinkStage stage;
 

--- a/orc-tests/gui/unit/config_dialog_base_test.cpp
+++ b/orc-tests/gui/unit/config_dialog_base_test.cpp
@@ -331,6 +331,38 @@ TEST(ConfigDialogBaseTest, FfmpegDialog_AppliesPresetAndOptionRules) {
   EXPECT_EQ(std::get<std::string>(params.at("output_path")), "exports/out.mp4");
 }
 
+TEST(ConfigDialogBaseTest, FfmpegDialog_Av1WebPresetDefaultsToCrf32) {
+  (void)ensureApplication();
+
+  FFmpegPresetDialog dialog;
+  auto* category_group = findGroupByTitle(dialog, "Export Category");
+  auto* preset_group = findGroupByTitle(dialog, "Preset Selection");
+  auto* advanced_group =
+      findGroupByTitle(dialog, "Advanced Settings (Optional)");
+  ASSERT_NE(category_group, nullptr);
+  ASSERT_NE(preset_group, nullptr);
+  ASSERT_NE(advanced_group, nullptr);
+
+  auto* category_combo = qobject_cast<QComboBox*>(
+      fieldWidgetByRowLabel(*category_group, "Category:"));
+  auto* preset_combo =
+      qobject_cast<QComboBox*>(fieldWidgetByRowLabel(*preset_group, "Preset:"));
+  ASSERT_NE(category_combo, nullptr);
+  ASSERT_NE(preset_combo, nullptr);
+
+  category_combo->setCurrentIndex(5);  // Modern (H.265/AV1)
+  QCoreApplication::processEvents();
+  const int av1_index = preset_combo->findText("AV1 (Web Delivery)");
+  ASSERT_GE(av1_index, 0);
+  preset_combo->setCurrentIndex(av1_index);
+  QCoreApplication::processEvents();
+
+  clickOk(dialog);
+  const auto parameters = dialog.get_parameters();
+  ASSERT_NE(parameters.find("encoder_crf"), parameters.end());
+  EXPECT_EQ(std::get<int>(parameters.at("encoder_crf")), 32);
+}
+
 TEST(ConfigDialogBaseTest, FfmpegDialog_RoundTripsAspectRatioAndVideoFilter) {
   (void)ensureApplication();
 

--- a/orc-tests/gui/unit/stage_parameter_dialog_test.cpp
+++ b/orc-tests/gui/unit/stage_parameter_dialog_test.cpp
@@ -291,6 +291,51 @@ TEST(StageParameterDialogTest,
   EXPECT_DOUBLE_EQ(double_spin->value(), -0.5);
 }
 
+TEST(StageParameterDialogTest, Av1RateControlsEnableForAv1Format) {
+  (void)ensureApplication();
+
+  auto ffmpeg_format =
+      makeDescriptor("ffmpeg_format", "FFmpeg Format",
+                     orc::ParameterType::STRING, std::string("mkv-ffv1"),
+                     std::nullopt, std::nullopt, {"mkv-ffv1", "mp4-av1"});
+  auto encoder_crf =
+      makeDescriptor("encoder_crf", "Encoder CRF", orc::ParameterType::INT32,
+                     static_cast<int32_t>(18), static_cast<int32_t>(0),
+                     static_cast<int32_t>(51));
+  encoder_crf.constraints.depends_on =
+      orc::ParameterDependency{"ffmpeg_format", {"mp4-av1"}};
+  auto encoder_bitrate =
+      makeDescriptor("encoder_bitrate", "Encoder Bitrate",
+                     orc::ParameterType::INT32, static_cast<int32_t>(0),
+                     static_cast<int32_t>(0), static_cast<int32_t>(100000000));
+  encoder_bitrate.constraints.depends_on =
+      orc::ParameterDependency{"ffmpeg_format", {"mp4-av1"}};
+
+  StageParameterDialog dialog("video_sink", "Video Sink", "",
+                              {ffmpeg_format, encoder_crf, encoder_bitrate},
+                              {});
+
+  auto* format_combo =
+      qobject_cast<QComboBox*>(widgetForDisplayName(dialog, "FFmpeg Format"));
+  auto* crf =
+      qobject_cast<QSpinBox*>(widgetForDisplayName(dialog, "Encoder CRF"));
+  auto* bitrate =
+      qobject_cast<QSpinBox*>(widgetForDisplayName(dialog, "Encoder Bitrate"));
+  ASSERT_NE(format_combo, nullptr);
+  ASSERT_NE(crf, nullptr);
+  ASSERT_NE(bitrate, nullptr);
+  EXPECT_TRUE(crf->isHidden());
+  EXPECT_TRUE(bitrate->isHidden());
+
+  const int av1_index = format_combo->findText("mp4-av1");
+  ASSERT_GE(av1_index, 0);
+  format_combo->setCurrentIndex(av1_index);
+  QCoreApplication::processEvents();
+
+  EXPECT_FALSE(crf->isHidden());
+  EXPECT_FALSE(bitrate->isHidden());
+}
+
 TEST(StageParameterDialogTest,
      FrameMapRanges_DisplayedOneBasedAndStoredZeroBased) {
   (void)ensureApplication();

--- a/orc/gui/ffmpegpresetdialog.cpp
+++ b/orc/gui/ffmpegpresetdialog.cpp
@@ -107,7 +107,7 @@ FFmpegPresetDialog::FFmpegPresetDialog(const QString& project_path,
       {"mp4-av1", "AV1 (Web Delivery)",
        "Modern royalty-free codec. Better compression than H.265. Excellent "
        "for web streaming. Limited device support currently.",
-       "mp4", "av1", false, true, 24, "medium", 0},
+       "mp4", "av1", false, true, 32, "medium", 0},
       {"mp4-av1_lossless", "AV1 Lossless",
        "Mathematically lossless AV1 encoding. Best compression for lossless "
        "archival. Slow encoding but excellent results.",

--- a/orc/plugins/stages/sinks/common/av1_rate_control.h
+++ b/orc/plugins/stages/sinks/common/av1_rate_control.h
@@ -1,0 +1,38 @@
+/*
+ * File:        av1_rate_control.h
+ * Module:      orc-stage-plugin-video-sink
+ * Purpose:     Resolves AV1 encoder rate-control precedence
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#ifndef ORC_STAGE_PLUGIN_VIDEO_SINK_AV1_RATE_CONTROL_H
+#define ORC_STAGE_PLUGIN_VIDEO_SINK_AV1_RATE_CONTROL_H
+
+namespace orc {
+
+// Selects AV1 rate control. Lossless overrides a requested bitrate, which in
+// turn overrides CRF quality mode when the bitrate is non-zero.
+enum class Av1RateControl {
+  kLossless,
+  kCrfQuality,
+  kTargetBitrate,
+};
+
+// Resolves the shared Video Sink rate-control parameters for software AV1
+// encoders. This function is pure and thread-safe.
+constexpr Av1RateControl resolve_av1_rate_control(bool use_lossless_mode,
+                                                  int encoder_bitrate) {
+  if (use_lossless_mode) {
+    return Av1RateControl::kLossless;
+  }
+  if (encoder_bitrate > 0) {
+    return Av1RateControl::kTargetBitrate;
+  }
+  return Av1RateControl::kCrfQuality;
+}
+
+}  // namespace orc
+
+#endif  // ORC_STAGE_PLUGIN_VIDEO_SINK_AV1_RATE_CONTROL_H

--- a/orc/plugins/stages/sinks/common/ffmpeg_output_backend.cpp
+++ b/orc/plugins/stages/sinks/common/ffmpeg_output_backend.cpp
@@ -29,6 +29,7 @@
 #include <thread>
 
 #include "audio_pair_selection.h"
+#include "av1_rate_control.h"
 #include "componentframe.h"
 #include "subtitle_embed_policy.h"
 #include "teletext_subtitle_feed.h"
@@ -794,29 +795,42 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id,
       }
     }
   } else if (codec_id == "libsvtav1" || codec_id == "libaom-av1") {
-    // AV1 encoder settings
-    if (use_lossless_mode_) {
-      // Lossless AV1
-      if (codec_id == "libaom-av1") {
-        av_opt_set(codec_ctx_->priv_data, "cpu-used", "4", 0);
-        av_opt_set(codec_ctx_->priv_data, "crf", "0", 0);
-        av_opt_set(codec_ctx_->priv_data, "lossless", "1", 0);
-      } else {
-        // SVT-AV1 doesn't have direct lossless mode, use CRF=0
-        av_opt_set(codec_ctx_->priv_data, "crf", "0", 0);
-      }
-      ORC_LOG_DEBUG("FFmpegOutputBackend: Using AV1 lossless mode");
+    // All software AV1 candidates share the same rate-control precedence.
+    // Keep encoder-specific speed defaults separate from rate control.
+    if (codec_id == "libsvtav1") {
+      av_opt_set(codec_ctx_->priv_data, "preset", "6", 0);
     } else {
-      // Quality mode
-      if (codec_id == "libsvtav1") {
-        av_opt_set(codec_ctx_->priv_data, "preset", "6", 0);
+      av_opt_set(codec_ctx_->priv_data, "cpu-used", "4", 0);
+    }
+
+    switch (resolve_av1_rate_control(use_lossless_mode_, encoder_bitrate_)) {
+      case Av1RateControl::kLossless:
+        if (codec_id == "libaom-av1") {
+          av_opt_set(codec_ctx_->priv_data, "crf", "0", 0);
+          av_opt_set(codec_ctx_->priv_data, "lossless", "1", 0);
+        } else {
+          // SVT-AV1 represents lossless output as CRF 0.
+          av_opt_set(codec_ctx_->priv_data, "crf", "0", 0);
+        }
+        ORC_LOG_DEBUG("FFmpegOutputBackend: Using AV1 lossless mode");
+        break;
+      case Av1RateControl::kTargetBitrate:
+        codec_ctx_->bit_rate = encoder_bitrate_;
+        if (codec_id == "libsvtav1") {
+          // SVT-AV1 rate control: 1 = variable bitrate. FFmpeg passes
+          // encoder-native options through the svtav1-params dictionary.
+          av_opt_set(codec_ctx_->priv_data, "svtav1-params", "rc=1", 0);
+        }
+        ORC_LOG_DEBUG(
+            "FFmpegOutputBackend: Using AV1 target bitrate mode: {} "
+            "bps",
+            encoder_bitrate_);
+        break;
+      case Av1RateControl::kCrfQuality:
         av_opt_set_int(codec_ctx_->priv_data, "crf", encoder_crf_, 0);
-      } else {
-        av_opt_set(codec_ctx_->priv_data, "cpu-used", "4", 0);
-        av_opt_set_int(codec_ctx_->priv_data, "crf", encoder_crf_, 0);
-      }
-      ORC_LOG_DEBUG("FFmpegOutputBackend: Using AV1 CRF mode: {}",
-                    encoder_crf_);
+        ORC_LOG_DEBUG("FFmpegOutputBackend: Using AV1 CRF mode: {}",
+                      encoder_crf_);
+        break;
     }
   } else if (codec_id == "h264_vaapi" || codec_id == "hevc_vaapi") {
     // VA-API settings
@@ -850,24 +864,6 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id,
     av_opt_set_int(codec_ctx_->priv_data, "q", 60, 0);
     stream_->codecpar->codec_tag = MKTAG('h', 'v', 'c', '1');
     ORC_LOG_DEBUG("FFmpegOutputBackend: Using VideoToolbox settings");
-  } else if (codec_id == "libsvtav1") {
-    // SVT-AV1 settings
-    av_opt_set_int(codec_ctx_->priv_data, "crf", 24, 0);
-    av_opt_set_int(codec_ctx_->priv_data, "cpu-used", 6, 0);
-    av_opt_set_int(codec_ctx_->priv_data, "row-mt", 1, 0);
-    ORC_LOG_DEBUG("FFmpegOutputBackend: Using SVT-AV1 settings");
-  } else if (codec_id == "libaom-av1") {
-    // libaom-av1 settings
-    if (codec_name_ == "av1_lossless") {
-      av_opt_set_int(codec_ctx_->priv_data, "crf", 0, 0);
-      av_opt_set(codec_ctx_->priv_data, "aom-params", "lossless=1", 0);
-    } else {
-      av_opt_set_int(codec_ctx_->priv_data, "crf", 24, 0);
-    }
-    av_opt_set_int(codec_ctx_->priv_data, "cpu-used", 6, 0);
-    av_opt_set_int(codec_ctx_->priv_data, "row-mt", 1, 0);
-    av_opt_set_int(codec_ctx_->priv_data, "error-resilience", 1, 0);
-    ORC_LOG_DEBUG("FFmpegOutputBackend: Using libaom-av1 settings");
   } else if (codec_id.find("_vaapi") != std::string::npos ||
              codec_id.find("_qsv") != std::string::npos ||
              codec_id.find("_nvenc") != std::string::npos) {

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -447,27 +447,34 @@ std::vector<ParameterDescriptor> VideoSinkStage::get_parameter_descriptors(
       ParameterDescriptor{
           "encoder_crf",
           "Encoder CRF",
-          "Constant Rate Factor for quality (0-51, lower=better). Typical: "
-          "18-28. 0 = use bitrate instead",
+          "Constant Rate Factor for quality-based encoding (0-51, "
+          "lower=better).\n"
+          "AV1 compact delivery typically uses 30-35.\n"
+          "Rate-control precedence: lossless mode, non-zero target bitrate, "
+          "then CRF quality.",
           ParameterType::INT32,
           {0,
            51,
            18,
            {},
            false,
-           ParameterDependency{"ffmpeg_format", {"mp4-h264", "mkv-ffv1"}}}},
+           ParameterDependency{"ffmpeg_format",
+                               {"mp4-h264", "mkv-ffv1", "mp4-av1"}}}},
       ParameterDescriptor{
           "encoder_bitrate",
           "Encoder Bitrate",
-          "Target bitrate in bits/sec (0 = use CRF instead). Example: 10000000 "
-          "= 10 Mbps",
+          "Target bitrate in bits/sec.\n"
+          "A non-zero value takes precedence over CRF; lossless mode takes "
+          "precedence over both.\n"
+          "0 uses CRF quality. Example: 10000000 = 10 Mbps.",
           ParameterType::INT32,
           {0,
            100000000,
            0,
            {},
            false,
-           ParameterDependency{"ffmpeg_format", {"mp4-h264", "mkv-ffv1"}}}},
+           ParameterDependency{"ffmpeg_format",
+                               {"mp4-h264", "mkv-ffv1", "mp4-av1"}}}},
       ParameterDescriptor{
           "hardware_encoder",
           "Hardware Encoder",
@@ -498,7 +505,7 @@ std::vector<ParameterDescriptor> VideoSinkStage::get_parameter_descriptors(
           "use_lossless_mode",
           "Use Lossless Mode",
           "Enable mathematically lossless encoding (H.264/H.265/AV1 only, "
-          "overrides CRF)",
+          "overrides bitrate and CRF)",
           ParameterType::BOOL,
           {{},
            {},

--- a/orc/plugins/stages/sinks/video_sink/instructions.md
+++ b/orc/plugins/stages/sinks/video_sink/instructions.md
@@ -64,10 +64,10 @@ Alignment padding added to each output frame. Default: `8`.
 FFmpeg mode only. Encoder speed/quality trade-off. Values: `fast`, `medium`, `slow`, `veryslow`. Slower presets produce smaller files at the same quality level.
 
 ### encoder_crf (int)
-FFmpeg mode only. Constant Rate Factor for quality-based encoding. Range: 0–51; lower values produce higher quality and larger files. Default: `18`. Used when `encoder_bitrate` is `0`.
+FFmpeg mode only. Constant Rate Factor for quality-based encoding. Range: 0–51; lower values produce higher quality and larger files. Default: `18`. AV1 compact delivery typically uses CRF 30–35; the AV1 web-delivery preset uses 32. CRF is used only when lossless mode is off and `encoder_bitrate` is `0`.
 
 ### encoder_bitrate (int)
-FFmpeg mode only. Target bitrate in bits per second. When non-zero, overrides CRF mode. Default: `0` (use CRF).
+FFmpeg mode only. Target bitrate in bits per second. When non-zero, it overrides CRF mode. Default: `0` (use CRF). Rate-control precedence for H.264, H.265, and AV1 is lossless mode first, then a non-zero target bitrate, then CRF quality.
 
 ### hardware_encoder (string)
 FFmpeg mode only. Hardware-accelerated encoding backend. Values: `none`, `vaapi`, `nvenc`, `qsv`, `amf`, `videotoolbox`. Default: `none`.
@@ -76,7 +76,7 @@ FFmpeg mode only. Hardware-accelerated encoding backend. Values: `none`, `vaapi`
 FFmpeg mode only, `mov-prores` format. ProRes quality profile: `proxy`, `lt`, `standard`, `hq`, `4444`, `4444xq`. Default: `hq`.
 
 ### use_lossless_mode (bool)
-FFmpeg mode only. Enable mathematically lossless encoding (H.264/H.265/AV1 only, overrides CRF). Default: `false`.
+FFmpeg mode only. Enable mathematically lossless encoding (H.264/H.265/AV1 only, overrides bitrate and CRF). Default: `false`.
 
 ### apply_deinterlace (bool)
 FFmpeg mode only. Apply the bwdif deinterlacing filter for progressive web playback. One frame is produced per field, so the output frame rate doubles (50 fps for PAL, 59.94 fps for NTSC). Default: `false`.
@@ -91,7 +91,7 @@ FFmpeg mode only. Custom FFmpeg video filter chain applied before encoding, usin
 - `bwdif=mode=send_frame` — deinterlace without doubling the frame rate
 - `crop=692:554` — crop the output frame
 
-Filters may change the output dimensions and frame rate; the encoder follows the filter output automatically. Leave empty for no filtering (the default). An invalid filter string causes the export to fail with the FFmpeg error message in the trigger status.
+Filters may change the output dimensions and frame rate; the encoder follows the filter output automatically. They may improve compressibility, but do not control the encoded bitrate. Leave empty for no filtering (the default). An invalid filter string causes the export to fail with the FFmpeg error message in the trigger status.
 
 ### embed_audio (bool)
 FFmpeg mode only. Embed pipeline audio into the output file, one output audio stream per selected channel pair. Requires audio data to be present in the pipeline. Default: `false`.
@@ -142,7 +142,7 @@ Opens a preset helper dialog that lets you select common encoder configurations 
 - Raw output files can be very large; ensure sufficient disk space before triggering.
 - The `y4m` raw format adds a Y4M header to the file, making it directly readable by tools such as FFmpeg and rav1e without specifying the pixel format manually.
 - Closed caption embedding is only supported in MP4/MOV containers.
-- CRF and bitrate modes are mutually exclusive; set `encoder_bitrate` to a non-zero value to switch from CRF mode.
+- Lossless mode overrides bitrate and CRF. Otherwise, set `encoder_bitrate` to a non-zero value to switch from CRF quality mode.
 - Video filtering (`apply_deinterlace` or `video_filter`) is not supported with hardware encoders that use GPU surfaces (`vaapi`, `qsv`, `videotoolbox`); the export automatically falls back to the software encoder in that case.
 - When a video filter chain is active, interlaced coding flags are not forced on the encoder; the field structure of the filter output determines how frames are flagged. Filters like `bwdif` and `fieldmatch,decimate` produce progressive frames.
 


### PR DESCRIPTION
## Summary

Expose and honor AV1 rate control in the Video Sink.

AV1 now uses lossless mode first, then target bitrate when non-zero, then CRF quality. The AV1 web-delivery preset uses CRF 32. Stage help now documents the precedence and clarifies that filters do not control bitrate.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Validation

- Native Debug build
- GUI test label: 451 tests
- Focused AV1 and affected audio tests: 41 tests
- SDK gates: 9 tests
- StagePluginLoader: 7 tests
- MVP architecture check
- Native Release build and CLI help smoke test

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [x] Related docs were updated if needed
- [ ] Linked issue (if applicable)
