### PR TITLE
Speed up the time to build preview and remove some odd silent delays

### DIFF
--- a/orc-tests/core/unit/contracts/project_to_dag_contract_test.cpp
+++ b/orc-tests/core/unit/contracts/project_to_dag_contract_test.cpp
@@ -11,8 +11,10 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "../../../orc/core/include/dag_executor.h"
 #include "../../../orc/core/include/project.h"
@@ -160,6 +162,206 @@ TEST(ProjectToDagContractTest, UnknownStageInProject_FailsCleanly) {
   orc::project_io::update_project_dag(project, nodes, {});
 
   EXPECT_THROW(orc::project_to_dag(project), orc::ProjectConversionError);
+}
+
+// ── Stage instance reuse across rebuilds ─────────────────────────────────
+//
+// Every edit in the DAG editor rebuilds the whole DAG. Discarding every stage
+// object each time also discards what execute() had accumulated behind them —
+// for a source, the representation it loaded, which on a long capture is
+// seconds of work. A node the edit did not touch keeps its instance so an
+// unrelated change no longer pays for that.
+
+namespace {
+
+// The stage instance behind |node_id|, or nullptr if the DAG has no such node.
+const orc::DAGStage* stage_of(const std::shared_ptr<orc::DAG>& dag,
+                              orc::NodeID node_id) {
+  for (const auto& node : dag->nodes()) {
+    if (node.node_id == node_id) return node.stage.get();
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TEST(ProjectToDagContractTest,
+     ReusesStageInstances_ForNodesTheEditDidNotTouch) {
+  const auto chain = find_representative_chain();
+  ASSERT_TRUE(chain.has_value());
+
+  auto project = orc::project_io::create_empty_project(
+      "reuse-project", orc::VideoSystem::Unknown, orc::SourceType::Unknown);
+  const auto source_id =
+      orc::project_io::add_node(project, chain->source, 0.0, 0.0);
+  const auto middle_id =
+      orc::project_io::add_node(project, chain->middle, 100.0, 0.0);
+  const auto sink_id =
+      orc::project_io::add_node(project, chain->sink, 200.0, 0.0);
+  orc::project_io::add_edge(project, source_id, middle_id);
+  orc::project_io::add_edge(project, middle_id, sink_id);
+
+  const auto first = orc::project_to_dag(project);
+  ASSERT_NE(first, nullptr);
+
+  // The edit: drop the link between the middle stage and the sink. It says
+  // nothing about the source, which is where the expensive state lives.
+  orc::project_io::remove_edge(project, middle_id, sink_id);
+  const auto second = orc::project_to_dag(project, first.get());
+  ASSERT_NE(second, nullptr);
+
+  EXPECT_EQ(stage_of(second, source_id), stage_of(first, source_id));
+  EXPECT_EQ(stage_of(second, middle_id), stage_of(first, middle_id));
+}
+
+TEST(ProjectToDagContractTest, BuildsAFreshStage_WhenANodesWiringChanged) {
+  const auto chain = find_representative_chain();
+  ASSERT_TRUE(chain.has_value());
+
+  auto project = orc::project_io::create_empty_project(
+      "rewire-project", orc::VideoSystem::Unknown, orc::SourceType::Unknown);
+  const auto source_id =
+      orc::project_io::add_node(project, chain->source, 0.0, 0.0);
+  const auto middle_id =
+      orc::project_io::add_node(project, chain->middle, 100.0, 0.0);
+  const auto sink_id =
+      orc::project_io::add_node(project, chain->sink, 200.0, 0.0);
+  orc::project_io::add_edge(project, source_id, middle_id);
+  orc::project_io::add_edge(project, middle_id, sink_id);
+
+  const auto first = orc::project_to_dag(project);
+  ASSERT_NE(first, nullptr);
+
+  // The sink loses its input, so anything it cached was computed from a graph
+  // it is no longer part of. Its instance must not be carried over — a stage
+  // that does not declare the reserved input-node-ids parameter has no other
+  // way to notice.
+  orc::project_io::remove_edge(project, middle_id, sink_id);
+  const auto second = orc::project_to_dag(project, first.get());
+  ASSERT_NE(second, nullptr);
+
+  EXPECT_NE(stage_of(second, sink_id), stage_of(first, sink_id));
+}
+
+TEST(ProjectToDagContractTest, BuildsFreshStages_DownstreamOfAChangedNode) {
+  const auto chain = find_representative_chain();
+  ASSERT_TRUE(chain.has_value());
+
+  auto project = orc::project_io::create_empty_project(
+      "downstream-project", orc::VideoSystem::Unknown,
+      orc::SourceType::Unknown);
+  const auto source_id =
+      orc::project_io::add_node(project, chain->source, 0.0, 0.0);
+  const auto middle_id =
+      orc::project_io::add_node(project, chain->middle, 100.0, 0.0);
+  const auto sink_id =
+      orc::project_io::add_node(project, chain->sink, 200.0, 0.0);
+  orc::project_io::add_edge(project, source_id, middle_id);
+  orc::project_io::add_edge(project, middle_id, sink_id);
+
+  const auto first = orc::project_to_dag(project);
+  ASSERT_NE(first, nullptr);
+
+  // Cutting the middle stage off from the source rebuilds it, because its own
+  // wiring changed. The sink's configuration and wiring are untouched — it
+  // still takes one input, still from the middle stage — but what the middle
+  // stage now produces is different, so anything the sink cached came from a
+  // graph that no longer exists.
+  orc::project_io::remove_edge(project, source_id, middle_id);
+  const auto second = orc::project_to_dag(project, first.get());
+  ASSERT_NE(second, nullptr);
+
+  EXPECT_NE(stage_of(second, middle_id), stage_of(first, middle_id));
+  EXPECT_NE(stage_of(second, sink_id), stage_of(first, sink_id));
+
+  // The source sits upstream of the change, so it keeps whatever it loaded.
+  // This is the whole point: an edit downstream must not cost a source reload.
+  EXPECT_EQ(stage_of(second, source_id), stage_of(first, source_id));
+}
+
+TEST(ProjectToDagContractTest, BuildsAFreshStage_WhenAParameterChanged) {
+  auto project = orc::project_io::create_empty_project(
+      "reparam-project", orc::VideoSystem::PAL, orc::SourceType::Composite);
+  const auto source_id =
+      orc::project_io::add_node(project, "PAL_CVBS_Source", 0.0, 0.0);
+  orc::project_io::set_node_parameters(
+      project, source_id,
+      {{"input_path", std::string("fixtures/before.cvbs")}});
+
+  const auto first = orc::project_to_dag(project);
+  ASSERT_NE(first, nullptr);
+
+  // Pointing the source somewhere else is exactly the case where the loaded
+  // representation must not survive.
+  orc::project_io::set_node_parameters(
+      project, source_id, {{"input_path", std::string("fixtures/after.cvbs")}});
+  const auto second = orc::project_to_dag(project, first.get());
+  ASSERT_NE(second, nullptr);
+
+  EXPECT_NE(stage_of(second, source_id), stage_of(first, source_id));
+}
+
+TEST(ProjectToDagContractTest, BuildsAFreshStage_WhenANodeIdChangedStage) {
+  const auto chain = find_representative_chain();
+  ASSERT_TRUE(chain.has_value());
+  ASSERT_NE(chain->middle, chain->sink);
+
+  // Built through update_project_dag() throughout, because it is the only way
+  // to put a different stage behind an id that is already in use. (It also
+  // preserves SOURCE nodes, so the two stages swapped here are not sources.)
+  auto project = orc::project_io::create_empty_project(
+      "restage-project", orc::VideoSystem::Unknown, orc::SourceType::Unknown);
+  const orc::NodeID node_id(1);
+
+  orc::project_io::update_project_dag(project,
+                                      {{node_id,
+                                        chain->middle,
+                                        orc::NodeType::TRANSFORM,
+                                        "Middle",
+                                        "Middle",
+                                        0.0,
+                                        0.0,
+                                        {}}},
+                                      {});
+  const auto first = orc::project_to_dag(project);
+  ASSERT_NE(first, nullptr);
+
+  // A node id can be re-used by a different stage type, and matching on the id
+  // alone would hand that stage the previous stage's object entirely.
+  orc::project_io::update_project_dag(project,
+                                      {{node_id,
+                                        chain->sink,
+                                        orc::NodeType::SINK,
+                                        "Sink",
+                                        "Sink",
+                                        0.0,
+                                        0.0,
+                                        {}}},
+                                      {});
+  const auto second = orc::project_to_dag(project, first.get());
+  ASSERT_NE(second, nullptr);
+
+  EXPECT_NE(stage_of(second, node_id), stage_of(first, node_id));
+}
+
+TEST(ProjectToDagContractTest, BuildsEveryStageFresh_WhenGivenNoPreviousDag) {
+  const auto chain = find_representative_chain();
+  ASSERT_TRUE(chain.has_value());
+
+  auto project = orc::project_io::create_empty_project(
+      "no-previous-project", orc::VideoSystem::Unknown,
+      orc::SourceType::Unknown);
+  const auto source_id =
+      orc::project_io::add_node(project, chain->source, 0.0, 0.0);
+
+  const auto first = orc::project_to_dag(project);
+  // The default: a build with no previous DAG owns its stages outright, which
+  // is what a throwaway conversion check relies on.
+  const auto second = orc::project_to_dag(project);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+
+  EXPECT_NE(stage_of(second, source_id), stage_of(first, source_id));
 }
 
 // ── DAG cloning for per-thread execution ─────────────────────────────────

--- a/orc-tests/gui/unit/CMakeLists.txt
+++ b/orc-tests/gui/unit/CMakeLists.txt
@@ -100,6 +100,7 @@ orc_add_gui_unit_tests(
             observation_status_formatter_test.cpp
             preview_audio_chase_test.cpp
             project_load_status_formatter_test.cpp
+            view_node_resolution_test.cpp
             quick_project_planner_test.cpp
             teletext_font_test.cpp
             closed_caption_assembler_test.cpp

--- a/orc-tests/gui/unit/view_node_resolution_test.cpp
+++ b/orc-tests/gui/unit/view_node_resolution_test.cpp
@@ -1,0 +1,89 @@
+/*
+ * File:        view_node_resolution_test.cpp
+ * Module:      orc-tests/gui/unit
+ * Purpose:     Tier 1 (gui-logic) tests for the post-rebuild viewed-node
+ *              decision
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "view_node_resolution.h"
+
+#include <gtest/gtest.h>
+
+namespace orc::gui {
+namespace {
+
+// The id MainWindow views while a project has no source. Negative, so it is
+// never a node the project can resolve.
+constexpr NodeID kNoSourcePlaceholder{-999};
+
+TEST(ViewNodeResolution, KeepsTheViewedNodeWhenTheRebuildLeftItInPlace) {
+  const auto decision = resolveViewNodeAfterRebuild(
+      NodeID(2), /*current_exists=*/true, NodeID(1));
+
+  EXPECT_EQ(decision.action, ViewNodeAction::Keep);
+  EXPECT_EQ(decision.target, NodeID(2));
+}
+
+TEST(ViewNodeResolution, SwitchesAwayFromANodeTheRebuildDeleted) {
+  // The regression this helper exists for: deleting the node being viewed
+  // leaves an id that is still is_valid() (it is >= 0), so a check written in
+  // terms of validity alone concluded there was nothing to do and left the
+  // preview addressing a node the DAG no longer had.
+  const auto decision = resolveViewNodeAfterRebuild(
+      NodeID(3), /*current_exists=*/false, NodeID(1));
+
+  EXPECT_EQ(decision.action, ViewNodeAction::Switch);
+  EXPECT_EQ(decision.target, NodeID(1));
+}
+
+TEST(ViewNodeResolution, SwitchesToTheFirstNodeWhenNothingWasViewedYet) {
+  const auto decision = resolveViewNodeAfterRebuild(
+      NodeID(), /*current_exists=*/false, NodeID(1));
+
+  EXPECT_EQ(decision.action, ViewNodeAction::Switch);
+  EXPECT_EQ(decision.target, NodeID(1));
+}
+
+TEST(ViewNodeResolution, LeavesThePlaceholderAsSoonAsARealNodeExists) {
+  const auto decision = resolveViewNodeAfterRebuild(
+      kNoSourcePlaceholder, /*current_exists=*/false, NodeID(1));
+
+  EXPECT_EQ(decision.action, ViewNodeAction::Switch);
+  EXPECT_EQ(decision.target, NodeID(1));
+}
+
+TEST(ViewNodeResolution, ClearsWhenTheRebuiltProjectHasNoNodesAtAll) {
+  // Deleting the last node: there is nothing to fall back to, and continuing
+  // to name the deleted node would send every later render at a dead id.
+  const auto decision = resolveViewNodeAfterRebuild(
+      NodeID(3), /*current_exists=*/false, NodeID());
+
+  EXPECT_EQ(decision.action, ViewNodeAction::Clear);
+  EXPECT_FALSE(decision.target.is_valid());
+}
+
+TEST(ViewNodeResolution, ClearsAnEmptyProjectRatherThanKeepingThePlaceholder) {
+  const auto decision = resolveViewNodeAfterRebuild(
+      kNoSourcePlaceholder, /*current_exists=*/false, NodeID());
+
+  EXPECT_EQ(decision.action, ViewNodeAction::Clear);
+  EXPECT_FALSE(decision.target.is_valid());
+}
+
+TEST(ViewNodeResolution, NeverKeepsAnIdTheProjectCannotResolve) {
+  // Whatever the id, "exists" is the only thing that licenses Keep.
+  for (const NodeID id :
+       {NodeID(), kNoSourcePlaceholder, NodeID(0), NodeID(7)}) {
+    EXPECT_NE(
+        resolveViewNodeAfterRebuild(id, /*current_exists=*/false, NodeID(1))
+            .action,
+        ViewNodeAction::Keep)
+        << "id " << id.to_string();
+  }
+}
+
+}  // namespace
+}  // namespace orc::gui

--- a/orc/core/include/project_to_dag.h
+++ b/orc/core/include/project_to_dag.h
@@ -56,7 +56,22 @@ class ProjectConversionError : public std::runtime_error {
  * 3. Set up edges and dependencies
  * 4. Validate the resulting DAG
  *
+ * A node whose stage, parameters and input wiring are all unchanged from
+ * @p previous keeps that build's stage instance rather than getting a fresh
+ * one. Stages are stateful, and what execute() accumulates behind them can be
+ * expensive: a source caches the representation it loaded, which for a long
+ * capture with a large dropout sidecar is seconds of work that an unrelated
+ * edit — deleting a link elsewhere in the graph — would otherwise throw away
+ * and pay again. Everything a node actually changed is still built fresh.
+ *
+ * Pass nullptr (the default) for a DAG that must own its stages outright: a
+ * throwaway built only to check the project converts, or the first build of a
+ * project. Note that this is not the thread-isolation primitive — a DAG to be
+ * executed on another thread wants clone_dag_with_fresh_stages().
+ *
  * @param project The project to convert
+ * @param previous Previous build of this project to carry unchanged stage
+ *                 instances over from, or nullptr to build every stage fresh
  * @return Executable DAG ready for rendering or execution
  * @throws ProjectConversionError if conversion fails
  *
@@ -72,7 +87,8 @@ class ProjectConversionError : public std::runtime_error {
  * auto result = renderer.render_frame_at_node("transform_1", FrameID(42));
  * ```
  */
-std::shared_ptr<DAG> project_to_dag(const Project& project);
+std::shared_ptr<DAG> project_to_dag(const Project& project,
+                                    const DAG* previous = nullptr);
 
 /**
  * @brief Resolve the file-path parameters of a node against the project root

--- a/orc/core/project_to_dag.cpp
+++ b/orc/core/project_to_dag.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <map>
 #include <sstream>
 
 #include "stage_registry.h"
@@ -156,7 +157,83 @@ void apply_input_node_ids_parameter(
   parameters[kInputNodeIdsParameter] = value;
 }
 
-std::shared_ptr<DAG> project_to_dag(const Project& project) {
+// Stage instances from |previous| that |nodes| can carry over, keyed by node
+// id.
+//
+// Rebuilding a DAG used to discard every stage object, and with it everything
+// execute() had accumulated behind them. That is invisible for most stages,
+// which recompute from their inputs anyway, but a source stage caches the
+// representation it loaded — for a long capture with a large dropout sidecar,
+// seconds of work — and would only load exactly the same thing again. Editing
+// a link somewhere else in the graph therefore cost a full source reload.
+//
+// A node is a candidate only when nothing about it changed:
+//
+//  - Same stage. A node id can be re-used by a different stage type.
+//  - Same effective parameters. This is the whole of a stage's configured
+//    state, so an unchanged map means an unchanged stage; it also covers the
+//    wiring of any stage that declares the reserved input-node-ids parameter,
+//    which is written into the map before this runs.
+//  - Same input wiring. Checked separately because a stage that does not
+//    declare that parameter has no other way to notice its inputs changed.
+//
+// Being unchanged in itself is not enough, though: a stage caches what it
+// computed, and what it computed came from its inputs. So the disqualification
+// propagates downstream — a node whose ancestry changed anywhere is rebuilt
+// too, even when its own configuration and immediate wiring are untouched.
+// That buys the invariant worth having: a carried-over instance holds state
+// produced by a subgraph identical to the one it now sits in. It costs nothing
+// in practice, because the expensive instances are sources, and a source is
+// upstream of everything — never downstream of an edit that spared it.
+std::map<NodeID, DAGStagePtr> reusable_stages(
+    const DAG* previous, const std::vector<DAGNode>& nodes) {
+  std::map<NodeID, DAGStagePtr> reusable;
+  if (!previous) return reusable;
+
+  std::map<NodeID, const DAGNode*> prior_index;
+  for (const auto& node : previous->nodes()) {
+    prior_index[node.node_id] = &node;
+  }
+
+  // Pass 1: the nodes that are unchanged in themselves.
+  for (const auto& node : nodes) {
+    const auto prior = prior_index.find(node.node_id);
+    if (prior == prior_index.end()) continue;
+
+    const DAGNode& before = *prior->second;
+    if (!before.stage || !node.stage) continue;
+    if (before.stage->get_node_type_info().stage_name !=
+        node.stage->get_node_type_info().stage_name) {
+      continue;
+    }
+    if (before.parameters != node.parameters) continue;
+    if (before.input_node_ids != node.input_node_ids) continue;
+
+    reusable[node.node_id] = before.stage;
+  }
+
+  // Pass 2: withdraw every node a rebuilt node feeds, transitively. Iterated to
+  // a fixpoint rather than walked in dependency order, because the project's
+  // node list carries no guarantee of being topologically sorted.
+  bool settled = false;
+  while (!settled) {
+    settled = true;
+    for (const auto& node : nodes) {
+      if (reusable.find(node.node_id) == reusable.end()) continue;
+      for (const auto& input_id : node.input_node_ids) {
+        if (reusable.find(input_id) != reusable.end()) continue;
+        reusable.erase(node.node_id);
+        settled = false;
+        break;
+      }
+    }
+  }
+
+  return reusable;
+}
+
+std::shared_ptr<DAG> project_to_dag(const Project& project,
+                                    const DAG* previous) {
   auto dag = std::make_shared<DAG>();
   auto& registry = StageRegistry::instance();
 
@@ -246,6 +323,26 @@ std::shared_ptr<DAG> project_to_dag(const Project& project) {
     dag_node.input_indices.assign(input_ids.size(), 0);  // Output index 0
 
     dag_nodes.push_back(dag_node);
+  }
+
+  // Carry unchanged stage instances over from the previous build, so whatever
+  // they had loaded survives the rebuild. The stages created above for those
+  // nodes are dropped: they were needed to read the descriptors that seed the
+  // parameter map, and building one costs nothing (a source's expense is in
+  // execute(), not in construction).
+  //
+  // Deliberately without re-applying the parameters to a carried-over
+  // instance. They are identical to the ones it was configured with, so
+  // set_parameters() could only be a no-op — or, for a stage that treats it as
+  // a reconfiguration and drops its caches, destroy the very state being
+  // preserved.
+  const auto reusable = reusable_stages(previous, dag_nodes);
+  for (auto& node : dag_nodes) {
+    const auto it = reusable.find(node.node_id);
+    if (it == reusable.end()) continue;
+    node.stage = it->second;
+    ORC_LOG_DEBUG("Node '{}': Reusing stage instance (unchanged)",
+                  node.node_id);
   }
 
   // Add all nodes to DAG

--- a/orc/gui/mainwindow.cpp
+++ b/orc/gui/mainwindow.cpp
@@ -55,6 +55,7 @@
 #include "vbidialog.h"
 #include "version.h"
 #include "videoparameterobserverdialog.h"
+#include "view_node_resolution.h"
 #include "waveformmonitordialog.h"
 
 // Forward declarations for core types used via opaque pointers
@@ -3854,6 +3855,23 @@ void MainWindow::refreshViewerControls(bool skip_preview) {
 void MainWindow::updatePreviewRenderer() {
   ORC_LOG_DEBUG("Updating preview renderer");
 
+  // Every caller has just rebuilt the DAG, and a rebuild replaces every stage
+  // object — so the source opens its file and sidecars again before the worker
+  // can answer what is previewable. On a long capture with a large dropout
+  // sidecar that is tens of seconds in which nothing in the window moves and
+  // the audio selector sits empty, which reads as "the audio has gone" rather
+  // than "the worker is busy". Cover the wait with the same modal a project
+  // open uses: it is armed here but only appears if the wait outlives the
+  // 400 ms show timer, so ordinary edits on small sources never flash it.
+  //
+  // A project open has already armed it around this call; that one owns its
+  // dialog and retires it itself, so only arm (and retire) what we started.
+  const bool armed_progress_here = !project_load_in_progress_;
+  const uint64_t outputs_request_before_rebuild = pending_outputs_request_id_;
+  if (armed_progress_here) {
+    beginProjectLoadProgress("Rebuilding Preview");
+  }
+
   // A playback reader holds the representation it was created from alive, so
   // any DAG or parameter edit makes it stale. Stop playback and drop it before
   // the worker rebuilds; the selector repopulates with the refreshed outputs.
@@ -3885,49 +3903,69 @@ void MainWindow::updatePreviewRenderer() {
   // Send DAG update to coordinator (thread-safe)
   render_coordinator_->updateDAG(dag);
 
-  // Check if current node is still valid, or if we need to switch
-  bool need_to_switch = false;
-  if (current_view_node_id_.is_valid() == false) {
-    // No node selected yet - use suggestion
-    need_to_switch = true;
-  } else {
-    // Check if current node still exists using presenter
-    bool current_exists = project_.presenter()->hasNode(current_view_node_id_);
+  // Decide what the preview should be looking at now. The rebuild may have
+  // deleted the viewed node, and a project open rebuilds into a project that
+  // has nothing in common with the last one. See resolveViewNodeAfterRebuild()
+  // for why "the id is valid" is not the same question as "the node exists".
+  //
+  // Note: could implement coordinator->requestSuggestedViewNode() to get a
+  // smarter fallback than the first node (e.g. prefer sinks, or the
+  // best-connected node); the first node is adequate for typical workflows.
+  const bool current_exists =
+      current_view_node_id_.is_valid() &&
+      project_.presenter()->hasNode(current_view_node_id_);
+  const auto view_decision = orc::gui::resolveViewNodeAfterRebuild(
+      current_view_node_id_, current_exists,
+      project_.presenter()->getFirstNode());
 
-    // If current node was deleted or is placeholder when real nodes exist,
-    // switch
-    if ((!current_exists && current_view_node_id_ != NodeID(-999)) ||
-        (current_view_node_id_ == NodeID(-999) &&
-         project_.presenter()->getFirstNode().is_valid())) {
-      need_to_switch = true;
-    }
-  }
-
-  // Node selection logic: The coordinator now handles renderer updates
-  // internally. When we need to switch nodes (e.g., current was deleted), we'll
-  // request outputs for the new node, and onAvailableOutputsReady will handle
-  // the rest.
-  if (need_to_switch) {
-    // Note: Could implement coordinator->requestSuggestedViewNode() to get a
-    // smart suggestion (e.g., prefer sink nodes, or nodes with most
-    // connections). Current approach: Simple fallback to first node is adequate
-    // for typical workflows.
-    ORC_LOG_DEBUG("Node switching needed - using first node fallback");
-    if (current_view_node_id_.is_valid() == false) {
-      // Pick first node as temporary fallback
-      NodeID first_node = project_.presenter()->getFirstNode();
-      if (first_node.is_valid()) {
-        selectStageInDAG(first_node);
-      }
-    }
-  } else {
-    // Keep current node - request fresh outputs in case parameters changed
-    if (current_view_node_id_.is_valid()) {
+  switch (view_decision.action) {
+    case orc::gui::ViewNodeAction::Keep:
+      // Parameters may have changed under it, so its outputs are re-read.
+      // onAvailableOutputsReady() picks up from there.
       ORC_LOG_DEBUG("Keeping current node '{}', refreshing outputs",
                     current_view_node_id_.to_string());
       pending_outputs_request_id_ =
           render_coordinator_->requestAvailableOutputs(current_view_node_id_);
+      break;
+
+    case orc::gui::ViewNodeAction::Switch:
+      ORC_LOG_DEBUG(
+          "Viewed node '{}' is not in the rebuilt DAG - switching to "
+          "first node '{}'",
+          current_view_node_id_.to_string(), view_decision.target.to_string());
+      // Selecting in the scene is what drives onNodeSelectedForView(), which
+      // adopts the node and asks for its outputs and audio pairs.
+      selectStageInDAG(view_decision.target);
+      break;
+
+    case orc::gui::ViewNodeAction::Clear:
+      ORC_LOG_DEBUG("Rebuilt DAG has no nodes - nothing to view");
+      break;
+  }
+
+  // selectStageInDAG() only asks the DAG scene to move its selection, and does
+  // nothing when the scene has not caught up with the rebuilt project — a
+  // project open calls us before loadProjectDAG(), and selects a stage of its
+  // own once the scene is populated. Whichever way the switch failed to take,
+  // the viewed node must not be left naming a node the project does not have:
+  // every render, output query and audio enumeration sent to it can only fail.
+  if (view_decision.action != orc::gui::ViewNodeAction::Keep &&
+      current_view_node_id_.is_valid() &&
+      !project_.presenter()->hasNode(current_view_node_id_)) {
+    ORC_LOG_DEBUG("Dropping stale viewed node '{}'",
+                  current_view_node_id_.to_string());
+    current_view_node_id_ = NodeID();
+    if (preview_dialog_) {
+      preview_dialog_->setCurrentNodeId(current_view_node_id_);
     }
+  }
+
+  // No available-outputs request went out (nothing selectable in the rebuilt
+  // DAG), so nothing will arrive to retire the modal — and it has no cancel
+  // button, so leaving it armed would wedge the window.
+  if (armed_progress_here &&
+      pending_outputs_request_id_ == outputs_request_before_rebuild) {
+    endProjectLoadProgress();
   }
 }
 
@@ -5169,7 +5207,7 @@ void MainWindow::endPreviewRenderInFlight() {
   preview_render_in_flight_ = false;
 }
 
-void MainWindow::beginProjectLoadProgress() {
+void MainWindow::beginProjectLoadProgress(const QString& title) {
   // A load already in progress keeps its dialog and its elapsed time.
   if (project_load_in_progress_) {
     return;
@@ -5187,7 +5225,7 @@ void MainWindow::beginProjectLoadProgress() {
   // timer decides whether the load lasts long enough to warrant a dialog.
   auto* dialog = new QProgressDialog("Preparing preview\xE2\x80\xA6", QString(),
                                      0, 0, this);
-  dialog->setWindowTitle("Opening Project");
+  dialog->setWindowTitle(title);
   dialog->setWindowModality(Qt::ApplicationModal);
   dialog->setCancelButton(nullptr);
   dialog->setAutoClose(false);

--- a/orc/gui/mainwindow.h
+++ b/orc/gui/mainwindow.h
@@ -277,7 +277,12 @@ class MainWindow : public QMainWindow {
   // enough that the window otherwise looks hung — the preview only appears when
   // the available-outputs response lands. begin/update/end drive a modal
   // progress dialog across exactly that window.
-  void beginProjectLoadProgress();
+  //
+  // Editing the DAG pays the same cost for the same reason (the rebuild
+  // replaces every stage object, so the source is opened again), so
+  // updatePreviewRenderer() arms this too; |title| names which of the two the
+  // user is waiting on.
+  void beginProjectLoadProgress(const QString& title = "Opening Project");
   void updateProjectLoadProgressLabel();
   void endProjectLoadProgress();
   void closeAllDialogs();  ///< Close all open dialogs when switching projects

--- a/orc/gui/view_node_resolution.h
+++ b/orc/gui/view_node_resolution.h
@@ -1,0 +1,69 @@
+/*
+ * File:        view_node_resolution.h
+ * Module:      orc-gui
+ * Purpose:     Pure helper that decides which node the preview should view
+ *              after the DAG has been rebuilt (Tier 1 / gui-logic testable)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#ifndef VIEW_NODE_RESOLUTION_H
+#define VIEW_NODE_RESOLUTION_H
+
+#include <orc/stage/node_id.h>
+
+namespace orc::gui {
+
+/// What should happen to the viewed node once the DAG has been rebuilt.
+enum class ViewNodeAction {
+  Keep,    ///< The viewed node survived; refresh its outputs in place.
+  Switch,  ///< It did not; view ViewNodeDecision::target instead.
+  Clear,   ///< There is nothing left to view; stop naming a node at all.
+};
+
+struct ViewNodeDecision {
+  ViewNodeAction action{ViewNodeAction::Clear};
+  /// The node to view. Meaningful for Keep and Switch; invalid for Clear.
+  NodeID target{};
+};
+
+/**
+ * @brief Decide which node the preview should be looking at after a rebuild.
+ *
+ * Rebuilding the DAG can delete the node being viewed, and a project open
+ * rebuilds into a project that has nothing in common with the previous one.
+ * Exactly one question decides the outcome: does the rebuilt project still
+ * have the node whose output is on screen?
+ *
+ * The distinction that matters is between an id that is *unset* and one that
+ * is *stale*. NodeID::is_valid() only asks whether the id is non-negative, so
+ * a node that has just been deleted still reports valid — it names something
+ * real, just not something that exists any more. Treating "valid" as "usable"
+ * is what let a delete leave the preview addressing a node the DAG no longer
+ * had, so |current_exists| is asked for separately and both must hold.
+ *
+ * The placeholder id used when a project has no source is negative, so it is
+ * covered by the same "not usable" path and switches to a real node as soon
+ * as one exists.
+ *
+ * @param current        Node currently being viewed; may be unset or stale.
+ * @param current_exists Whether the rebuilt project still has |current|.
+ * @param first_node     Fallback node to view, or an invalid id if the project
+ *                       has no nodes at all.
+ */
+inline ViewNodeDecision resolveViewNodeAfterRebuild(NodeID current,
+                                                    bool current_exists,
+                                                    NodeID first_node) {
+  if (current.is_valid() && current_exists) {
+    return {ViewNodeAction::Keep, current};
+  }
+  if (first_node.is_valid()) {
+    return {ViewNodeAction::Switch, first_node};
+  }
+  return {ViewNodeAction::Clear, NodeID()};
+}
+
+}  // namespace orc::gui
+
+#endif  // VIEW_NODE_RESOLUTION_H

--- a/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
+++ b/orc/plugins/stages/cvbs_source/cvbs_source_stage.cpp
@@ -748,9 +748,15 @@ class CVBSSourceStageDeps final : public ICVBSSourceStageDeps {
       return {};
     }
 
+    // ORDER BY leads with cvbs_file_id so the scan can walk the primary-key
+    // index instead of sorting the whole table in a temp B-tree: a sidecar
+    // holds runs for exactly one CVBS file, so the emitted order is the same
+    // (frame_id, sample_start) sequence either way.  On a feature-length
+    // Domesday capture (20.7 M runs) that is the difference between roughly
+    // 18 and 6 seconds.
     constexpr const char* kSql =
         "SELECT frame_id, sample_start, sample_count, severity "
-        "FROM dropout_run ORDER BY frame_id, sample_start";
+        "FROM dropout_run ORDER BY cvbs_file_id, frame_id, sample_start";
 
     sqlite3_stmt* stmt = nullptr;
     if (sqlite3_prepare_v2(db, kSql, -1, &stmt, nullptr) != SQLITE_OK) {
@@ -760,6 +766,13 @@ class CVBSSourceStageDeps final : public ICVBSSourceStageDeps {
       return {};
     }
 
+    // The vector is deliberately not reserve()d.  A sidecar this size holds
+    // ~500 MB of runs, so an exact reservation does save the reallocation
+    // copies — but measured on a 20.7 M-run sidecar it is worth only ~0.4 s of
+    // a 5.6 s load, while the "SELECT count(*)" needed to size it costs 8.7 s
+    // on its own: SQLite answers it with a covering-index scan, which still
+    // walks all 20.7 M entries.  Paying that to save the copies is a 20x bad
+    // trade, and no cheaper exact count is available.
     std::vector<DropoutRun> runs;
     while (sqlite3_step(stmt) == SQLITE_ROW) {
       DropoutRun run;

--- a/orc/presenters/src/project_presenter.cpp
+++ b/orc/presenters/src/project_presenter.cpp
@@ -1892,8 +1892,14 @@ std::shared_ptr<void> ProjectPresenter::buildDAG() {
   if (!project_.get()) return nullptr;
 
   try {
-    // Build and cache the DAG
-    dag_ = std::static_pointer_cast<void>(orc::project_to_dag(*getProject()));
+    // The build this one replaces is offered as the source of stage instances
+    // for nodes the edit did not touch, so an unrelated change (deleting a
+    // link, adding a stage) no longer makes every source reload its file. The
+    // previous DAG is kept alive across the call by this local, because dag_
+    // is only reassigned once the new build has succeeded.
+    const auto previous = std::static_pointer_cast<orc::DAG>(dag_);
+    dag_ = std::static_pointer_cast<void>(
+        orc::project_to_dag(*getProject(), previous.get()));
     return dag_;
   } catch (const std::exception&) {
     dag_.reset();


### PR DESCRIPTION
## Summary

Editing the DAG on a project with a large source could stall the GUI for tens of
seconds with no feedback, and left the preview in a state that looked like data
had gone missing. Investigating a report that deleting the EFM audio stage made
*every* stage stop offering audio preview turned up four separate causes.

**The audio never went away — the render worker never got to answer.** The
preview dialog clears its audio-pair selector on every node change and relies on
an async re-enumeration to repopulate it. That request sat in the worker's FIFO
queue behind a source reload, so the selector stayed empty on every node, which
reads as "this project has no audio" rather than "the worker is busy". Nothing
was corrupted; the answer was ~30 s late.

**Each of the four fixes addresses one link in that chain:**

1. **The dropout sidecar load was doing an unindexable sort.** `load_dropout_sidecar()`
   ordered by `frame_id, sample_start`, but both indexes on `dropout_run` are
   prefixed with `cvbs_file_id`, so SQLite fell back to a full scan plus a
   disk-spilling temp B-tree over all rows. Leading the `ORDER BY` with
   `cvbs_file_id` turns that into a plain index scan. A sidecar holds runs for
   exactly one CVBS file, so the emitted order is unchanged.

2. **Every DAG rebuild threw away every stage instance.** `project_to_dag()`
   called `registry.create_stage()` unconditionally for all nodes, so deleting a
   link between two unrelated stages destroyed the source and its loaded
   representation, and the next execute reloaded the file from scratch. It now
   takes an optional previous DAG and carries instances over for nodes whose
   stage, effective parameters and input wiring are all unchanged.

   The disqualification propagates downstream: a node whose ancestry changed
   anywhere is rebuilt too, even when its own configuration and wiring are
   untouched. Without that, cutting `source → A` would rebuild A but carry over
   B, leaving B holding a `cached_output_` computed from a graph that no longer
   exists — trading an empty cache for a stale one. The invariant is now that a
   carried-over instance holds state produced by a subgraph identical to the one
   it sits in. It costs nothing in practice: the expensive instances are sources,
   and a source is never downstream of an edit that spared it.

   `clone_dag_with_fresh_stages()` is deliberately untouched — it exists to *not*
   share instances, so the background observation pool keeps its per-thread
   stages.

3. **A slow rebuild gave no feedback at all.** `updatePreviewRenderer()` now arms
   the existing project-load modal, which appears only if the wait outlives its
   400 ms show timer, titled "Rebuilding Preview" rather than "Opening Project".
   Two guards keep it honest: only the call that armed it retires it (so a
   project open's own modal is unaffected), and it is retired immediately if no
   available-outputs request went out, since the dialog has no cancel button.

4. **Deleting the viewed node left the preview addressing a node that was gone.**
   `NodeID::is_valid()` is just `id_ >= 0`, so a deleted node still reports valid.
   Three conditions set `need_to_switch`, but the action was gated on "nothing
   selected yet" — which a deleted node fails. The branch logged its intention
   and did nothing, and every later render, output query and audio enumeration
   was sent to a node the DAG no longer had. Since the bug was a mis-encoded case
   analysis, the decision is extracted into a pure helper
   (`resolveViewNodeAfterRebuild()`) that asks about existence separately from
   validity. A backstop drops the id if the switch could not take, which happens
   when the DAG scene has not caught up with the project yet.

Measured on a 54,000-frame PAL capture with a 1.15 GB dropout sidecar
(20,731,505 runs): the sidecar load drops from **20.7 s to 5.6 s**, and edits
that do not touch the source no longer pay it at all.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Validation

**Full suite: 3632 passed, 0 failed** (includes `ClangFormatCheck` and
`MVPArchitectureCheck`).

New tests:

- `project_to_dag_contract_test.cpp` — six contract tests, one per reuse rule:
  reuse for untouched nodes; fresh on changed wiring; fresh on changed
  parameters; fresh when a node id changes stage; fresh downstream of a change
  (asserting the source is still reused in the same build); fresh throughout when
  no previous DAG is given.
- `view_node_resolution_test.cpp` — seven gui-logic tests covering each branch of
  the viewed-node decision, with the deleted-node regression named explicitly.

The SQL change was verified against the real 1.15 GB sidecar rather than a
fixture, since the behaviour is a query-planner property:

- `EXPLAIN QUERY PLAN` goes from `SCAN dropout_run` + `USE TEMP B-TREE FOR ORDER BY`
  to `SCAN dropout_run USING INDEX sqlite_autoindex_dropout_run_1`.
- A purpose-built benchmark of the loader produced a **bit-identical
  order-sensitive checksum** over all 20.7 M runs before and after, confirming
  the row sequence is unchanged.

One thing that measurement changed: I had also intended to `reserve()` the runs
vector from a `SELECT count(*)`. Benchmarking showed that makes it **worse** —
`count(*)` costs 8.7 s on its own (it is a covering-index scan, but the index
still has 20.7 M entries), while an exact reservation saves only ~0.4 s of a
5.6 s load. The reserve was dropped and the numbers recorded in a comment so it
does not get re-added.

Not yet driven through the real GUI against the original project. The two log
lines to watch for are `Node '1': Reusing stage instance (unchanged)` and the
disappearance of the per-rebuild `VideoSink: decoder_type changed from 'ntsc2d'
to 'pal2d'`.

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [ ] Related docs were updated if needed
- [x] Linked issue (if applicable)

