### PR TITLE
20260830 001

### DIFF
--- a/docs/gui-user-guide/dialogues/main.md
+++ b/docs/gui-user-guide/dialogues/main.md
@@ -299,6 +299,41 @@ To select multiple items, use standard multi-select gestures (depending on platf
 * Hold **Shift** or **Ctrl/Cmd** while clicking additional stages
 * Drag a selection rectangle on empty space to select a group
 
+### Keyboard Navigation
+
+The selection can be moved from the keyboard once the graph editor has focus
+(click anywhere on the canvas). This is quicker than the mouse when stepping
+back and forth between two stages to compare their previews, especially with
+**View → Show Preview on Selection** enabled.
+
+| Key | Action |
+|-----|--------|
+| **Left** / **Right** / **Up** / **Down** | Select the neighbouring stage in that direction |
+| **Tab** | Select the next stage in the order the stages were added |
+| **Shift+Tab** | Select the previous stage in that order |
+| **Ctrl+Left** / **Right** / **Up** / **Down** | Scroll the canvas without changing the selection |
+
+Cursor keys select the stage you are pointing at rather than following the
+connections:
+
+* A stage that is level with the current one in the direction pressed is always
+  preferred, so on a left-to-right pipeline **Right** walks down the chain a
+  stage at a time
+* A stage off to one side is only chosen when nothing is level — which is what
+  makes **Up** and **Down** step between parallel branches
+* Pressing a direction with nothing beyond the current stage leaves the
+  selection where it is; the canvas does not scroll away
+
+**Tab** cycles through every stage on the canvas, wrapping at the end, and is
+the reliable way to reach a stage in a layout where no direction points at it.
+With nothing selected, a cursor key selects the stage nearest the centre of the
+view and **Tab** starts at the first stage. While the graph editor has focus and
+the project has stages, **Tab** stays on the canvas rather than moving focus to
+the toolbar; click a toolbar button or use the menus to leave the canvas.
+
+The view scrolls automatically to bring a keyboard-selected stage into sight if
+it is off screen.
+
 ### Moving Stages
 
 * Click and drag a stage to reposition it
@@ -372,6 +407,8 @@ Common gestures include:
 
 * Dragging the background with the middle mouse button
 * Trackpad pan gestures
+* **Ctrl** with the cursor keys (the unmodified cursor keys move the selection
+  between stages — see [Keyboard Navigation](#keyboard-navigation))
 
 ---
 

--- a/docs/gui-user-guide/stages/sink-core-stages.md
+++ b/docs/gui-user-guide/stages/sink-core-stages.md
@@ -146,7 +146,7 @@ The stage reads the two caption bytes from each field's VBI Line 21, keeps the p
 
 **What it does**
 
-This stage writes processed frame data using the selected sample encoding, and a `.meta` SQLite sidecar. The output signal type follows the project type automatically: a composite project is written as a single `.cvbs` file and a Y/C project as a `.cvbsy`/`.cvbsc` pair (per the CVBS file format naming convention) — Y/C cannot be derived from a composite signal, so this is not a choice. The `.meta` file records the signal type and the selected `sample_encoding_preset`, and always carries `signal_state_preset = 'STANDARD_TBC_LOCKED'`. The signal state is not user-configurable — it reflects the pipeline invariant that only locked, standard-state signals appear at this point.
+This stage writes processed frame data using the selected sample encoding, and a `.meta` SQLite sidecar. The output signal type follows the project type automatically: a composite project is written as a single `.cvbs` file and a Y/C project as a `.cvbsy`/`.cvbsc` pair (per the CVBS file format naming convention) — Y/C cannot be derived from a composite signal, so this is not a choice. The `.meta` file records the signal type, the selected `sample_encoding_preset`, and a measured `signal_state_preset`. The signal state is not user-configurable: it describes the file that was actually written.
 
 Associated sidecars are written automatically when the upstream source provides them:
 
@@ -174,7 +174,7 @@ A CVBS file written by this stage can be round-tripped back through the CVBS Sou
 
 **Notes**
 
-* `signal_state_preset` in the output `.meta` is always `STANDARD_TBC_LOCKED` and cannot be overridden by the user.
+* `signal_state_preset` in the output `.meta` is measured rather than assumed, and cannot be overridden by the user. Each frame's colour-sequence phase is measured from its burst as it is written; the file is marked `STANDARD_TBC_LOCKED` only when that sequence runs unbroken through every frame written, and `STANDARD_TBC_UNLOCKED` otherwise (including when no burst could be measured at all). Frames with no measurable burst — blank leader, lead-in, black frames — are not treated as breaks: the expected phase is projected across them and re-checked on the far side. The verdict, with the output frame number of the first discontinuity, appears in the stage's completion status and in the log. Because the marker describes what was written, a pipeline that legitimately reorders or drops frames can turn a locked input into an unlocked output; run the Disc Mapper first to restore a continuous sequence.
 * Absent upstream extensions (no audio, no EFM, etc.) produce no sidecar files — this is not an error.
 
 ---

--- a/docs/gui-user-guide/stages/source-stages.md
+++ b/docs/gui-user-guide/stages/source-stages.md
@@ -87,7 +87,9 @@ Associated audio (analogue `.pcm`), EFM disc data (`.efm`), and AC3 RF symbols (
 
 This stage reads CVBS payloads from `.cvbs` files (or `.cvbsy`/`.cvbsc` pairs) and normalises them to the CVBS_U10_4FSC 10-bit domain. By default the video system, sample encoding, and signal state are read from the `.meta` SQLite sidecar; because the CVBS file format declares metadata optional, the sample encoding can also be selected manually so that sources without a sidecar can be used.
 
-Only the `STANDARD_TBC_LOCKED` signal-state preset is accepted. Files with any other signal state are rejected with a clear error before any frame data is returned. When a sample encoding is selected manually the sidecar is ignored: the signal is assumed to be TBC-locked and the frame count is measured from the file size.
+The `STANDARD_TBC_LOCKED` and `STANDARD_TBC_UNLOCKED` signal-state presets are accepted. Files in any other state are rejected with a clear error before any frame data is returned, because the stage's frame geometry assumes time-base-corrected samples at the standard 4fsc rate. When a sample encoding is selected manually the sidecar is ignored: the signal is assumed to be TBC'd and the frame count is measured from the file size.
+
+Burst lock is not required. Colour-sequence phase is measured from each frame's burst rather than read from the sidecar, so an unlocked source decodes normally; opening one shows an advisory and the source loads. `STANDARD_TBC_UNLOCKED` means the colour phase sequence is not continuous from start to end, which for a LaserDisc source usually means the player skipped or jumped during the decode. Run the Disc Mapper (right-click a Frame Map stage, then **Stage Tools > Disc Mapper**) to put the frames back into their recorded order before exporting.
 
 The following sample encodings are normalised automatically:
 

--- a/orc-tests/core/functional/contracts/multi_track_audio_roundtrip_test.cpp
+++ b/orc-tests/core/functional/contracts/multi_track_audio_roundtrip_test.cpp
@@ -218,6 +218,14 @@ void run_roundtrip(orc::VideoSystem system, size_t frame_count,
   // CVBS spec v1.4.0 metadata: PRAGMA user_version = 10.
   EXPECT_EQ(read_sqlite_user_version(base + ".meta"), 10u);
 
+  // The sink's signal_state_preset reports what it measured. These synthetic
+  // frames carry no colour burst and no observation service is installed
+  // here, so the sequence is unmeasurable and the file is written unlocked;
+  // the read-back below is what proves the source accepts that state.
+  EXPECT_NE(write_result.status_message.find("STANDARD_TBC_UNLOCKED"),
+            std::string::npos)
+      << write_result.status_message;
+
   // Equal-length 24-bit 48 kHz pair files: exactly
   // audio_pair_offset(frame_count) stereo pairs each.
   const uint64_t total_pairs =

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -186,6 +186,7 @@ orc_add_core_unit_tests(
         stages/raw_efm_sink/raw_efm_sink_stage_test.cpp
         stages/raw_efm_sink/raw_efm_sink_stage_deps_test.cpp
         stages/cvbs_sink/cvbs_sink_stage_test.cpp
+        stages/cvbs_sink/cvbs_sink_phase_sequence_test.cpp
         stages/dropout_analysis_sink/dropout_analysis_sink_stage_test.cpp
         stages/dropout_analysis_sink/dropout_analysis_sink_deps_test.cpp
         stages/dropout_analysis_sink/dropout_analysis_sink_map_contract_test.cpp

--- a/orc-tests/core/unit/preview_types/preview_frame_layout_test.cpp
+++ b/orc-tests/core/unit/preview_types/preview_frame_layout_test.cpp
@@ -207,18 +207,80 @@ TEST(PreviewFrameLayoutTest,
   }
 }
 
+// ---------------------------------------------------------------------------
+// Flat single-field views navigate by sequential field number
+// ---------------------------------------------------------------------------
+// The GUI converts a frame position into a field position when switching into
+// these views, and get_line_samples() resolves a field's frame as index / 2,
+// so output_index is the field itself - not the frame that contains it.
+
 TEST(PreviewFrameLayoutTest,
      RowToField_MapsRowsDirectly_ForSingleFieldOutputs) {
   const auto field1 = orc::map_preview_row_to_field(
       orc::PreviewOutputType::Frame_Field1,
-      orc::PreviewFrameLayout::FieldSequential, kFrameIndex, 200, kPalGeometry);
+      orc::PreviewFrameLayout::FieldSequential, kField1, 200, kPalGeometry);
   ASSERT_TRUE(field1.is_valid);
   EXPECT_EQ(field1.field_index, kField1);
   EXPECT_EQ(field1.field_line, 200);
 
-  const auto past_end = orc::map_preview_row_to_field(
+  const auto field2 = orc::map_preview_row_to_field(
       orc::PreviewOutputType::Frame_Field2,
-      orc::PreviewFrameLayout::FieldSequential, kFrameIndex, 312, kPalGeometry);
+      orc::PreviewFrameLayout::FieldSequential, kField2, 200, kPalGeometry);
+  ASSERT_TRUE(field2.is_valid);
+  EXPECT_EQ(field2.field_index, kField2);
+  EXPECT_EQ(field2.field_line, 200);
+}
+
+TEST(PreviewFrameLayoutTest,
+     RowToField_BoundsRowsByTheDisplayedFieldsHeight_ForSingleFieldOutputs) {
+  // PAL field 2 holds 312 lines, so row 312 is past its end...
+  const auto past_field2_end = orc::map_preview_row_to_field(
+      orc::PreviewOutputType::Frame_Field2,
+      orc::PreviewFrameLayout::FieldSequential, kField2, 312, kPalGeometry);
+  EXPECT_FALSE(past_field2_end.is_valid);
+
+  // ...while field 1 holds 313, so the same row is its last line.
+  const auto last_field1_line = orc::map_preview_row_to_field(
+      orc::PreviewOutputType::Frame_Field1,
+      orc::PreviewFrameLayout::FieldSequential, kField1, 312, kPalGeometry);
+  ASSERT_TRUE(last_field1_line.is_valid);
+  EXPECT_EQ(last_field1_line.field_index, kField1);
+  EXPECT_EQ(last_field1_line.field_line, 312);
+}
+
+TEST(PreviewFrameLayoutTest, FieldToRow_RoundTripsRows_ForSingleFieldOutputs) {
+  for (const uint64_t field : {kField1, kField2}) {
+    const auto row =
+        orc::map_field_to_preview_row(orc::PreviewOutputType::Frame_Field1,
+                                      orc::PreviewFrameLayout::FieldSequential,
+                                      field, field, 200, kPalGeometry);
+    ASSERT_TRUE(row.is_valid);
+    EXPECT_EQ(row.image_y, 200);
+
+    const auto back =
+        orc::map_preview_row_to_field(orc::PreviewOutputType::Frame_Field1,
+                                      orc::PreviewFrameLayout::FieldSequential,
+                                      field, row.image_y, kPalGeometry);
+    ASSERT_TRUE(back.is_valid);
+    EXPECT_EQ(back.field_index, field);
+    EXPECT_EQ(back.field_line, 200);
+  }
+}
+
+TEST(PreviewFrameLayoutTest,
+     FieldToRow_RejectsFieldsThatAreNotOnScreen_ForSingleFieldOutputs) {
+  // Only one field is displayed, so the other field of the same frame - and
+  // any field of another frame - has no row.
+  const auto other_field =
+      orc::map_field_to_preview_row(orc::PreviewOutputType::Frame_Field1,
+                                    orc::PreviewFrameLayout::FieldSequential,
+                                    kField1, kField2, 10, kPalGeometry);
+  EXPECT_FALSE(other_field.is_valid);
+
+  const auto past_end =
+      orc::map_field_to_preview_row(orc::PreviewOutputType::Frame_Field2,
+                                    orc::PreviewFrameLayout::FieldSequential,
+                                    kField2, kField2, 312, kPalGeometry);
   EXPECT_FALSE(past_end.is_valid);
 }
 

--- a/orc-tests/core/unit/stages/cvbs_sink/cvbs_sink_phase_sequence_test.cpp
+++ b/orc-tests/core/unit/stages/cvbs_sink/cvbs_sink_phase_sequence_test.cpp
@@ -1,0 +1,182 @@
+/*
+ * File:        cvbs_sink_phase_sequence_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Unit tests for the CVBS sink's colour-sequence continuity check
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include "../../../../orc/plugins/stages/cvbs_sink/cvbs_sink_phase_sequence.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+namespace orc_unit_test {
+namespace {
+
+using orc::ColourPhaseSequenceCheck;
+using orc::VideoSystem;
+
+// Feed |frames| consecutive frames of a continuous sequence starting with the
+// given first-field phase ID.
+void feed_continuous(ColourPhaseSequenceCheck& check, VideoSystem system,
+                     int32_t first_phase, int frames) {
+  const int32_t n = (system == VideoSystem::NTSC) ? 4 : 8;
+  int32_t phase = first_phase;
+  for (int i = 0; i < frames; ++i) {
+    const int32_t field2 = (phase % n) + 1;
+    check.observe(phase, field2);
+    phase = ((phase - 1 + 2) % n) + 1;
+  }
+}
+
+}  // namespace
+
+TEST(CVBSSinkPhaseSequence, ContinuousPALSequenceIsLocked) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  feed_continuous(check, VideoSystem::PAL, 1, 20);
+
+  EXPECT_TRUE(check.locked());
+  EXPECT_EQ(check.discontinuities(), 0u);
+  EXPECT_EQ(check.frames_measured(), 20u);
+  EXPECT_EQ(check.frames_seen(), 20u);
+  EXPECT_STREQ(check.signal_state_preset(), "STANDARD_TBC_LOCKED");
+}
+
+TEST(CVBSSinkPhaseSequence, ContinuousNTSCSequenceIsLocked) {
+  ColourPhaseSequenceCheck check(VideoSystem::NTSC);
+  feed_continuous(check, VideoSystem::NTSC, 1, 12);
+
+  EXPECT_TRUE(check.locked());
+  EXPECT_STREQ(check.signal_state_preset(), "STANDARD_TBC_LOCKED");
+}
+
+TEST(CVBSSinkPhaseSequence, PALMUsesTheEightFieldSequence) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL_M);
+  feed_continuous(check, VideoSystem::PAL_M, 3, 9);
+
+  EXPECT_TRUE(check.locked());
+}
+
+TEST(CVBSSinkPhaseSequence, SingleFrameHasNothingToBreak) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  check.observe(5, 6);
+
+  EXPECT_TRUE(check.locked());
+}
+
+TEST(CVBSSinkPhaseSequence, DiscontinuityMarksTheFileUnlocked) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  // Frames 0-2 continuous (1/2, 3/4, 5/6), then frame 3 jumps to 1/2 where
+  // 7/8 was expected.
+  check.observe(1, 2);
+  check.observe(3, 4);
+  check.observe(5, 6);
+  check.observe(1, 2);
+
+  EXPECT_FALSE(check.locked());
+  EXPECT_EQ(check.discontinuities(), 1u);
+  ASSERT_TRUE(check.first_discontinuity_frame().has_value());
+  EXPECT_EQ(*check.first_discontinuity_frame(), 3u);
+  EXPECT_STREQ(check.signal_state_preset(), "STANDARD_TBC_UNLOCKED");
+}
+
+TEST(CVBSSinkPhaseSequence, OneJumpCostsOneDiscontinuity) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  check.observe(1, 2);
+  check.observe(3, 4);
+  // Jump: 1/2 instead of 5/6, then continuous from there.
+  check.observe(1, 2);
+  check.observe(3, 4);
+  check.observe(5, 6);
+
+  EXPECT_EQ(check.discontinuities(), 1u);
+  EXPECT_EQ(*check.first_discontinuity_frame(), 2u);
+}
+
+TEST(CVBSSinkPhaseSequence, MismatchedFieldsWithinAFrameIsADiscontinuity) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  check.observe(1, 3);  // field 2 should be phase 2
+
+  EXPECT_FALSE(check.locked());
+  EXPECT_EQ(check.discontinuities(), 1u);
+  EXPECT_EQ(*check.first_discontinuity_frame(), 0u);
+}
+
+// Blank leader, lead-in and black frames have no burst. They still advance the
+// sequence by two fields each, so the expected phase is projected across them
+// rather than treated as a break.
+TEST(CVBSSinkPhaseSequence, UnmeasurableFramesAreProjectedAcross) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  check.observe(1, 2);
+  check.observe(-1, -1);
+  check.observe(-1, -1);
+  check.observe(7, 8);  // 1 + 2*3 fields = 7
+
+  EXPECT_TRUE(check.locked());
+  EXPECT_EQ(check.frames_seen(), 4u);
+  EXPECT_EQ(check.frames_measured(), 2u);
+}
+
+TEST(CVBSSinkPhaseSequence, ABreakAcrossAGapIsStillCaught) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  check.observe(1, 2);
+  check.observe(-1, -1);
+  check.observe(1, 2);  // expected 5/6 after a one-frame gap
+
+  EXPECT_FALSE(check.locked());
+  EXPECT_EQ(check.discontinuities(), 1u);
+  EXPECT_EQ(*check.first_discontinuity_frame(), 2u);
+}
+
+TEST(CVBSSinkPhaseSequence, NothingMeasurableIsNotLocked) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  for (int i = 0; i < 5; ++i) check.observe(-1, -1);
+
+  EXPECT_FALSE(check.locked());
+  EXPECT_EQ(check.frames_measured(), 0u);
+  EXPECT_EQ(check.discontinuities(), 0u);
+  EXPECT_STREQ(check.signal_state_preset(), "STANDARD_TBC_UNLOCKED");
+  EXPECT_NE(check.summary().find("unmeasurable"), std::string::npos);
+}
+
+TEST(CVBSSinkPhaseSequence, NoFramesAtAllIsNotLocked) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+
+  EXPECT_FALSE(check.locked());
+  EXPECT_EQ(check.frames_seen(), 0u);
+}
+
+TEST(CVBSSinkPhaseSequence, OutOfRangePhaseIdsAreTreatedAsUnmeasurable) {
+  ColourPhaseSequenceCheck check(VideoSystem::NTSC);
+  check.observe(5, 6);  // beyond the NTSC 4-field sequence
+
+  EXPECT_EQ(check.frames_measured(), 0u);
+  EXPECT_EQ(check.discontinuities(), 0u);
+}
+
+TEST(CVBSSinkPhaseSequence, UnknownSystemCannotBeVerified) {
+  ColourPhaseSequenceCheck check(VideoSystem::Unknown);
+  feed_continuous(check, VideoSystem::PAL, 1, 5);
+
+  EXPECT_FALSE(check.locked());
+  EXPECT_EQ(check.frames_seen(), 5u);
+  EXPECT_EQ(check.frames_measured(), 0u);
+  EXPECT_NE(check.summary().find("unknown video system"), std::string::npos);
+}
+
+TEST(CVBSSinkPhaseSequence, SummaryNamesTheFirstBreak) {
+  ColourPhaseSequenceCheck check(VideoSystem::PAL);
+  check.observe(1, 2);
+  check.observe(1, 2);
+
+  const std::string summary = check.summary();
+  EXPECT_NE(summary.find("output frame 1"), std::string::npos);
+  EXPECT_NE(summary.find("STANDARD_TBC_UNLOCKED"), std::string::npos);
+  EXPECT_NE(summary.find("disc mapping"), std::string::npos);
+}
+
+}  // namespace orc_unit_test

--- a/orc-tests/core/unit/stages/cvbs_source/cvbs_source_stage_test.cpp
+++ b/orc-tests/core/unit/stages/cvbs_source/cvbs_source_stage_test.cpp
@@ -511,11 +511,29 @@ TEST(CVBSSourceStageStatusTest,
 // Signal state validation
 // ===========================================================================
 
-TEST(CVBSSourceStageValidationTest, RejectsNonTBCLockedState) {
+TEST(CVBSSourceStageValidationTest, RejectsNonTBCSignalState) {
   auto deps = std::make_shared<FakeCVBSSourceStageDeps>("PAL");
-  deps->metadata_record.signal_state_preset = "FREE_RUNNING";
+  deps->metadata_record.signal_state_preset = "STANDARD_RAW";
   PALCVBSSourceStage stage(deps);
   expect_user_data_error(stage, kDefaultParams, "STANDARD_TBC_LOCKED");
+}
+
+TEST(CVBSSourceStageValidationTest, RejectsNonStandardSampleRateState) {
+  auto deps = std::make_shared<FakeCVBSSourceStageDeps>("PAL");
+  deps->metadata_record.signal_state_preset = "NONSTANDARD_TBC_LOCKED";
+  PALCVBSSourceStage stage(deps);
+  expect_user_data_error(stage, kDefaultParams, "STANDARD_TBC_LOCKED");
+}
+
+// Burst lock is not required: colour-sequence phase is measured from the burst
+// downstream, so an unlocked file (a disc skip during decode) still loads.
+TEST(CVBSSourceStageValidationTest, AcceptsTBCUnlockedState) {
+  auto deps = std::make_shared<FakeCVBSSourceStageDeps>("PAL");
+  deps->metadata_record.signal_state_preset = "STANDARD_TBC_UNLOCKED";
+  PALCVBSSourceStage stage(deps);
+  std::vector<ArtifactPtr> inputs;
+  ObservationContext obs;
+  EXPECT_NO_THROW(stage.execute(inputs, kDefaultParams, obs));
 }
 
 TEST(CVBSSourceStageValidationTest, RejectsMissingMetadata) {

--- a/orc-tests/gui/unit/CMakeLists.txt
+++ b/orc-tests/gui/unit/CMakeLists.txt
@@ -86,6 +86,7 @@ orc_add_gui_unit_tests(
         OFFSCREEN
         SOURCES
             audio_channel_pair_notice_test.cpp
+            cvbs_signal_state_notice_test.cpp
             source_join_notice_test.cpp
             field_frame_presentation_test.cpp
             frame_view_geometry_test.cpp

--- a/orc-tests/gui/unit/CMakeLists.txt
+++ b/orc-tests/gui/unit/CMakeLists.txt
@@ -93,6 +93,7 @@ orc_add_gui_unit_tests(
             framescopedialog_test.cpp
             frametimingdialog_test.cpp
             line_navigation_mapper_test.cpp
+            node_navigation_mapper_test.cpp
             logging_settings_test.cpp
             theme_manager_test.cpp
             node_type_helper_port_test.cpp
@@ -135,6 +136,7 @@ orc_add_gui_unit_tests(
         analysis_dialog_smoke_test.cpp
         project_properties_dialog_test.cpp
         dropout_frame_view_test.cpp
+        orc_graphics_view_navigation_test.cpp
         dropout_editor_dialog_test.cpp
         field_preview_crosshair_test.cpp
         preview_dialog_playback_test.cpp

--- a/orc-tests/gui/unit/cvbs_signal_state_notice_test.cpp
+++ b/orc-tests/gui/unit/cvbs_signal_state_notice_test.cpp
@@ -1,0 +1,41 @@
+/*
+ * File:        cvbs_signal_state_notice_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Tier 1 (gui-logic) tests for the CVBS "source is not
+ *              colour-phase locked" advisory helper
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "cvbs_signal_state_notice.h"
+
+#include <gtest/gtest.h>
+
+namespace orc::gui {
+namespace {
+
+TEST(CVBSSignalStateNotice, LockedSourceNeedsNoNotice) {
+  EXPECT_EQ(cvbsSignalStateNotice("STANDARD_TBC_LOCKED"), "");
+}
+
+// States the source stage refuses outright get an error from the stage; an
+// advisory here would only be confusing.
+TEST(CVBSSignalStateNotice, RejectedStatesGetNoNotice) {
+  EXPECT_EQ(cvbsSignalStateNotice("STANDARD_RAW"), "");
+  EXPECT_EQ(cvbsSignalStateNotice("NONSTANDARD_TBC_UNLOCKED"), "");
+  EXPECT_EQ(cvbsSignalStateNotice(""), "");
+}
+
+TEST(CVBSSignalStateNotice, UnlockedSourceIsExplainedAndAllowed) {
+  const std::string note = cvbsSignalStateNotice("STANDARD_TBC_UNLOCKED");
+  ASSERT_FALSE(note.empty());
+  EXPECT_NE(note.find("STANDARD_TBC_UNLOCKED"), std::string::npos);
+  // Says what it means, that the source still works, and what to do about it.
+  EXPECT_NE(note.find("skipped or jumped"), std::string::npos);
+  EXPECT_NE(note.find("load and decode normally"), std::string::npos);
+  EXPECT_NE(note.find("Disc Mapper"), std::string::npos);
+}
+
+}  // namespace
+}  // namespace orc::gui

--- a/orc-tests/gui/unit/field_frame_presentation_test.cpp
+++ b/orc-tests/gui/unit/field_frame_presentation_test.cpp
@@ -261,4 +261,35 @@ TEST(PresentationLineTest,
   EXPECT_EQ(line, 525);
 }
 
+// ---- frameFlatLineIndex() --------------------------------------------------
+// The line scope addresses lines per field; orc::make_line_label() numbers them
+// frame-flat (field 2's block follows field 1's).
+
+TEST(FrameFlatLineIndexTest, FirstFieldLinesAreUnchanged) {
+  EXPECT_EQ(frameFlatLineIndex(0, 0, orc::VideoSystem::PAL), 0u);
+  EXPECT_EQ(frameFlatLineIndex(0, 312, orc::VideoSystem::PAL), 312u);
+  // Field parity, not the frame, selects the block.
+  EXPECT_EQ(frameFlatLineIndex(4, 17, orc::VideoSystem::PAL), 17u);
+}
+
+TEST(FrameFlatLineIndexTest, SecondFieldLinesFollowTheFirstFieldBlock) {
+  // EBU Tech. 3280-E §1.1: PAL field 1 holds 313 lines.
+  EXPECT_EQ(frameFlatLineIndex(1, 0, orc::VideoSystem::PAL), 313u);
+  EXPECT_EQ(frameFlatLineIndex(1, 311, orc::VideoSystem::PAL), 624u);
+  EXPECT_EQ(frameFlatLineIndex(5, 17, orc::VideoSystem::PAL), 330u);
+}
+
+TEST(FrameFlatLineIndexTest, SecondFieldUsesTheSystemsFieldOneHeight) {
+  // SMPTE 170M-2004 §11.3: NTSC VFR field 1 holds 263 lines.
+  EXPECT_EQ(frameFlatLineIndex(1, 0, orc::VideoSystem::NTSC), 263u);
+  EXPECT_EQ(frameFlatLineIndex(1, 0, orc::VideoSystem::PAL_M), 263u);
+}
+
+TEST(FrameFlatLineIndexTest, BothFieldsOfAFrameGetDistinctIndices) {
+  // The defect this guards: without the block offset, the two interleaved
+  // lines either side of a weaved preview row report the same label.
+  EXPECT_NE(frameFlatLineIndex(2, 120, orc::VideoSystem::PAL),
+            frameFlatLineIndex(3, 120, orc::VideoSystem::PAL));
+}
+
 }  // namespace gui_unit_test

--- a/orc-tests/gui/unit/line_navigation_mapper_test.cpp
+++ b/orc-tests/gui/unit/line_navigation_mapper_test.cpp
@@ -15,42 +15,184 @@
 
 namespace gui_unit_test {
 
-TEST(LineNavigationMapperTest,
-     ComputeTargetValidStepDown_SkipsSameFieldLineAndMapsToNext) {
+// Models a weaved frame preview: even rows carry field 1 (index 2), odd rows
+// carry field 2 (index 3), and both fields show field line image_y / 2. This
+// is the row order map_preview_row_to_field() produces for a Frame_Field1_First
+// weaved frame.
+struct WeavedFrameModel {
+  int image_height = 0;
+
+  orc::FieldToImageMappingResult fieldToImage(uint64_t field_index,
+                                              int field_line, int) const {
+    if (field_index == 2) {
+      return {true, field_line * 2};
+    }
+    if (field_index == 3) {
+      return {true, field_line * 2 + 1};
+    }
+    return {false, 0};
+  }
+
+  orc::ImageToFieldMappingResult imageToField(int image_y, int) const {
+    if (image_y < 0 || image_y >= image_height) {
+      return {false, 0, 0};
+    }
+    const uint64_t field_index = (image_y % 2 == 0) ? 2 : 3;
+    return {true, field_index, image_y / 2};
+  }
+};
+
+orc::gui::LineNavigationTarget navigate(const WeavedFrameModel& model,
+                                        int direction, uint64_t field_index,
+                                        int line_number) {
+  return orc::gui::computeLineNavigationTarget(
+      {
+          .direction = direction,
+          .current_field = field_index,
+          .current_line = line_number,
+          .image_height = model.image_height,
+      },
+      [&model](uint64_t f, int l, int h) {
+        return model.fieldToImage(f, l, h);
+      },
+      [&model](int y, int h) { return model.imageToField(y, h); });
+}
+
+TEST(LineNavigationMapperTest, ComputeTargetStepsOneRow_InWeavedFrame) {
   std::vector<int> observed_image_ys;
   int observed_next_height = -1;
 
   const auto result = orc::gui::computeLineNavigationTarget(
       {
           .direction = 1,
-          .current_field = 3,
+          .current_field = 2,
           .current_line = 120,
           .image_height = 525,
       },
       [](uint64_t field_index, int field_line, int image_height) {
-        EXPECT_EQ(field_index, 3u);
+        EXPECT_EQ(field_index, 2u);
         EXPECT_EQ(field_line, 120);
         EXPECT_EQ(image_height, 525);
-        return orc::FieldToImageMappingResult{true, 241};
+        return orc::FieldToImageMappingResult{true, 240};
       },
       [&observed_image_ys, &observed_next_height](int image_y,
                                                   int image_height) {
         observed_image_ys.push_back(image_y);
         observed_next_height = image_height;
-        // Interlaced frame: row 242 is the other field on the same scan
-        // line (visually unchanged), so the mapper must step once more to
-        // row 243 to reach the next field line.
-        if (image_y == 242) {
-          return orc::ImageToFieldMappingResult{true, 4, 120};
-        }
-        return orc::ImageToFieldMappingResult{true, 4, 121};
+        return orc::ImageToFieldMappingResult{true, 3, 120};
       });
 
+  // Row 241 is the next line of the picture - the other field's line, which
+  // carries a different trace - so navigation lands on it rather than
+  // skipping over it to the next line of the same field.
   EXPECT_TRUE(result.is_valid);
-  EXPECT_EQ(result.field_index, 4u);
-  EXPECT_EQ(result.line_number, 121);
-  EXPECT_EQ(observed_image_ys, (std::vector<int>{242, 243}));
+  EXPECT_EQ(result.field_index, 3u);
+  EXPECT_EQ(result.line_number, 120);
+  EXPECT_EQ(observed_image_ys, (std::vector<int>{241}));
   EXPECT_EQ(observed_next_height, 525);
+}
+
+TEST(LineNavigationMapperTest, ComputeTargetUpDown_IsReversibleInWeavedFrame) {
+  const WeavedFrameModel model{.image_height = 526};
+
+  // Down then up must return to the starting field and line, from both fields.
+  for (const uint64_t start_field : {uint64_t{2}, uint64_t{3}}) {
+    const int start_line = 120;
+
+    const auto down = navigate(model, +1, start_field, start_line);
+    ASSERT_TRUE(down.is_valid);
+    const auto back_up =
+        navigate(model, -1, down.field_index, down.line_number);
+    ASSERT_TRUE(back_up.is_valid);
+    EXPECT_EQ(back_up.field_index, start_field);
+    EXPECT_EQ(back_up.line_number, start_line);
+
+    const auto up = navigate(model, -1, start_field, start_line);
+    ASSERT_TRUE(up.is_valid);
+    const auto back_down = navigate(model, +1, up.field_index, up.line_number);
+    ASSERT_TRUE(back_down.is_valid);
+    EXPECT_EQ(back_down.field_index, start_field);
+    EXPECT_EQ(back_down.line_number, start_line);
+  }
+}
+
+TEST(LineNavigationMapperTest, ComputeTargetWalk_ReachesEveryPreviewRow) {
+  // Every line the cross-hairs can select is one preview row, so walking the
+  // buttons from the top must visit all of them - none may be reachable only
+  // by clicking.
+  const WeavedFrameModel model{.image_height = 20};
+
+  std::vector<int> visited_rows;
+  auto current = model.imageToField(0, model.image_height);
+  ASSERT_TRUE(current.is_valid);
+  visited_rows.push_back(0);
+
+  for (int guard = 0; guard < 100; ++guard) {
+    const auto next =
+        navigate(model, +1, current.field_index, current.field_line);
+    if (!next.is_valid) {
+      break;
+    }
+    const auto row = model.fieldToImage(next.field_index, next.line_number, 0);
+    ASSERT_TRUE(row.is_valid);
+    visited_rows.push_back(row.image_y);
+    current = {true, next.field_index, next.line_number};
+  }
+
+  std::vector<int> all_rows(model.image_height);
+  for (int y = 0; y < model.image_height; ++y) {
+    all_rows[y] = y;
+  }
+  EXPECT_EQ(visited_rows, all_rows);
+}
+
+TEST(LineNavigationMapperTest,
+     ComputeTargetCrossesFieldBlockBoundary_InStackedLayout) {
+  // Field-sequential/split layout: field 1 occupies rows 0..312, field 2
+  // occupies rows 313..624. Stepping past the end of a block continues into
+  // the next one, and stepping back returns to the row it came from.
+  constexpr int kField1Lines = 313;
+  constexpr int kImageHeight = 625;
+
+  const auto field_to_image = [](uint64_t field_index, int field_line, int) {
+    if (field_index == 2) {
+      return orc::FieldToImageMappingResult{true, field_line};
+    }
+    if (field_index == 3) {
+      return orc::FieldToImageMappingResult{true, field_line + kField1Lines};
+    }
+    return orc::FieldToImageMappingResult{false, 0};
+  };
+  const auto image_to_field = [](int image_y, int) {
+    if (image_y < kField1Lines) {
+      return orc::ImageToFieldMappingResult{true, 2, image_y};
+    }
+    return orc::ImageToFieldMappingResult{true, 3, image_y - kField1Lines};
+  };
+
+  const auto down = orc::gui::computeLineNavigationTarget(
+      {
+          .direction = 1,
+          .current_field = 2,
+          .current_line = kField1Lines - 1,
+          .image_height = kImageHeight,
+      },
+      field_to_image, image_to_field);
+  ASSERT_TRUE(down.is_valid);
+  EXPECT_EQ(down.field_index, 3u);
+  EXPECT_EQ(down.line_number, 0);
+
+  const auto back_up = orc::gui::computeLineNavigationTarget(
+      {
+          .direction = -1,
+          .current_field = down.field_index,
+          .current_line = down.line_number,
+          .image_height = kImageHeight,
+      },
+      field_to_image, image_to_field);
+  ASSERT_TRUE(back_up.is_valid);
+  EXPECT_EQ(back_up.field_index, 2u);
+  EXPECT_EQ(back_up.line_number, kField1Lines - 1);
 }
 
 TEST(LineNavigationMapperTest,

--- a/orc-tests/gui/unit/node_navigation_mapper_test.cpp
+++ b/orc-tests/gui/unit/node_navigation_mapper_test.cpp
@@ -1,0 +1,166 @@
+/*
+ * File:        node_navigation_mapper_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Unit tests for DAG canvas keyboard navigation mapping
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "node_navigation_mapper.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace gui_unit_test {
+
+using orc::gui::findAdjacentNode;
+using orc::gui::findCycledNode;
+using orc::gui::findNodeNearestPoint;
+using orc::gui::NavigationDirection;
+using orc::gui::NodeBounds;
+
+namespace {
+
+// Node size the graph model reports for every stage node.
+constexpr double kNodeWidth = 140.0;
+constexpr double kNodeHeight = 80.0;
+
+NodeBounds node(std::uint64_t id, double x, double y) {
+  return NodeBounds{id, x, y, kNodeWidth, kNodeHeight};
+}
+
+// A straight left-to-right pipeline: source -> transform -> sink.
+std::vector<NodeBounds> chain() {
+  return {node(1, 0.0, 0.0), node(2, 300.0, 0.0), node(3, 600.0, 0.0)};
+}
+
+}  // namespace
+
+TEST(NodeNavigationMapperTest, MovesRightAlongChain) {
+  const auto nodes = chain();
+
+  EXPECT_EQ(findAdjacentNode(nodes, 1, NavigationDirection::Right), 2u);
+  EXPECT_EQ(findAdjacentNode(nodes, 2, NavigationDirection::Right), 3u);
+}
+
+TEST(NodeNavigationMapperTest, MovesLeftAlongChain) {
+  const auto nodes = chain();
+
+  EXPECT_EQ(findAdjacentNode(nodes, 3, NavigationDirection::Left), 2u);
+  EXPECT_EQ(findAdjacentNode(nodes, 2, NavigationDirection::Left), 1u);
+}
+
+TEST(NodeNavigationMapperTest, StopsAtTheEndOfTheChain) {
+  const auto nodes = chain();
+
+  EXPECT_FALSE(findAdjacentNode(nodes, 3, NavigationDirection::Right));
+  EXPECT_FALSE(findAdjacentNode(nodes, 1, NavigationDirection::Left));
+}
+
+TEST(NodeNavigationMapperTest, VerticalMovesPickParallelBranches) {
+  // One source feeding two branches stacked above and below it.
+  const std::vector<NodeBounds> nodes = {
+      node(1, 300.0, 0.0), node(2, 300.0, 200.0), node(3, 300.0, 400.0)};
+
+  EXPECT_EQ(findAdjacentNode(nodes, 2, NavigationDirection::Up), 1u);
+  EXPECT_EQ(findAdjacentNode(nodes, 2, NavigationDirection::Down), 3u);
+  EXPECT_FALSE(findAdjacentNode(nodes, 1, NavigationDirection::Up));
+}
+
+TEST(NodeNavigationMapperTest, AlignedNodeBeatsNearerDiagonalNode) {
+  // Node 3 is closer in a straight line, but node 2 is the one the user is
+  // pointing at when they press Right from node 1.
+  const std::vector<NodeBounds> nodes = {
+      node(1, 0.0, 0.0), node(2, 400.0, 20.0), node(3, 150.0, 400.0)};
+
+  EXPECT_EQ(findAdjacentNode(nodes, 1, NavigationDirection::Right), 2u);
+}
+
+TEST(NodeNavigationMapperTest, ConeIsUsedWhenTheBandIsEmpty) {
+  // Nothing sits level with node 1, so the off-axis node ahead is taken.
+  const std::vector<NodeBounds> nodes = {node(1, 0.0, 0.0),
+                                         node(2, 300.0, 250.0)};
+
+  EXPECT_EQ(findAdjacentNode(nodes, 1, NavigationDirection::Right), 2u);
+}
+
+TEST(NodeNavigationMapperTest, ConeExcludesNodesOutsideIt) {
+  // Node 2 is barely ahead but far off to the side: not a Right move.
+  const std::vector<NodeBounds> nodes = {node(1, 0.0, 0.0),
+                                         node(2, 20.0, 800.0)};
+
+  EXPECT_FALSE(findAdjacentNode(nodes, 1, NavigationDirection::Right));
+  EXPECT_EQ(findAdjacentNode(nodes, 1, NavigationDirection::Down), 2u);
+}
+
+TEST(NodeNavigationMapperTest, NodesLevelWithEachOtherAreNotAhead) {
+  const std::vector<NodeBounds> nodes = {node(1, 0.0, 0.0), node(2, 0.0, 0.0)};
+
+  EXPECT_FALSE(findAdjacentNode(nodes, 1, NavigationDirection::Right));
+  EXPECT_FALSE(findAdjacentNode(nodes, 1, NavigationDirection::Down));
+}
+
+TEST(NodeNavigationMapperTest, TiesBreakOnTheLowestNodeId) {
+  // Two candidates at the same distance in the band and two more in the cone.
+  const std::vector<NodeBounds> banded = {
+      node(1, 0.0, 0.0), node(3, 300.0, 0.0), node(2, 300.0, 0.0)};
+  EXPECT_EQ(findAdjacentNode(banded, 1, NavigationDirection::Right), 2u);
+
+  const std::vector<NodeBounds> coned = {
+      node(1, 0.0, 0.0), node(3, 300.0, 250.0), node(2, 300.0, -250.0)};
+  EXPECT_EQ(findAdjacentNode(coned, 1, NavigationDirection::Right), 2u);
+}
+
+TEST(NodeNavigationMapperTest, UnknownOrEmptyInputYieldsNoTarget) {
+  EXPECT_FALSE(findAdjacentNode({}, 1, NavigationDirection::Right));
+  EXPECT_FALSE(findAdjacentNode(chain(), 99, NavigationDirection::Right));
+}
+
+TEST(NodeNavigationMapperTest, NearestPointPicksTheClosestCentre) {
+  const auto nodes = chain();
+
+  // Node centres sit at x = 70, 370 and 670.
+  EXPECT_EQ(findNodeNearestPoint(nodes, 80.0, 40.0), 1u);
+  EXPECT_EQ(findNodeNearestPoint(nodes, 360.0, 500.0), 2u);
+  EXPECT_EQ(findNodeNearestPoint(nodes, 5000.0, 40.0), 3u);
+  EXPECT_FALSE(findNodeNearestPoint({}, 0.0, 0.0));
+}
+
+TEST(NodeNavigationMapperTest, NearestPointTiesBreakOnTheLowestNodeId) {
+  const std::vector<NodeBounds> nodes = {node(2, 0.0, 0.0), node(1, 0.0, 0.0)};
+
+  EXPECT_EQ(findNodeNearestPoint(nodes, 0.0, 0.0), 1u);
+}
+
+TEST(NodeNavigationMapperTest, CycleWalksNodesInIdOrderAndWraps) {
+  // Deliberately unordered, and positioned so geometry cannot be the ordering.
+  const std::vector<NodeBounds> nodes = {
+      node(7, 600.0, 0.0), node(2, 0.0, 400.0), node(5, 300.0, 100.0)};
+
+  EXPECT_EQ(findCycledNode(nodes, 2, true), 5u);
+  EXPECT_EQ(findCycledNode(nodes, 5, true), 7u);
+  EXPECT_EQ(findCycledNode(nodes, 7, true), 2u);
+
+  EXPECT_EQ(findCycledNode(nodes, 2, false), 7u);
+  EXPECT_EQ(findCycledNode(nodes, 7, false), 5u);
+}
+
+TEST(NodeNavigationMapperTest, CycleWithoutAnAnchorStartsAtAnEnd) {
+  const auto nodes = chain();
+
+  EXPECT_EQ(findCycledNode(nodes, std::nullopt, true), 1u);
+  EXPECT_EQ(findCycledNode(nodes, std::nullopt, false), 3u);
+
+  // An anchor that is no longer on the canvas behaves the same way.
+  EXPECT_EQ(findCycledNode(nodes, 99, true), 1u);
+  EXPECT_EQ(findCycledNode(nodes, 99, false), 3u);
+}
+
+TEST(NodeNavigationMapperTest, CycleOverAnEmptyCanvasYieldsNoTarget) {
+  EXPECT_FALSE(findCycledNode({}, std::nullopt, true));
+  EXPECT_FALSE(findCycledNode({}, 1, false));
+}
+
+}  // namespace gui_unit_test

--- a/orc-tests/gui/unit/orc_graphics_view_navigation_test.cpp
+++ b/orc-tests/gui/unit/orc_graphics_view_navigation_test.cpp
@@ -1,0 +1,239 @@
+/*
+ * File:        orc_graphics_view_navigation_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Keyboard node navigation tests for the DAG canvas view
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QScrollBar>
+#include <QTest>
+#include <QtNodes/Definitions>
+#include <memory>
+
+#include "mocks/mock_project_presenter.h"
+#include "orcgraphicsscene.h"
+#include "orcgraphicsview.h"
+#include "orcgraphmodel.h"
+
+namespace gui_unit_test {
+
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace {
+
+// Requires QApplication. Run under the "gui-widget" CTest label.
+QApplication& ensureApplication() {
+  if (auto* existing_app =
+          qobject_cast<QApplication*>(QCoreApplication::instance())) {
+    return *existing_app;
+  }
+
+  static int argc = 3;
+  static char app_name[] = "orc-gui-view-navigation-test";
+  static char platform_opt[] = "-platform";
+  static char platform_val[] = "offscreen";
+  static char* argv[] = {app_name, platform_opt, platform_val, nullptr};
+  static QApplication* app = [] {
+    auto* created_app = new QApplication(argc, argv);
+    created_app->setQuitOnLastWindowClosed(false);
+    return created_app;
+  }();
+  return *app;
+}
+
+orc::presenters::NodeInfo makeNodeInfo(int32_t id, const std::string& stage,
+                                       const std::string& label, double x,
+                                       double y) {
+  return orc::presenters::NodeInfo{
+      orc::NodeID(id), stage, label, x, y, true, true, "", ""};
+}
+
+// A source, a transform to its right, and a second transform below the first,
+// so both horizontal and vertical moves have somewhere to go. QtNodes assigns
+// node ids 0, 1 and 2 in the order the presenter reports them.
+struct CanvasFixture {
+  NiceMock<orc::presenters::test::MockProjectPresenter> presenter;
+  std::unique_ptr<OrcGraphModel> model;
+  std::unique_ptr<OrcGraphicsScene> scene;
+  std::unique_ptr<OrcGraphicsView> view;
+
+  CanvasFixture() {
+    const auto source = makeNodeInfo(10, "tbc_source", "Source", 0.0, 0.0);
+    const auto right = makeNodeInfo(20, "dropout_correct", "Right", 300.0, 0.0);
+    const auto below =
+        makeNodeInfo(30, "dropout_correct", "Below", 300.0, 300.0);
+
+    ON_CALL(presenter, getNodes())
+        .WillByDefault(Return(
+            std::vector<orc::presenters::NodeInfo>{source, right, below}));
+    ON_CALL(presenter, getEdges())
+        .WillByDefault(Return(std::vector<orc::presenters::EdgeInfo>{}));
+    ON_CALL(presenter, getNodeInfo(orc::NodeID(10)))
+        .WillByDefault(Return(source));
+    ON_CALL(presenter, getNodeInfo(orc::NodeID(20)))
+        .WillByDefault(Return(right));
+    ON_CALL(presenter, getNodeInfo(orc::NodeID(30)))
+        .WillByDefault(Return(below));
+
+    model = std::make_unique<OrcGraphModel>(presenter);
+    scene = std::make_unique<OrcGraphicsScene>(*model);
+    view = std::make_unique<OrcGraphicsView>();
+    view->setScene(scene.get());
+    view->resize(800, 600);
+    view->show();
+    QCoreApplication::processEvents();
+  }
+
+  ~CanvasFixture() {
+    view->setScene(nullptr);
+    view.reset();
+    scene.reset();
+    model.reset();
+  }
+
+  QtNodes::NodeId selectedNode() const { return scene->lastSelectedNodeId(); }
+};
+
+constexpr QtNodes::NodeId kSourceNode = 0;
+constexpr QtNodes::NodeId kRightNode = 1;
+constexpr QtNodes::NodeId kBelowNode = 2;
+
+}  // namespace
+
+TEST(OrcGraphicsViewNavigationTest, CursorKeysMoveTheSelectionBetweenNodes) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  canvas.scene->selectNode(kSourceNode);
+  ASSERT_EQ(canvas.selectedNode(), kSourceNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Right);
+  EXPECT_EQ(canvas.selectedNode(), kRightNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Down);
+  EXPECT_EQ(canvas.selectedNode(), kBelowNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Up);
+  EXPECT_EQ(canvas.selectedNode(), kRightNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Left);
+  EXPECT_EQ(canvas.selectedNode(), kSourceNode);
+}
+
+TEST(OrcGraphicsViewNavigationTest, CursorKeyWithNoNeighbourKeepsTheSelection) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  canvas.scene->selectNode(kSourceNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Left);
+  EXPECT_EQ(canvas.selectedNode(), kSourceNode);
+}
+
+TEST(OrcGraphicsViewNavigationTest, CursorKeyWithNoSelectionPicksANode) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  ASSERT_EQ(canvas.selectedNode(), QtNodes::InvalidNodeId);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Right);
+  EXPECT_NE(canvas.selectedNode(), QtNodes::InvalidNodeId);
+}
+
+TEST(OrcGraphicsViewNavigationTest, ControlCursorKeyLeavesTheSelectionAlone) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  canvas.scene->selectNode(kSourceNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Right, Qt::ControlModifier);
+  EXPECT_EQ(canvas.selectedNode(), kSourceNode);
+}
+
+TEST(OrcGraphicsViewNavigationTest, TabCyclesThroughEveryNodeAndWraps) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  canvas.scene->selectNode(kSourceNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Tab);
+  EXPECT_EQ(canvas.selectedNode(), kRightNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Tab);
+  EXPECT_EQ(canvas.selectedNode(), kBelowNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Tab);
+  EXPECT_EQ(canvas.selectedNode(), kSourceNode);
+}
+
+TEST(OrcGraphicsViewNavigationTest, ShiftTabCyclesBackwards) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  canvas.scene->selectNode(kSourceNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Tab, Qt::ShiftModifier);
+  EXPECT_EQ(canvas.selectedNode(), kBelowNode);
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Tab, Qt::ShiftModifier);
+  EXPECT_EQ(canvas.selectedNode(), kRightNode);
+}
+
+// A node that is already fully on screen must not move the canvas: enforcing a
+// reveal margin unconditionally scrolled the whole DAG whenever the selection
+// landed near a viewport edge, which looked like the cursor key had fallen
+// through to the canvas panning underneath.
+TEST(OrcGraphicsViewNavigationTest,
+     SelectingAVisibleNodeDoesNotScrollTheCanvas) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  // Mirror MainWindow::positionViewToTopLeft(): the top-left node sits 20px
+  // in from the corner of the viewport, well inside any reveal margin.
+  canvas.scene->setSceneRect(-2000.0, -2000.0, 4000.0, 4000.0);
+  const QRectF viewport_rect = canvas.view->viewport()->rect();
+  canvas.view->centerOn(QPointF(viewport_rect.width() / 2 - 20.0,
+                                viewport_rect.height() / 2 - 20.0));
+  canvas.scene->selectNode(kSourceNode);
+  QCoreApplication::processEvents();
+
+  const int horizontal = canvas.view->horizontalScrollBar()->value();
+  const int vertical = canvas.view->verticalScrollBar()->value();
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Right);
+  ASSERT_EQ(canvas.selectedNode(), kRightNode);
+
+  EXPECT_EQ(canvas.view->horizontalScrollBar()->value(), horizontal);
+  EXPECT_EQ(canvas.view->verticalScrollBar()->value(), vertical);
+}
+
+TEST(OrcGraphicsViewNavigationTest, SelectingAnOffscreenNodeScrollsItIntoView) {
+  (void)ensureApplication();
+  CanvasFixture canvas;
+
+  canvas.scene->setSceneRect(-2000.0, -2000.0, 4000.0, 4000.0);
+  canvas.view->resize(260, 200);
+  QCoreApplication::processEvents();
+
+  // Park the view on the source node so the node to its right is off screen.
+  canvas.view->centerOn(QPointF(70.0, 40.0));
+  QCoreApplication::processEvents();
+  canvas.scene->selectNode(kSourceNode);
+
+  const int horizontal = canvas.view->horizontalScrollBar()->value();
+
+  QTest::keyClick(canvas.view.get(), Qt::Key_Right);
+  ASSERT_EQ(canvas.selectedNode(), kRightNode);
+
+  EXPECT_GT(canvas.view->horizontalScrollBar()->value(), horizontal);
+}
+
+}  // namespace gui_unit_test

--- a/orc/core/preview_frame_layout.cpp
+++ b/orc/core/preview_frame_layout.cpp
@@ -54,24 +54,20 @@ ImageToFieldMappingResult map_preview_row_to_field(
   const size_t f1_lines = geometry.field1_lines;
   const size_t f2_lines = geometry.field2_lines;
 
-  if (output_type == PreviewOutputType::Frame_Field1) {
-    // Flat single-field display: image_y maps directly to line within field1
-    if (image_y < 0 || static_cast<size_t>(image_y) >= f1_lines) {
+  if (output_type == PreviewOutputType::Frame_Field1 ||
+      output_type == PreviewOutputType::Frame_Field2) {
+    // Flat single-field display: image_y maps directly to a line of the one
+    // field on screen. These views navigate by sequential field number rather
+    // than by frame - the GUI converts a frame position to a field position
+    // when switching into them, and the line-sample reader resolves the frame
+    // as index / 2 - so output_index already identifies the field, and its
+    // parity selects which of the two field heights bounds the view.
+    const size_t field_lines = (output_index % 2 == 0) ? f1_lines : f2_lines;
+    if (image_y < 0 || static_cast<size_t>(image_y) >= field_lines) {
       return result;
     }
     result.is_valid = true;
-    result.field_index = output_index * 2;  // Sequential field1 index
-    result.field_line = image_y;
-    return result;
-  }
-
-  if (output_type == PreviewOutputType::Frame_Field2) {
-    // Flat single-field display: image_y maps directly to line within field2
-    if (image_y < 0 || static_cast<size_t>(image_y) >= f2_lines) {
-      return result;
-    }
-    result.is_valid = true;
-    result.field_index = output_index * 2 + 1;  // Sequential field2 index
+    result.field_index = output_index;
     result.field_line = image_y;
     return result;
   }
@@ -148,7 +144,16 @@ FieldToImageMappingResult map_field_to_preview_row(
 
   if (output_type == PreviewOutputType::Frame_Field1 ||
       output_type == PreviewOutputType::Frame_Field2) {
-    // Flat single-field view: field_line is the image_y directly
+    // Flat single-field view: output_index is the sequential field number of
+    // the only field on screen, so any other field has no row to map to.
+    if (field_index != output_index) {
+      return result;
+    }
+    const size_t field_lines =
+        (output_index % 2 == 0) ? geometry.field1_lines : geometry.field2_lines;
+    if (field_line < 0 || static_cast<size_t>(field_line) >= field_lines) {
+      return result;
+    }
     result.is_valid = true;
     result.image_y = field_line;
     return result;

--- a/orc/core/preview_renderer.cpp
+++ b/orc/core/preview_renderer.cpp
@@ -862,6 +862,21 @@ FrameLineNavigationResult PreviewRenderer::navigate_frame_line(
   return result;
 }
 
+namespace {
+
+// Field geometry is looked up per frame, but the flat single-field views
+// navigate by sequential field number rather than by frame.
+uint64_t frame_index_for_output(PreviewOutputType output_type,
+                                uint64_t output_index) {
+  if (output_type == PreviewOutputType::Frame_Field1 ||
+      output_type == PreviewOutputType::Frame_Field2) {
+    return output_index / 2;
+  }
+  return output_index;
+}
+
+}  // namespace
+
 ImageToFieldMappingResult PreviewRenderer::map_image_to_field(
     const NodeID& node_id, PreviewOutputType output_type, uint64_t output_index,
     int image_y, int image_height, const std::string& option_id) const {
@@ -871,7 +886,8 @@ ImageToFieldMappingResult PreviewRenderer::map_image_to_field(
       node_id.to_string(), static_cast<int>(output_type), output_index, image_y,
       image_height, option_id);
 
-  auto geometry = get_preview_field_geometry(node_id, output_index);
+  auto geometry = get_preview_field_geometry(
+      node_id, frame_index_for_output(output_type, output_index));
   if (!geometry) {
     ORC_LOG_DEBUG(
         "map_image_to_field: no representation available for node='{}'",
@@ -898,7 +914,8 @@ FieldToImageMappingResult PreviewRenderer::map_field_to_image(
       node_id.to_string(), static_cast<int>(output_type), output_index,
       field_index, field_line, image_height, option_id);
 
-  auto geometry = get_preview_field_geometry(node_id, output_index);
+  auto geometry = get_preview_field_geometry(
+      node_id, frame_index_for_output(output_type, output_index));
   if (!geometry) {
     ORC_LOG_DEBUG(
         "map_field_to_image: no representation available for node='{}'",

--- a/orc/gui/CMakeLists.txt
+++ b/orc/gui/CMakeLists.txt
@@ -86,6 +86,8 @@ set(ORC_GUI_LIB_SOURCES
     framescopedialog.h
     line_navigation_mapper.cpp
     line_navigation_mapper.h
+    node_navigation_mapper.cpp
+    node_navigation_mapper.h
     stageparameterdialog.cpp
     stageparameterdialog.h
     projectpropertiesdialog.cpp

--- a/orc/gui/cvbs_signal_state_notice.h
+++ b/orc/gui/cvbs_signal_state_notice.h
@@ -1,0 +1,47 @@
+/*
+ * File:        cvbs_signal_state_notice.h
+ * Module:      orc-gui
+ * Purpose:     Pure helper that explains a CVBS source's signal state to the
+ *              user when it is not burst-locked (Tier 1 / gui-logic testable)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <string>
+
+namespace orc::gui {
+
+// Note shown when a CVBS source is opened whose .meta declares a signal state
+// that is not burst-locked. Empty for a locked source, and for a state the
+// source stage would refuse outright — those get an error from the stage, not
+// an advisory here.
+//
+// Nothing is wrong with the file: decode-orc measures colour-sequence phase
+// from the burst of each frame rather than trusting the sidecar, so an
+// unlocked source decodes normally. What the marker says is that the phase
+// sequence is not continuous end to end, which on a LaserDisc means the player
+// skipped or jumped during the decode. The Disc Mapper puts the frames back
+// into their recorded order, which is what restores the sequence, so it is
+// worth running before exporting.
+inline std::string cvbsSignalStateNotice(const std::string& signal_state) {
+  if (signal_state != "STANDARD_TBC_UNLOCKED") {
+    return {};
+  }
+  return "This CVBS source is marked STANDARD_TBC_UNLOCKED, meaning its "
+         "colour phase sequence is not continuous from start to end. That "
+         "normally means the player skipped or jumped while the disc was "
+         "being decoded.\n\n"
+         "The source will load and decode normally: decode-orc measures the "
+         "colour phase of every frame from its burst rather than relying on "
+         "this marker.\n\n"
+         "Before exporting, it is worth running the Disc Mapper to put the "
+         "frames back into their recorded order: add a Frame Map stage, then "
+         "right-click it and choose Stage Tools > Disc Mapper. A CVBS file "
+         "exported from decode-orc is marked locked or unlocked according to "
+         "the phase sequence actually measured in the frames it writes.";
+}
+
+}  // namespace orc::gui

--- a/orc/gui/docs/main_window.md
+++ b/orc/gui/docs/main_window.md
@@ -103,6 +103,25 @@ selection rectangle and select multiple nodes at once. If **Show Preview on
 Selection** is enabled, selecting a preview-capable node will automatically
 update the Preview Window to show that node's output.
 
+### Keyboard Navigation
+
+With the canvas focused, the selection can be moved from the keyboard, which is
+quicker than the mouse when stepping back and forth between two stages to
+compare their previews.
+
+| Key | Action |
+|-----|--------|
+| Left / Right / Up / Down | Move the selection to the neighbouring node in that direction. With nothing selected, the node nearest the centre of the view is selected. |
+| Tab | Select the next node in the order the stages were added, wrapping at the end. |
+| Shift+Tab | Select the previous node in that order. |
+| Ctrl+Left / Right / Up / Down | Scroll the canvas, leaving the selection where it is. |
+| Delete / Backspace | Delete the selected node or connection. |
+
+Cursor keys pick the node you are pointing at rather than following the
+connections: a node level with the current one in the direction pressed always
+wins, and a node off to one side is only chosen when nothing is level. The view
+scrolls to the newly selected node if it is off screen.
+
 ### Moving and Arranging Nodes
 
 Drag a node to reposition it on the canvas. Use **Arrange DAG to Grid**

--- a/orc/gui/field_frame_presentation.cpp
+++ b/orc/gui/field_frame_presentation.cpp
@@ -9,6 +9,8 @@
 
 #include "field_frame_presentation.h"
 
+#include <orc/stage/cvbs_signal_constants.h>
+
 #include <algorithm>
 #include <cstddef>
 
@@ -104,6 +106,13 @@ QString formatFrameViewWithInternal(uint64_t field_id, int field_line_index,
                                      // 1-312 or 313-625)
       .arg(field_id)                 // Internal fieldID (0-indexed)
       .arg(field_line_index);        // Internal fieldLineIndex (0-indexed)
+}
+
+size_t frameFlatLineIndex(uint64_t field_id, int field_line_index,
+                          orc::VideoSystem system) {
+  const size_t line = static_cast<size_t>(std::max(0, field_line_index));
+  const bool is_first_field = (field_id % 2) == 0;
+  return is_first_field ? line : orc::field1_lines(system) + line;
 }
 
 QString formatFrameFieldRange(uint64_t frame_index) {

--- a/orc/gui/field_frame_presentation.h
+++ b/orc/gui/field_frame_presentation.h
@@ -10,7 +10,10 @@
 #ifndef FIELD_FRAME_PRESENTATION_H
 #define FIELD_FRAME_PRESENTATION_H
 
+#include <orc/stage/common_types.h>
+
 #include <QString>
+#include <cstddef>
 #include <cstdint>
 
 namespace orc::gui {
@@ -185,6 +188,31 @@ int getInterlacedFrameLine(uint64_t field_id, int field_line_index,
  */
 QString formatFrameViewWithInternal(uint64_t field_id, int field_line_index,
                                     bool is_pal);
+
+/**
+ * @brief Convert a field-relative line to its frame-flat index
+ *
+ * The line scope addresses lines as (field ID, 0-based line within that
+ * field), but orc::make_line_label() - and the frame-flat convention it
+ * documents - numbers a frame's lines as one block per field: field 1 occupies
+ * indices 0..field1_lines-1 and field 2 follows it.
+ *
+ * Without this conversion both fields report the same label, so the two
+ * interleaved lines either side of a frame row are indistinguishable.
+ *
+ * @param field_id 0-indexed internal field ID (its parity selects the field)
+ * @param field_line_index 0-indexed line within the field
+ * @param system Video system, which fixes the field 1 line count
+ * @return 0-based frame-flat line index
+ *
+ * Example (PAL):
+ *   fieldID 0, fieldLineIndex 0 → 0
+ *   fieldID 1, fieldLineIndex 0 → 313
+ *   fieldID 2, fieldLineIndex 5 → 5
+ *   fieldID 3, fieldLineIndex 5 → 318
+ */
+size_t frameFlatLineIndex(uint64_t field_id, int field_line_index,
+                          orc::VideoSystem system);
 
 /**
  * @brief Format field range for a frame (for VBI dialog showing both fields)

--- a/orc/gui/line_navigation_mapper.cpp
+++ b/orc/gui/line_navigation_mapper.cpp
@@ -38,6 +38,19 @@ LineNavigationTarget computeLineNavigationTarget(
   const int current_image_y =
       std::clamp(current_image_pos.image_y, 0, request.image_height - 1);
 
+  // Navigation moves by exactly one preview row. Every line the user can
+  // select is one row of the preview - clicking the cross-hairs resolves the
+  // clicked row through the same mapping - so a single-row step is what makes
+  // the whole picture reachable from the buttons. It is also its own inverse:
+  // stepping down then up returns to the row that was showing, which skipping
+  // rows does not (in a weaved frame the two fields sit on opposite sides of
+  // the current row, so a skip is not symmetric).
+  //
+  // In a weaved frame preview consecutive rows alternate between the two
+  // fields, so the field index changes on every press while the field-relative
+  // line number only advances on every second press. That is the frame's real
+  // line order, and the scope's line label reports the frame-flat position, so
+  // each press is a visibly different line.
   const int step = (request.direction > 0) ? 1 : -1;
   const int new_image_y = current_image_y + step;
   if (new_image_y < 0 || new_image_y >= request.image_height) {
@@ -48,28 +61,6 @@ LineNavigationTarget computeLineNavigationTarget(
       map_image_to_field(new_image_y, request.image_height);
   if (!next_mapping.is_valid) {
     return target;
-  }
-
-  // In interlaced frame modes two consecutive image rows both map to the same
-  // field_line (one per field). If stepping one row lands on the same field
-  // line as the starting position we are at the adjacent field for the same
-  // scan line — visually unchanged. Step one more row so that a single button
-  // press always moves to a different line.
-  if (next_mapping.field_line == request.current_line) {
-    const int retry_y = new_image_y + step;
-    if (retry_y >= 0 && retry_y < request.image_height) {
-      const auto retry_mapping =
-          map_image_to_field(retry_y, request.image_height);
-      if (retry_mapping.is_valid &&
-          retry_mapping.field_line != request.current_line) {
-        target.is_valid = true;
-        target.field_index = retry_mapping.field_index;
-        target.line_number = retry_mapping.field_line;
-        return target;
-      }
-    }
-    // If the retry also gives the same line (boundary or degenerate mapping),
-    // fall through and return the single-step result anyway.
   }
 
   target.is_valid = true;

--- a/orc/gui/mainwindow.cpp
+++ b/orc/gui/mainwindow.cpp
@@ -16,6 +16,7 @@
 #include "burstlevelanalysisdialog.h"
 #include "cataloguedialog.h"
 #include "closedcaptiondialog.h"
+#include "cvbs_signal_state_notice.h"
 #include "dropout_editor_dialog.h"
 #include "dropoutanalysisdialog.h"
 #include "ffmpegpresetdialog.h"
@@ -1900,6 +1901,20 @@ void MainWindow::quickProject(const QString& filename) {
     }
     video_format = cvbs_params_opt->system;
     is_ld_decode = (cvbs_params_opt->decoder == "ld-decode");
+
+    // A source that is not burst-locked loads and decodes normally; say what
+    // the marker means and point at the Disc Mapper, then carry on.
+    const auto signal_state =
+        orc::presenters::ProjectPresenter::readCVBSSignalState(
+            meta_path.toStdString());
+    if (signal_state) {
+      const std::string notice = orc::gui::cvbsSignalStateNotice(*signal_state);
+      if (!notice.empty()) {
+        ORC_LOG_INFO("CVBS source signal state is '{}'", *signal_state);
+        QMessageBox::information(this, "Source Is Not Colour-Phase Locked",
+                                 QString::fromStdString(notice));
+      }
+    }
     {
       const std::string& decoder = cvbs_params_opt->decoder;
       ORC_LOG_INFO("CVBS source metadata reports decoder '{}': ld-decode = {}",

--- a/orc/gui/node_navigation_mapper.cpp
+++ b/orc/gui/node_navigation_mapper.cpp
@@ -1,0 +1,197 @@
+/*
+ * File:        node_navigation_mapper.cpp
+ * Module:      orc-gui
+ * Purpose:     Keyboard navigation mapping between DAG nodes on the canvas
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "node_navigation_mapper.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace orc::gui {
+
+namespace {
+
+// Nodes closer together than this along the axis of travel count as level with
+// each other rather than ahead, so a cursor key never "moves" sideways to a
+// node that is really beside the current one.
+constexpr double kAheadEpsilon = 1.0;
+
+// Weight applied to off-axis distance in the tier 2 cone score. Anything above
+// 1.0 makes an aligned node win over an equally distant diagonal one; 2.0 is
+// firm enough that the cone only ever picks a diagonal when the band is empty.
+constexpr double kAcrossWeight = 2.0;
+
+struct Centre {
+  double x{0.0};
+  double y{0.0};
+};
+
+Centre centreOf(const NodeBounds& node) {
+  return Centre{node.x + node.width / 2.0, node.y + node.height / 2.0};
+}
+
+bool isHorizontal(NavigationDirection direction) {
+  return direction == NavigationDirection::Left ||
+         direction == NavigationDirection::Right;
+}
+
+// Signed distance from |from| to |to| along the direction of travel; positive
+// means |to| lies ahead.
+double alongDistance(const Centre& from, const Centre& to,
+                     NavigationDirection direction) {
+  switch (direction) {
+    case NavigationDirection::Left:
+      return from.x - to.x;
+    case NavigationDirection::Right:
+      return to.x - from.x;
+    case NavigationDirection::Up:
+      return from.y - to.y;
+    case NavigationDirection::Down:
+      return to.y - from.y;
+  }
+  return 0.0;
+}
+
+double acrossDistance(const Centre& from, const Centre& to,
+                      NavigationDirection direction) {
+  return isHorizontal(direction) ? std::abs(to.y - from.y)
+                                 : std::abs(to.x - from.x);
+}
+
+// True when the two nodes overlap on the axis perpendicular to the direction
+// of travel, i.e. the candidate sits in the current node's band.
+bool overlapsBand(const NodeBounds& current, const NodeBounds& candidate,
+                  NavigationDirection direction) {
+  if (isHorizontal(direction)) {
+    return candidate.y < current.y + current.height &&
+           current.y < candidate.y + candidate.height;
+  }
+  return candidate.x < current.x + current.width &&
+         current.x < candidate.x + candidate.width;
+}
+
+const NodeBounds* findNode(const std::vector<NodeBounds>& nodes,
+                           std::uint64_t id) {
+  const auto it =
+      std::find_if(nodes.begin(), nodes.end(),
+                   [id](const NodeBounds& node) { return node.id == id; });
+  return it == nodes.end() ? nullptr : &(*it);
+}
+
+}  // namespace
+
+std::optional<std::uint64_t> findAdjacentNode(
+    const std::vector<NodeBounds>& nodes, std::uint64_t current_id,
+    NavigationDirection direction) {
+  const NodeBounds* current = findNode(nodes, current_id);
+  if (!current) {
+    return std::nullopt;
+  }
+
+  const Centre current_centre = centreOf(*current);
+
+  std::optional<std::uint64_t> banded_best;
+  double banded_best_score = std::numeric_limits<double>::max();
+  std::optional<std::uint64_t> cone_best;
+  double cone_best_score = std::numeric_limits<double>::max();
+
+  for (const NodeBounds& candidate : nodes) {
+    if (candidate.id == current_id) {
+      continue;
+    }
+
+    const Centre candidate_centre = centreOf(candidate);
+    const double along =
+        alongDistance(current_centre, candidate_centre, direction);
+    if (along <= kAheadEpsilon) {
+      continue;  // Level with, or behind, the current node
+    }
+
+    const double across =
+        acrossDistance(current_centre, candidate_centre, direction);
+
+    if (overlapsBand(*current, candidate, direction)) {
+      // Tier 1: distance along the axis alone, so the nearest node in the
+      // band wins regardless of how it is offset within that band.
+      if (along < banded_best_score ||
+          (along == banded_best_score && banded_best &&
+           candidate.id < *banded_best)) {
+        banded_best_score = along;
+        banded_best = candidate.id;
+      }
+      continue;
+    }
+
+    // Tier 2: a 90 degree cone centred on the direction of travel.
+    if (across > along) {
+      continue;
+    }
+
+    const double score = along + kAcrossWeight * across;
+    if (score < cone_best_score ||
+        (score == cone_best_score && cone_best && candidate.id < *cone_best)) {
+      cone_best_score = score;
+      cone_best = candidate.id;
+    }
+  }
+
+  return banded_best ? banded_best : cone_best;
+}
+
+std::optional<std::uint64_t> findNodeNearestPoint(
+    const std::vector<NodeBounds>& nodes, double x, double y) {
+  std::optional<std::uint64_t> best;
+  double best_distance = std::numeric_limits<double>::max();
+
+  for (const NodeBounds& node : nodes) {
+    const Centre centre = centreOf(node);
+    const double dx = centre.x - x;
+    const double dy = centre.y - y;
+    const double distance = (dx * dx) + (dy * dy);
+
+    if (distance < best_distance ||
+        (distance == best_distance && best && node.id < *best)) {
+      best_distance = distance;
+      best = node.id;
+    }
+  }
+
+  return best;
+}
+
+std::optional<std::uint64_t> findCycledNode(
+    const std::vector<NodeBounds>& nodes,
+    std::optional<std::uint64_t> current_id, bool forward) {
+  if (nodes.empty()) {
+    return std::nullopt;
+  }
+
+  std::vector<std::uint64_t> ids;
+  ids.reserve(nodes.size());
+  for (const NodeBounds& node : nodes) {
+    ids.push_back(node.id);
+  }
+  std::sort(ids.begin(), ids.end());
+
+  if (!current_id) {
+    return forward ? ids.front() : ids.back();
+  }
+
+  const auto it = std::find(ids.begin(), ids.end(), *current_id);
+  if (it == ids.end()) {
+    return forward ? ids.front() : ids.back();
+  }
+
+  const auto index = static_cast<std::size_t>(std::distance(ids.begin(), it));
+  const std::size_t next = forward ? (index + 1) % ids.size()
+                                   : (index + ids.size() - 1) % ids.size();
+  return ids[next];
+}
+
+}  // namespace orc::gui

--- a/orc/gui/node_navigation_mapper.h
+++ b/orc/gui/node_navigation_mapper.h
@@ -1,0 +1,91 @@
+/*
+ * File:        node_navigation_mapper.h
+ * Module:      orc-gui
+ * Purpose:     Keyboard navigation mapping between DAG nodes on the canvas
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#ifndef NODE_NAVIGATION_MAPPER_H
+#define NODE_NAVIGATION_MAPPER_H
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace orc::gui {
+
+/// Direction of a cursor-key move across the DAG canvas.
+enum class NavigationDirection { Left, Right, Up, Down };
+
+/// On-screen extent of one node, in scene coordinates.
+struct NodeBounds {
+  std::uint64_t id{0};
+  double x{0.0};
+  double y{0.0};
+  double width{0.0};
+  double height{0.0};
+};
+
+/**
+ * @brief Find the node a cursor-key press should move the selection to.
+ *
+ * Selection is geometric, not topological: the node picked is the one a user
+ * would point at, which on a left-to-right pipeline is also the next stage in
+ * the chain. Two tiers are tried in turn:
+ *
+ * 1. Nodes ahead on the pressed axis whose extent overlaps the current node's
+ *    band on the cross axis; the smallest edge gap wins. Walking a chain
+ *    rightwards therefore never diverts to a branch that merely happens to be
+ *    closer diagonally.
+ * 2. If the band is empty, nodes ahead within a 90-degree cone, scored by
+ *    distance along the axis plus twice the distance across it, so a slightly
+ *    off-axis node beats a badly off-axis one at the same range.
+ *
+ * Ties are broken by the lowest node id so the result is deterministic for
+ * nodes that sit on top of each other.
+ *
+ * @param nodes All nodes on the canvas (may include |current_id|)
+ * @param current_id Node the selection is moving from
+ * @param direction Direction of the move
+ * @return Target node id, or nullopt if there is nothing in that direction
+ */
+std::optional<std::uint64_t> findAdjacentNode(
+    const std::vector<NodeBounds>& nodes, std::uint64_t current_id,
+    NavigationDirection direction);
+
+/**
+ * @brief Find the node whose centre is closest to a point.
+ *
+ * Used to pick an anchor when a cursor key arrives with nothing selected: the
+ * viewport centre gives the most visible node rather than an arbitrary one.
+ *
+ * @param nodes All nodes on the canvas
+ * @param x Scene x coordinate
+ * @param y Scene y coordinate
+ * @return Closest node id, or nullopt if |nodes| is empty
+ */
+std::optional<std::uint64_t> findNodeNearestPoint(
+    const std::vector<NodeBounds>& nodes, double x, double y);
+
+/**
+ * @brief Find the next or previous node in a stable cycle over all nodes.
+ *
+ * Ordering is by node id, which for ORC node ids is creation order, so Tab
+ * walks the graph in the order the stages were added and always terminates.
+ * The cycle wraps at both ends; with no valid |current_id| the first (or, when
+ * stepping backwards, the last) node is returned.
+ *
+ * @param nodes All nodes on the canvas
+ * @param current_id Node the selection is moving from, if any
+ * @param forward True to step to the next node, false for the previous one
+ * @return Target node id, or nullopt if |nodes| is empty
+ */
+std::optional<std::uint64_t> findCycledNode(
+    const std::vector<NodeBounds>& nodes,
+    std::optional<std::uint64_t> current_id, bool forward);
+
+}  // namespace orc::gui
+
+#endif  // NODE_NAVIGATION_MAPPER_H

--- a/orc/gui/orcgraphicsscene.h
+++ b/orc/gui/orcgraphicsscene.h
@@ -55,6 +55,16 @@ class OrcGraphicsScene : public QtNodes::BasicGraphicsScene {
   void selectNode(QtNodes::NodeId nodeId);
 
   /**
+   * @brief Node the scene last reported as selected
+   *
+   * Keyboard navigation anchors on this when the current selection holds no
+   * node graphics item (for example after a connection was selected).
+   *
+   * @return Last selected node id, or QtNodes::InvalidNodeId if none
+   */
+  QtNodes::NodeId lastSelectedNodeId() const { return last_selected_node_id_; }
+
+  /**
    * @brief Create context menu for scene background
    * @param scenePos Position where menu was requested
    * @return Context menu with node creation options

--- a/orc/gui/orcgraphicsview.cpp
+++ b/orc/gui/orcgraphicsview.cpp
@@ -14,12 +14,14 @@
 #include <QAction>
 #include <QContextMenuEvent>
 #include <QFont>
+#include <QKeyEvent>
 #include <QKeySequence>
 #include <QMenu>
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QScrollBar>
 #include <QShowEvent>
 #include <QWheelEvent>
 #include <QtNodes/internal/ConnectionGraphicsObject.hpp>
@@ -37,7 +39,14 @@ using orc::NodeID;
 #include <QMessageBox>
 #include <QShowEvent>
 #include <QWheelEvent>
+#include <algorithm>
 #include <cmath>
+
+namespace {
+// Gap left between a keyboard-selected node and the viewport edge when the
+// view scrolls to reveal it, in device pixels.
+constexpr int kRevealMargin = 60;
+}  // namespace
 
 OrcGraphicsView::OrcGraphicsView(QWidget* parent)
     : QtNodes::GraphicsView(parent),
@@ -193,6 +202,217 @@ void OrcGraphicsView::commitDraggedNodePositions() {
       graph_model.setNodeData(qt_node_id, QtNodes::NodeRole::Position, current);
     }
   }
+}
+
+void OrcGraphicsView::keyPressEvent(QKeyEvent* event) {
+  // Ctrl+arrow keeps the canvas panning that the unmodified cursor keys used
+  // to provide before they were given over to node navigation.
+  if (event->modifiers().testFlag(Qt::ControlModifier)) {
+    switch (event->key()) {
+      case Qt::Key_Left:
+      case Qt::Key_Right:
+      case Qt::Key_Up:
+      case Qt::Key_Down:
+        scrollCanvas(event->key());
+        event->accept();
+        return;
+      default:
+        break;
+    }
+  }
+
+  // Unmodified cursor keys move the selection to the neighbouring node. The
+  // key is accepted either way: falling through on a failed move would scroll
+  // the canvas instead, which reads as the selection having jumped away.
+  if (event->modifiers() == Qt::NoModifier ||
+      event->modifiers() == Qt::KeypadModifier) {
+    using orc::gui::NavigationDirection;
+    switch (event->key()) {
+      case Qt::Key_Left:
+        navigateSelection(NavigationDirection::Left);
+        event->accept();
+        return;
+      case Qt::Key_Right:
+        navigateSelection(NavigationDirection::Right);
+        event->accept();
+        return;
+      case Qt::Key_Up:
+        navigateSelection(NavigationDirection::Up);
+        event->accept();
+        return;
+      case Qt::Key_Down:
+        navigateSelection(NavigationDirection::Down);
+        event->accept();
+        return;
+      default:
+        break;
+    }
+  }
+
+  QtNodes::GraphicsView::keyPressEvent(event);
+}
+
+bool OrcGraphicsView::focusNextPrevChild(bool next) {
+  if (cycleSelection(next)) {
+    return true;
+  }
+
+  return QtNodes::GraphicsView::focusNextPrevChild(next);
+}
+
+std::vector<orc::gui::NodeBounds> OrcGraphicsView::collectNodeBounds() const {
+  std::vector<orc::gui::NodeBounds> bounds;
+
+  if (!scene()) {
+    return bounds;
+  }
+
+  for (QGraphicsItem* item : scene()->items()) {
+    auto* node_graphics = dynamic_cast<QtNodes::NodeGraphicsObject*>(item);
+    if (!node_graphics) {
+      continue;
+    }
+
+    const QRectF rect = node_graphics->sceneBoundingRect();
+    bounds.push_back(orc::gui::NodeBounds{
+        static_cast<std::uint64_t>(node_graphics->nodeId()), rect.x(), rect.y(),
+        rect.width(), rect.height()});
+  }
+
+  return bounds;
+}
+
+std::optional<QtNodes::NodeId> OrcGraphicsView::anchorNodeId(
+    const std::vector<orc::gui::NodeBounds>& bounds) const {
+  if (!scene()) {
+    return std::nullopt;
+  }
+
+  for (QGraphicsItem* item : scene()->selectedItems()) {
+    auto* node_graphics = dynamic_cast<QtNodes::NodeGraphicsObject*>(item);
+    if (node_graphics) {
+      return node_graphics->nodeId();
+    }
+  }
+
+  // Nothing selected right now: fall back to the node the scene reported last,
+  // which is also what a selected connection resolves to.
+  auto* orc_scene = dynamic_cast<OrcGraphicsScene*>(scene());
+  if (!orc_scene) {
+    return std::nullopt;
+  }
+
+  const QtNodes::NodeId last = orc_scene->lastSelectedNodeId();
+  if (last == QtNodes::InvalidNodeId) {
+    return std::nullopt;
+  }
+
+  const auto id = static_cast<std::uint64_t>(last);
+  const bool still_present =
+      std::any_of(bounds.begin(), bounds.end(),
+                  [id](const orc::gui::NodeBounds& b) { return b.id == id; });
+
+  return still_present ? std::optional<QtNodes::NodeId>(last) : std::nullopt;
+}
+
+void OrcGraphicsView::selectAndReveal(OrcGraphicsScene* orc_scene,
+                                      QtNodes::NodeId node_id) {
+  orc_scene->selectNode(node_id);
+
+  for (QGraphicsItem* item : orc_scene->items()) {
+    auto* node_graphics = dynamic_cast<QtNodes::NodeGraphicsObject*>(item);
+    if (!node_graphics || node_graphics->nodeId() != node_id) {
+      continue;
+    }
+
+    // Scroll only when the node is not already fully on screen. Handing the
+    // margin straight to ensureVisible() would scroll a node that is merely
+    // close to a viewport edge, which reads as the whole canvas jumping under
+    // a selection that never left the screen.
+    const QRect node_rect =
+        mapFromScene(node_graphics->sceneBoundingRect()).boundingRect();
+    if (!viewport()->rect().contains(node_rect)) {
+      // The node was off screen, so keep it clear of the viewport edge to
+      // leave its ports and the node it was reached from in sight.
+      ensureVisible(node_graphics, kRevealMargin, kRevealMargin);
+    }
+    break;
+  }
+}
+
+bool OrcGraphicsView::navigateSelection(
+    orc::gui::NavigationDirection direction) {
+  auto* orc_scene = dynamic_cast<OrcGraphicsScene*>(scene());
+  if (!orc_scene) {
+    return false;
+  }
+
+  const std::vector<orc::gui::NodeBounds> bounds = collectNodeBounds();
+  if (bounds.empty()) {
+    return false;
+  }
+
+  const std::optional<QtNodes::NodeId> anchor = anchorNodeId(bounds);
+
+  // With nothing selected the first cursor key selects the most visible node
+  // rather than moving from an arbitrary one.
+  if (!anchor) {
+    const QPointF centre = mapToScene(viewport()->rect().center());
+    const auto nearest =
+        orc::gui::findNodeNearestPoint(bounds, centre.x(), centre.y());
+    if (!nearest) {
+      return false;
+    }
+    selectAndReveal(orc_scene, static_cast<QtNodes::NodeId>(*nearest));
+    return true;
+  }
+
+  const auto target = orc::gui::findAdjacentNode(
+      bounds, static_cast<std::uint64_t>(*anchor), direction);
+  if (!target) {
+    return false;
+  }
+
+  selectAndReveal(orc_scene, static_cast<QtNodes::NodeId>(*target));
+  return true;
+}
+
+bool OrcGraphicsView::cycleSelection(bool forward) {
+  auto* orc_scene = dynamic_cast<OrcGraphicsScene*>(scene());
+  if (!orc_scene) {
+    return false;
+  }
+
+  const std::vector<orc::gui::NodeBounds> bounds = collectNodeBounds();
+  if (bounds.empty()) {
+    return false;
+  }
+
+  std::optional<std::uint64_t> current;
+  if (const std::optional<QtNodes::NodeId> anchor = anchorNodeId(bounds)) {
+    current = static_cast<std::uint64_t>(*anchor);
+  }
+
+  const auto target = orc::gui::findCycledNode(bounds, current, forward);
+  if (!target) {
+    return false;
+  }
+
+  selectAndReveal(orc_scene, static_cast<QtNodes::NodeId>(*target));
+  return true;
+}
+
+void OrcGraphicsView::scrollCanvas(int key) {
+  QScrollBar* bar = (key == Qt::Key_Left || key == Qt::Key_Right)
+                        ? horizontalScrollBar()
+                        : verticalScrollBar();
+  if (!bar) {
+    return;
+  }
+
+  const bool decrease = (key == Qt::Key_Left || key == Qt::Key_Up);
+  bar->triggerAction(decrease ? QAbstractSlider::SliderSingleStepSub
+                              : QAbstractSlider::SliderSingleStepAdd);
 }
 
 void OrcGraphicsView::contextMenuEvent(QContextMenuEvent* event) {

--- a/orc/gui/orcgraphicsview.h
+++ b/orc/gui/orcgraphicsview.h
@@ -11,8 +11,13 @@
 
 #include <QString>
 #include <QtNodes/GraphicsView>
+#include <optional>
+#include <vector>
+
+#include "node_navigation_mapper.h"
 
 class OrcGraphModel;
+class OrcGraphicsScene;
 
 /**
  * Custom graphics view that validates node deletion before allowing it
@@ -30,6 +35,11 @@ class OrcGraphicsView : public QtNodes::GraphicsView {
   void showEvent(QShowEvent* event) override;
   void contextMenuEvent(QContextMenuEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
+  void keyPressEvent(QKeyEvent* event) override;
+
+  // Tab and Shift+Tab are consumed by QWidget::event() for focus traversal
+  // before keyPressEvent() ever runs, so node cycling has to hook in here.
+  bool focusNextPrevChild(bool next) override;
 
  public:
   void setShowWelcomeMessage(bool show);
@@ -44,6 +54,30 @@ class OrcGraphicsView : public QtNodes::GraphicsView {
   // project keeps stale positions and every node snaps back to its old spot
   // the next time the scene is rebuilt (e.g. after editing parameters).
   void commitDraggedNodePositions();
+
+  // On-screen extent of every node, in scene coordinates. Taken from the
+  // graphics items rather than the model so navigation follows what the user
+  // can actually see, including nodes moved but not yet committed.
+  std::vector<orc::gui::NodeBounds> collectNodeBounds() const;
+
+  // Node keyboard navigation moves from: the selected node, else the last
+  // selected one if it still exists, else nothing.
+  std::optional<QtNodes::NodeId> anchorNodeId(
+      const std::vector<orc::gui::NodeBounds>& bounds) const;
+
+  // Select |node_id| and scroll it into view.
+  void selectAndReveal(OrcGraphicsScene* orc_scene, QtNodes::NodeId node_id);
+
+  // Move the selection one node in |direction|; returns false when there is
+  // no node to move to.
+  bool navigateSelection(orc::gui::NavigationDirection direction);
+
+  // Step the selection through all nodes in creation order.
+  bool cycleSelection(bool forward);
+
+  // Keyboard canvas panning, kept on Ctrl+arrow now that the unmodified
+  // cursor keys move the selection instead.
+  void scrollCanvas(int key);
 
   bool show_welcome_message_{true};
   QString welcome_message_;

--- a/orc/gui/previewdialog.cpp
+++ b/orc/gui/previewdialog.cpp
@@ -33,6 +33,7 @@
 #include <utility>
 
 #include "audio_channel_pair_notice.h"
+#include "field_frame_presentation.h"
 #include "fieldpreviewwidget.h"
 #include "framescopedialog.h"
 #include "frametimingdialog.h"
@@ -63,6 +64,22 @@ constexpr int kAudioPrimeDialogDelayMs = 400;
 
 // How often the prime dialog picks up the worker's published progress.
 constexpr int kAudioPrimeTickMs = 200;
+
+// Convert the presenter-layer VideoSystem to the core orc::VideoSystem used by
+// the field/frame presentation helpers. The two enums are mirrors; this
+// translation keeps the GUI layer decoupled from core types.
+orc::VideoSystem toOrcVideoSystem(orc::presenters::VideoSystem sys) {
+  switch (sys) {
+    case orc::presenters::VideoSystem::PAL:
+      return orc::VideoSystem::PAL;
+    case orc::presenters::VideoSystem::NTSC:
+      return orc::VideoSystem::NTSC;
+    case orc::presenters::VideoSystem::PAL_M:
+      return orc::VideoSystem::PAL_M;
+    default:
+      return orc::VideoSystem::Unknown;
+  }
+}
 
 }  // namespace
 
@@ -1338,12 +1355,24 @@ void PreviewDialog::showLineScope(
       preview_widget_->setCrosshairsEnabled(true);
     }
 
-    // field_index is used as frame_id; line_number (1-based) → frame_line
-    // (0-based)
-    const size_t frame_line = static_cast<size_t>(std::max(0, line_number - 1));
+    // FrameScopeDialog identifies the line by frame and frame-flat line
+    // (docs/gui-user-guide/dialogues/line-scope.md), but the response
+    // addresses it as a sequential field plus a line within that field.
+    //
+    // The frame holding a field is field_index / 2. The line has to be rebased
+    // onto the frame-flat numbering orc::make_line_label() expects - field 2's
+    // block follows field 1's - or both fields of a frame report the same
+    // label and adjacent preview rows look identical.
+    const uint64_t frame_id = field_index / 2;
+    const int field_line = std::max(0, line_number - 1);
+    const size_t frame_line = video_params.has_value()
+                                  ? orc::gui::frameFlatLineIndex(
+                                        field_index, field_line,
+                                        toOrcVideoSystem(video_params->system))
+                                  : static_cast<size_t>(field_line);
 
     frame_scope_dialog_->setFrameLineSamples(
-        node_id, stage_index, field_index, frame_line, sample_x, samples,
+        node_id, stage_index, frame_id, frame_line, sample_x, samples,
         video_params, preview_image_width, original_sample_x, original_image_y,
         y_samples, c_samples);
 

--- a/orc/plugins/stages/cvbs_sink/cvbs_sink_phase_sequence.h
+++ b/orc/plugins/stages/cvbs_sink/cvbs_sink_phase_sequence.h
@@ -1,0 +1,152 @@
+/*
+ * File:        cvbs_sink_phase_sequence.h
+ * Module:      orc-core
+ * Purpose:     Colour-sequence continuity check for the CVBS sink's
+ *              signal_state_preset decision
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#ifndef ORC_CORE_CVBS_SINK_PHASE_SEQUENCE_H
+#define ORC_CORE_CVBS_SINK_PHASE_SEQUENCE_H
+
+#include <orc/stage/common_types.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace orc {
+
+// Tracks whether the colour-sequence phase runs continuously through the
+// frames a CVBS sink writes, so the .meta signal_state_preset can state what
+// was observed rather than what was assumed.
+//
+// The colour sequence is a property of the burst, so the phase IDs fed in here
+// come from the host "colour_frame_phase" observer (see
+// orc/stage/observation/colour_frame_phase_query.h): 1-8 per field for
+// PAL/PAL_M (EBU Tech. 3280-E §1.1.1) and 1-4 for NTSC (SMPTE 244M-2003 §3.2),
+// with -1 where the burst could not be measured.
+//
+// Two things are checked per frame: that its second field follows its first,
+// and that its first field follows the previous measured frame's.  A frame
+// advances the sequence by two fields, so a frame whose burst is unmeasurable
+// (blank leader, lead-in, black frame) is not a discontinuity in itself: the
+// expected phase is projected across the gap and re-checked on the far side.
+// Penalising those would mark all but the cleanest capture unlocked.
+//
+// Feed observe() exactly once per frame actually written, in output order.
+class ColourPhaseSequenceCheck {
+ public:
+  explicit ColourPhaseSequenceCheck(VideoSystem system)
+      : fields_in_sequence_(fields_in_sequence(system)) {}
+
+  // Record one written frame's per-field phase IDs (-1 where unmeasurable).
+  void observe(int32_t field1_phase_id, int32_t field2_phase_id) {
+    const uint64_t frame_index = frames_seen_;
+    ++frames_seen_;
+
+    if (fields_in_sequence_ == 0) return;  // unknown system: nothing to check
+    if (!is_valid(field1_phase_id) || !is_valid(field2_phase_id)) return;
+
+    ++frames_measured_;
+
+    bool broken = (field2_phase_id != advance(field1_phase_id, 1));
+
+    if (last_measured_frame_.has_value()) {
+      const uint64_t gap = frame_index - *last_measured_frame_;
+      if (field1_phase_id != advance(last_field1_phase_id_, 2 * gap)) {
+        broken = true;
+      }
+    }
+
+    if (broken) {
+      ++discontinuities_;
+      if (!first_discontinuity_frame_.has_value()) {
+        first_discontinuity_frame_ = frame_index;
+      }
+    }
+
+    // Re-anchor on this frame either way, so one skip costs one discontinuity
+    // rather than marking every remaining frame as broken.
+    last_measured_frame_ = frame_index;
+    last_field1_phase_id_ = field1_phase_id;
+  }
+
+  // True when the sequence was measurable and ran unbroken.  A file in which
+  // no burst could be measured at all is not locked: there is nothing to
+  // support the claim.
+  bool locked() const { return frames_measured_ > 0 && discontinuities_ == 0; }
+
+  const char* signal_state_preset() const {
+    return locked() ? "STANDARD_TBC_LOCKED" : "STANDARD_TBC_UNLOCKED";
+  }
+
+  uint64_t frames_seen() const { return frames_seen_; }
+  uint64_t frames_measured() const { return frames_measured_; }
+  uint64_t discontinuities() const { return discontinuities_; }
+
+  // Output-file frame index of the first discontinuity, if any.
+  std::optional<uint64_t> first_discontinuity_frame() const {
+    return first_discontinuity_frame_;
+  }
+
+  // One line for the log and the trigger status, explaining the verdict.
+  std::string summary() const {
+    if (fields_in_sequence_ == 0) {
+      return "colour phase sequence not checked (unknown video system): "
+             "written as STANDARD_TBC_UNLOCKED";
+    }
+    if (frames_measured_ == 0) {
+      return "colour phase sequence unmeasurable (no burst found in any "
+             "frame): written as STANDARD_TBC_UNLOCKED";
+    }
+    if (discontinuities_ == 0) {
+      return "colour phase sequence continuous over " +
+             std::to_string(frames_measured_) +
+             " measured frames: written as "
+             "STANDARD_TBC_LOCKED";
+    }
+    return "colour phase sequence breaks " + std::to_string(discontinuities_) +
+           " time(s), first at output frame " +
+           std::to_string(first_discontinuity_frame_.value_or(0)) +
+           ": written as STANDARD_TBC_UNLOCKED (run disc mapping to restore a "
+           "continuous sequence)";
+  }
+
+ private:
+  static int32_t fields_in_sequence(VideoSystem system) {
+    switch (system) {
+      case VideoSystem::PAL:
+      case VideoSystem::PAL_M:
+        return 8;
+      case VideoSystem::NTSC:
+        return 4;
+      default:
+        return 0;
+    }
+  }
+
+  bool is_valid(int32_t phase_id) const {
+    return phase_id >= 1 && phase_id <= fields_in_sequence_;
+  }
+
+  int32_t advance(int32_t phase_id, uint64_t fields) const {
+    const uint64_t n = static_cast<uint64_t>(fields_in_sequence_);
+    return static_cast<int32_t>(
+        ((static_cast<uint64_t>(phase_id - 1) + fields) % n) + 1);
+  }
+
+  int32_t fields_in_sequence_ = 0;
+  uint64_t frames_seen_ = 0;
+  uint64_t frames_measured_ = 0;
+  uint64_t discontinuities_ = 0;
+  std::optional<uint64_t> first_discontinuity_frame_;
+  std::optional<uint64_t> last_measured_frame_;
+  int32_t last_field1_phase_id_ = 0;
+};
+
+}  // namespace orc
+
+#endif  // ORC_CORE_CVBS_SINK_PHASE_SEQUENCE_H

--- a/orc/plugins/stages/cvbs_sink/cvbs_sink_stage_deps.cpp
+++ b/orc/plugins/stages/cvbs_sink/cvbs_sink_stage_deps.cpp
@@ -12,6 +12,7 @@
 #include <orc/stage/audio/audio_channel_pair.h>
 #include <orc/stage/cvbs_signal_constants.h>
 #include <orc/stage/frame_descriptor.h>
+#include <orc/stage/observation/colour_frame_phase_query.h>
 #include <orc/support/logging.h>
 #include <sqlite3.h>
 
@@ -24,6 +25,7 @@
 #include <vector>
 
 #include "cvbs_sink_container.h"
+#include "cvbs_sink_phase_sequence.h"
 
 namespace orc {
 
@@ -112,7 +114,8 @@ sqlite3* create_sidecar_db(const std::string& path, const char* schema_sql,
 bool write_core_metadata(
     const std::string& meta_path, VideoSystem system,
     const CVBSSinkWriteConfig& config, uint64_t frames_written,
-    std::optional<int32_t> black_level, bool has_nonstandard_values,
+    const char* signal_state_preset, std::optional<int32_t> black_level,
+    bool has_nonstandard_values,
     const std::vector<CVBSAudioChannelPairMetaRow>& audio_channel_pairs,
     std::string& error_message) {
   sqlite3* db =
@@ -123,7 +126,7 @@ bool write_core_metadata(
       "INSERT INTO cvbs_file (cvbs_file_id, preset, sample_encoding_preset, "
       "signal_state_preset, signal_type, decoder, number_of_sequential_frames, "
       "black_level, has_nonstandard_values, capture_notes) "
-      "VALUES (1, ?, ?, 'STANDARD_TBC_LOCKED', ?, 'other', ?, ?, ?, ?)";
+      "VALUES (1, ?, ?, ?, ?, 'other', ?, ?, ?, ?)";
 
   sqlite3_stmt* stmt = nullptr;
   if (sqlite3_prepare_v2(db, kInsert, -1, &stmt, nullptr) != SQLITE_OK) {
@@ -136,23 +139,24 @@ bool write_core_metadata(
   sqlite3_bind_text(stmt, 1, preset_name(system), -1, SQLITE_STATIC);
   sqlite3_bind_text(stmt, 2, cvbs_sample_encoding_name(config.sample_encoding),
                     -1, SQLITE_STATIC);
-  sqlite3_bind_text(stmt, 3, config.signal_type.c_str(), -1, SQLITE_TRANSIENT);
-  sqlite3_bind_int64(stmt, 4, static_cast<sqlite3_int64>(frames_written));
+  sqlite3_bind_text(stmt, 3, signal_state_preset, -1, SQLITE_STATIC);
+  sqlite3_bind_text(stmt, 4, config.signal_type.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_int64(stmt, 5, static_cast<sqlite3_int64>(frames_written));
   if (black_level.has_value()) {
-    sqlite3_bind_int(stmt, 5, *black_level);
-  } else {
-    sqlite3_bind_null(stmt, 5);
-  }
-  if (has_nonstandard_values) {
-    sqlite3_bind_int(stmt, 6, 1);
+    sqlite3_bind_int(stmt, 6, *black_level);
   } else {
     sqlite3_bind_null(stmt, 6);
   }
-  if (!config.capture_notes.empty()) {
-    sqlite3_bind_text(stmt, 7, config.capture_notes.c_str(), -1,
-                      SQLITE_TRANSIENT);
+  if (has_nonstandard_values) {
+    sqlite3_bind_int(stmt, 7, 1);
   } else {
     sqlite3_bind_null(stmt, 7);
+  }
+  if (!config.capture_notes.empty()) {
+    sqlite3_bind_text(stmt, 8, config.capture_notes.c_str(), -1,
+                      SQLITE_TRANSIENT);
+  } else {
+    sqlite3_bind_null(stmt, 8);
   }
 
   bool ok = (sqlite3_step(stmt) == SQLITE_DONE);
@@ -490,6 +494,12 @@ CVBSSinkWriteResult CVBSSinkStageDeps::write_cvbs(
   std::vector<uint16_t> encode_buffer;
   uint64_t frames_written = 0;
 
+  // The .meta signal_state_preset states what this file is, not what the
+  // input claimed to be: any stage upstream may have reordered, dropped or
+  // synthesised frames.  Measure the colour sequence of what is actually
+  // written and let the result decide (issue #287).
+  ColourPhaseSequenceCheck phase_check(system);
+
   // Encode one flat frame plane and append it to the stream.
   const auto write_plane =
       [&](std::ofstream& out,
@@ -583,6 +593,12 @@ CVBSSinkWriteResult CVBSSinkStageDeps::write_cvbs(
       ac3_offset += ac3.size();
     }
 
+    // Measured after the plane writes: measure_frame_phase() re-fetches the
+    // frame, which may invalidate primary_data/chroma_data.
+    const auto phase =
+        orc::observation::measure_frame_phase(*representation, fid);
+    phase_check.observe(phase.field1_phase_id, phase.field2_phase_id);
+
     ++frames_written;
 
     if (frames_written % 10 == 0 && progress_callback_) {
@@ -626,6 +642,7 @@ CVBSSinkWriteResult CVBSSinkStageDeps::write_cvbs(
     audio_pair_rows.push_back(std::move(row));
   }
   if (!write_core_metadata(base + ".meta", system, config, frames_written,
+                           phase_check.signal_state_preset(),
                            black_level_override, has_nonstandard_values,
                            audio_pair_rows, err)) {
     return {false, frames_written, err};
@@ -652,8 +669,16 @@ CVBSSinkWriteResult CVBSSinkStageDeps::write_cvbs(
       dropout_rows.empty() ? "no" : "yes", audio_pair_rows.size(),
       write_efm ? "yes" : "no", write_ac3 ? "yes" : "no");
 
+  const std::string phase_summary = phase_check.summary();
+  if (phase_check.locked()) {
+    ORC_LOG_INFO("CVBSSinkDeps: {}", phase_summary);
+  } else {
+    ORC_LOG_WARN("CVBSSinkDeps: {}", phase_summary);
+  }
+
   return {true, frames_written,
-          "Success: " + std::to_string(frames_written) + " frames written"};
+          "Success: " + std::to_string(frames_written) + " frames written; " +
+              phase_summary};
 }
 
 }  // namespace orc

--- a/orc/plugins/stages/cvbs_sink/instructions.md
+++ b/orc/plugins/stages/cvbs_sink/instructions.md
@@ -8,7 +8,7 @@ Use this sink at the end of a CVBS processing pipeline when you want to save the
 
 ## What it does
 
-Writes the incoming video stream using the selected sample encoding, plus a `.meta` SQLite sidecar database. The output signal type follows the project type automatically and is not user-selectable: a composite project is written as a single `.cvbs` file, and a Y/C project is written as a `.cvbsy`/`.cvbsc` pair (per the CVBS file format naming convention). The sidecar records the video standard preset, the selected `sample_encoding_preset`, the signal type, the frame count, and `signal_state_preset = STANDARD_TBC_LOCKED` (the signal state is fixed: only locked, standard-state signals reach a sink).
+Writes the incoming video stream using the selected sample encoding, plus a `.meta` SQLite sidecar database. The output signal type follows the project type automatically and is not user-selectable: a composite project is written as a single `.cvbs` file, and a Y/C project is written as a `.cvbsy`/`.cvbsc` pair (per the CVBS file format naming convention). The sidecar records the video standard preset, the selected `sample_encoding_preset`, the signal type, the frame count, and a measured `signal_state_preset`.
 
 Associated data are written automatically as sidecar files when present in the incoming stream:
 
@@ -31,7 +31,7 @@ Optional free-text notes written to the `.meta` file. When left empty, no notes 
 ## Notes
 
 - The output signal type (`composite` vs `yc`) follows the project type and cannot be overridden — Y/C cannot be derived from a composite signal.
-- `signal_state_preset` in the output `.meta` is always `STANDARD_TBC_LOCKED` and cannot be overridden.
+- `signal_state_preset` in the output `.meta` is measured, not assumed, and cannot be overridden. As each frame is written its colour-sequence phase is measured from the burst; the file is marked `STANDARD_TBC_LOCKED` only when that sequence runs unbroken through every frame written, and `STANDARD_TBC_UNLOCKED` otherwise (including when no burst could be measured at all). Frames with no measurable burst — blank leader, lead-in, black frames — are not breaks in themselves: the expected phase is projected across them and re-checked on the far side. The verdict appears in the stage's completion status and in the log, naming the output frame of the first discontinuity. Because the marker describes the file that was written, a stage that legitimately reorders or drops frames can turn a locked input into an unlocked output; running the Disc Mapper first is what restores a continuous sequence.
 - Sidecar files for dropout, audio, EFM, and AC3 data are written automatically alongside the main output when those data streams are present; absent streams produce no sidecar files (this is not an error).
 - Every pipeline audio channel pair is exported — there is no pair selection at this sink. Per-pair descriptions are recorded in the `.meta` `audio_channel_pair` table.
 - The output is compatible with the CVBS Source stage for round-trip workflows.

--- a/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
+++ b/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
@@ -1115,12 +1115,29 @@ std::vector<ArtifactPtr> FixedFormatCVBSSourceStage::execute(
     }
     const CVBSMetadataRecord& meta = *meta_opt;
 
-    // Hard-reject non-STANDARD_TBC_LOCKED signal states.
-    if (meta.signal_state_preset != "STANDARD_TBC_LOCKED") {
-      throw UserDataError("CVBS source '" + input_path +
-                          "' has signal_state_preset '" +
-                          meta.signal_state_preset +
-                          "'. Only STANDARD_TBC_LOCKED files are accepted.");
+    // Signal state: the stage needs standard-rate, TBC'd samples because its
+    // frame geometry is fixed at 4fsc.  The burst-lock axis is a different
+    // matter: colour-sequence phase is measured from the burst by the
+    // "colour_frame_phase" observer rather than taken on trust from the
+    // sidecar, so an unlocked file decodes correctly.  Accept both TBC states
+    // at the standard rate and reject the rest.
+    if (meta.signal_state_preset != "STANDARD_TBC_LOCKED" &&
+        meta.signal_state_preset != "STANDARD_TBC_UNLOCKED") {
+      throw UserDataError(
+          "CVBS source '" + input_path + "' has signal_state_preset '" +
+          meta.signal_state_preset +
+          "'. Only STANDARD_TBC_LOCKED and STANDARD_TBC_UNLOCKED files are "
+          "accepted: the stage requires time-base-corrected samples at the "
+          "standard 4fsc rate.");
+    }
+    if (meta.signal_state_preset == "STANDARD_TBC_UNLOCKED") {
+      ORC_LOG_WARN(
+          "CVBS source '{}' is marked STANDARD_TBC_UNLOCKED: the colour "
+          "phase sequence is not guaranteed continuous through the file "
+          "(typically a disc skip during decode). Decoding is unaffected, but "
+          "run disc mapping before exporting if a continuous sequence is "
+          "wanted.",
+          input_path);
     }
 
     // Validate that the .meta video standard matches this stage's fixed

--- a/orc/plugins/stages/cvbs_source/cvbs_source_stage.h
+++ b/orc/plugins/stages/cvbs_source/cvbs_source_stage.h
@@ -36,7 +36,7 @@ struct CVBSExtensionFrameRef {
 struct CVBSMetadataRecord {
   std::string preset;                  // video_standard_preset (PAL/NTSC/PAL_M)
   std::string sample_encoding_preset;  // CVBS_U10_4FSC / CVBS_U16_4FSC / etc.
-  std::string signal_state_preset;     // must be STANDARD_TBC_LOCKED
+  std::string signal_state_preset;     // STANDARD_TBC_LOCKED/_UNLOCKED
   std::string signal_type;             // composite / yc
   int32_t number_of_sequential_frames = 0;
   // NTSC-J only: explicit black level stored in the 10-bit domain.
@@ -150,8 +150,12 @@ class ICVBSSourceStageDeps {
 // The stage loads the CVBS data file and its sidecars at execute() time and
 // returns a CVBSDecodedFrameRepresentation satisfying VideoFrameRepresentation.
 //
-// Signal state: only STANDARD_TBC_LOCKED is accepted.  Files with any other
-// state are rejected with a clear UserDataError before any sample data is read.
+// Signal state: STANDARD_TBC_LOCKED and STANDARD_TBC_UNLOCKED are accepted;
+// files in any other state are rejected with a clear UserDataError before any
+// sample data is read, because the stage's frame geometry assumes
+// time-base-corrected samples at the standard 4fsc rate.  Burst lock is not
+// required: colour-sequence phase is measured from the burst downstream, never
+// taken from the sidecar.  An unlocked file is accepted with a logged warning.
 //
 // Sample encoding: CVBS_U10_4FSC, CVBS_U16_4FSC, CVBS_TPG21_4FSC, and
 // CVBS_S16_4FSC are all normalised to CVBS_U10_4FSC (int16_t 10-bit domain)

--- a/orc/plugins/stages/cvbs_source/instructions.md
+++ b/orc/plugins/stages/cvbs_source/instructions.md
@@ -4,7 +4,7 @@ Reads composite video from a `.cvbs` file (or a `.cvbsy` / `.cvbsc` pair for Y/C
 
 ## When to use
 
-Add CVBS Source as the first stage in any pipeline that starts from a CVBS file produced by the decode-orc capture toolchain. Only files with a signal state of `STANDARD_TBC_LOCKED` are accepted; files in any other state (for example `STANDARD_TBC_UNLOCKED` or `STANDARD_RAW`) are rejected before any sample data is read.
+Add CVBS Source as the first stage in any pipeline that starts from a CVBS file produced by the decode-orc capture toolchain. Files with a signal state of `STANDARD_TBC_LOCKED` or `STANDARD_TBC_UNLOCKED` are accepted; any other state (for example `STANDARD_RAW` or a `NONSTANDARD_*` sample rate) is rejected before any sample data is read, because the stage's frame geometry assumes time-base-corrected samples at the standard 4fsc rate.
 
 ## Parameters
 
@@ -21,7 +21,9 @@ The `lock_audio` parameter has been removed: the pipeline no longer has a free-r
 
 ## What it does
 
-With **Sample Encoding** at its default (`From metadata`), the stage opens the `.meta` sidecar at execute time and reads the video standard, sample encoding, signal state, frame count, NTSC-J black level, and decode provenance (the upstream decoder name and its git branch/commit, passed through unchanged to downstream stages). If the signal state is not `STANDARD_TBC_LOCKED`, or the video standard does not match the stage, the stage reports a configuration error and stops.
+With **Sample Encoding** at its default (`From metadata`), the stage opens the `.meta` sidecar at execute time and reads the video standard, sample encoding, signal state, frame count, NTSC-J black level, and decode provenance (the upstream decoder name and its git branch/commit, passed through unchanged to downstream stages). If the signal state is neither `STANDARD_TBC_LOCKED` nor `STANDARD_TBC_UNLOCKED`, or the video standard does not match the stage, the stage reports a configuration error and stops.
+
+Burst lock is not required. Colour-sequence phase is measured from each frame's burst by the `colour_frame_phase` observer rather than taken from the sidecar, so a `STANDARD_TBC_UNLOCKED` source decodes normally; the stage logs a warning and continues. That marker means the colour phase sequence is not continuous end to end, which for a LaserDisc source usually means the player skipped or jumped during the decode — run the Disc Mapper (a Frame Map stage tool) to restore the recorded frame order before exporting.
 
 When a sample encoding is selected manually the `.meta` sidecar is ignored (it need not exist). The video standard comes from the stage itself, the signal is assumed to be TBC-locked, the frame count is measured from the file size, and audio channel pairs carry derived names (the `audio_channel_pair` metadata table is not read).
 

--- a/orc/presenters/include/project_presenter.h
+++ b/orc/presenters/include/project_presenter.h
@@ -158,6 +158,18 @@ class ProjectPresenter : public IProjectPresenter {
   static std::optional<orc::SourceParameters> readCVBSVideoParameters(
       const std::string& meta_path);
 
+  /**
+   * @brief Read the signal state preset from a CVBS .meta metadata file
+   * @param meta_path Path to .meta SQLite file
+   * @return The signal_state_preset string, or nullopt when it cannot be read
+   *
+   * Kept separate from readCVBSVideoParameters() because SourceParameters is
+   * an ABI struct shared with plugins and the signal state is only wanted by
+   * the UI, to tell the user when a source is not burst-locked.
+   */
+  static std::optional<std::string> readCVBSSignalState(
+      const std::string& meta_path);
+
   // === Project Lifecycle ===
 
   /**

--- a/orc/presenters/src/project_presenter.cpp
+++ b/orc/presenters/src/project_presenter.cpp
@@ -235,6 +235,41 @@ std::optional<orc::SourceParameters> ProjectPresenter::readCVBSVideoParameters(
   return result;
 }
 
+std::optional<std::string> ProjectPresenter::readCVBSSignalState(
+    const std::string& meta_path) {
+  sqlite3* db = nullptr;
+  int rc =
+      sqlite3_open_v2(meta_path.c_str(), &db, SQLITE_OPEN_READONLY, nullptr);
+  if (rc != SQLITE_OK) {
+    ORC_LOG_WARN("Failed to open CVBS metadata file: {}", meta_path);
+    if (db) sqlite3_close(db);
+    return std::nullopt;
+  }
+
+  sqlite3_stmt* stmt = nullptr;
+  rc = sqlite3_prepare_v2(db,
+                          "SELECT signal_state_preset FROM cvbs_file "
+                          "ORDER BY cvbs_file_id LIMIT 1",
+                          -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    ORC_LOG_WARN("Failed to query signal_state_preset from CVBS metadata: {}",
+                 meta_path);
+    sqlite3_close(db);
+    return std::nullopt;
+  }
+
+  std::optional<std::string> result;
+  if (sqlite3_step(stmt) == SQLITE_ROW) {
+    const char* text =
+        reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    if (text) result = text;
+  }
+
+  sqlite3_finalize(stmt);
+  sqlite3_close(db);
+  return result;
+}
+
 // === ProjectPresenter Implementation ===
 
 ProjectPresenter::ProjectPresenter()


### PR DESCRIPTION
## Summary

Three GUI/pipeline fixes:

- **Issue #287 — support `STANDARD_TBC_UNLOCKED` CVBS sources.** The CVBS source stage
  no longer hard-rejects unlocked files: colour-sequence phase is measured from each
  frame's burst by the `colour_frame_phase` observer rather than taken on trust from the
  sidecar, so an unlocked file decodes normally. Both TBC states at the standard 4fsc rate
  are accepted, everything else is still refused with a clearer message. Opening an
  unlocked source shows an advisory notice explaining that the phase sequence is not
  continuous end to end (typically a disc skip during decode) and that the Disc Mapper
  restores the recorded frame order. The CVBS sink now measures the phase sequence of the
  frames it actually writes (`ColourPhaseSequenceCheck`) and stamps
  `signal_state_preset` from that observation instead of hard-coding `STANDARD_TBC_LOCKED`
  — an upstream stage may have reordered, dropped or synthesised frames. Frames whose
  burst is unmeasurable are projected across rather than counted as a break.

- **Issue #286 — keyboard navigation on the DAG canvas.** Cursor keys move the selection
  to the neighbouring stage (geometric, not topological: a stage level on the pressed axis
  wins, so Right walks a left-to-right chain and Up/Down step between parallel branches),
  Tab/Shift+Tab cycle in stage-creation order, and Ctrl+cursor keeps its old meaning of
  scrolling the canvas. The view scrolls to bring an off-screen selection into sight.

- **Line scope up/down buttons.** Navigation now steps exactly one preview row per press,
  making it symmetric (down-then-up returns to the same row) and every line reachable; the
  old "skip a row if the field line repeats" workaround is gone, and the scope's line
  label now reports the frame-flat index so the two interleaved fields are
  distinguishable. The flat single-field previews (Field 1 / Field 2) had their index
  convention corrected — `output_index` is the sequential field number, so geometry lookup
  and field↔row mapping were resolving the wrong frame.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Validation

New unit tests: `cvbs_sink_phase_sequence_test`, `cvbs_signal_state_notice_test`,
`node_navigation_mapper_test`, `orc_graphics_view_navigation_test`,
`field_frame_presentation_test`, plus extensions to `line_navigation_mapper_test`,
`preview_frame_layout_test`, `cvbs_source_stage_test` and the multi-track audio
round-trip contract test (unlocked-state coverage). Run the full suite before merge, and
sanity-check in the live GUI: open an `UNLOCKED` CVBS source, step the line scope through
a weaved frame and both single-field views, and drive the canvas selection from the
keyboard.

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [x] Related docs were updated if needed
- [x] Linked issue (if applicable)

## Related issue

Closes #286
Closes #287
