### PR TITLE
Issue 307

### DIFF
--- a/docs/gui-user-guide/stages/transform-stages.md
+++ b/docs/gui-user-guide/stages/transform-stages.md
@@ -215,14 +215,16 @@ If only **1 input** is provided, the stage acts as a passthrough.
 * `efm_stacking` (string)
     - How to combine EFM t-values across sources.
     - Allowed values:
-        - `Disabled` (use EFM from the source with the fewest dropouts)
+        - `Disabled` (use EFM from the source with the fewest dropouts, bytes untouched)
+        - `Confidence` (align the sources on the EFM frame-sync grid and let them vote on each transition, weighted by the doubt each recorded)
         - `Mean`
         - `Median`
-    - Default: `Mean`.
+    - Default: `Confidence`.
 
 **Notes**
 
 * Stacking reduces noise only when the sources contain independent noise (separate captures). Sources that are identical apart from dropouts stack to the same underlying signal, so SNR will not improve on dropout-free picture areas.
+* `Mean` and `Median` combine EFM by sample index, which only holds while the sources stay in step: EFM t-values are run lengths, so a single spurious or missed transition in one capture shifts every t-value after it and the streams are then averaged out of step for the rest of the video frame. They also emit averages that no source reported. `Confidence` combines on the channel bit axis and re-anchors on the frame sync every 588 bits, so an insertion or a deletion costs at most the channel frame it is in, and it emits a doubt of its own that `efm_sink` and `efm_audio_decode` can use as an error-correction erasure hint. Prefer it unless you are reproducing an earlier result.
 
 **Analysis / preview tools**
 

--- a/docs/gui-user-guide/stages/transform-stages.md
+++ b/docs/gui-user-guide/stages/transform-stages.md
@@ -216,14 +216,15 @@ If only **1 input** is provided, the stage acts as a passthrough.
     - How to combine EFM t-values across sources.
     - Allowed values:
         - `Disabled` (use EFM from the source with the fewest dropouts, bytes untouched)
-        - `Confidence` (align the sources on the EFM frame-sync grid and let them vote on each transition, weighted by the doubt each recorded)
+        - `Confidence` (align the sources on the EFM frame-sync grid and let them vote on each transition, weighted by the doubt each recorded) — experimental
         - `Mean`
         - `Median`
-    - Default: `Confidence`.
+    - Default: `Disabled`.
 
 **Notes**
 
 * Stacking reduces noise only when the sources contain independent noise (separate captures). Sources that are identical apart from dropouts stack to the same underlying signal, so SNR will not improve on dropout-free picture areas.
+* EFM combining is off by default because none of the modes has yet been shown to beat passing the best single source through. On six independent captures of one Domesday side, the best source alone recovered 21,695 sectors with 8 uncorrectable; `Confidence` managed 21,577 with 140, and `Mean` just 5. Only `Disabled` is recommended for production use; `Confidence` is experimental.
 * `Mean` and `Median` combine EFM by sample index, which only holds while the sources stay in step: EFM t-values are run lengths, so a single spurious or missed transition in one capture shifts every t-value after it and the streams are then averaged out of step for the rest of the video frame. They also emit averages that no source reported. `Confidence` combines on the channel bit axis and re-anchors on the frame sync every 588 bits, so an insertion or a deletion costs at most the channel frame it is in, and it emits a doubt of its own that `efm_sink` and `efm_audio_decode` can use as an error-correction erasure hint. Prefer it unless you are reproducing an earlier result.
 
 **Analysis / preview tools**

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -140,6 +140,7 @@ orc_add_core_unit_tests(
         "unit;transforms"
 
         stages/stacker/stacker_stage_test.cpp
+        stages/stacker/efm_confidence_stack_test.cpp
         stages/frame_map/frame_map_stage_test.cpp
         stages/source_join/source_join_stage_test.cpp
         analysis/frame_map_range_search_test.cpp

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -334,6 +334,29 @@ gtest_discover_tests(orc-core-unit-tests-efm-reedsolomon-padding
         DISCOVERY_TIMEOUT 30
         PROPERTIES LABELS "unit\;sinks")
 
+# Issue #307: the producer's per-t-value doubt must survive EFM framing and be
+# attributed to the F3 symbols it contributed to, and the CIRC must seed C1/C2
+# erasures from it without ever exceeding the code's erasure capacity.
+add_executable(orc-core-unit-tests-efm-doubt-attribution
+        stages/efm_common/efm_doubt_attribution_test.cpp)
+target_link_libraries(orc-core-unit-tests-efm-doubt-attribution
+        orc-efm-decode
+        GTest::gmock_main)
+gtest_discover_tests(orc-core-unit-tests-efm-doubt-attribution
+        DISCOVERY_MODE POST_BUILD
+        DISCOVERY_TIMEOUT 30
+        PROPERTIES LABELS "unit\;sinks")
+
+add_executable(orc-core-unit-tests-efm-doubt-erasure
+        stages/efm_common/reedsolomon_doubt_erasure_test.cpp)
+target_link_libraries(orc-core-unit-tests-efm-doubt-erasure
+        orc-efm-decode
+        GTest::gmock_main)
+gtest_discover_tests(orc-core-unit-tests-efm-doubt-erasure
+        DISCOVERY_MODE POST_BUILD
+        DISCOVERY_TIMEOUT 30
+        PROPERTIES LABELS "unit\;sinks")
+
 # End-of-stream Q-channel metadata: a trailing run of CRC-failure sections must
 # have its timeline continued from the last valid section instead of being
 # emitted with the default (track 0, 00:00:00) metadata.

--- a/orc-tests/core/unit/stages/efm_common/efm_doubt_attribution_test.cpp
+++ b/orc-tests/core/unit/stages/efm_common/efm_doubt_attribution_test.cpp
@@ -1,0 +1,177 @@
+/*
+ * File:        efm_doubt_attribution_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Unit tests for issue #307 - carrying the producer's per-t-value
+ *              doubt through EFM framing and attributing it to F3 symbols
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include <gtest/gtest.h>
+#include <orc/stage/video_frame_representation.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "dec_channeltof3frame.h"
+#include "dec_tvaluestochannel.h"
+#include "efm_constants.h"
+
+namespace {
+
+// A whole EFM channel frame's worth of T3 pulses: 588 / 3 = 196 exactly
+// (IEC 60908 §18 - a channel frame is 588 channel bits). Using a single
+// T-value throughout makes the bit position of every T-value trivially
+// predictable: T-value k occupies channel bits [3k, 3k+2].
+constexpr int kTValue = 3;
+constexpr int kTValuesPerFrame = efm::kEfmFrameChannelBits / kTValue;  // 196
+
+std::vector<uint8_t> uniformFrame(uint8_t doubt) {
+  return std::vector<uint8_t>(kTValuesPerFrame, orc::efm_pack(kTValue, doubt));
+}
+
+// The 32 data symbols start at channel bit 44 and repeat every 17 bits
+// (14 symbol bits + 3 merging bits).
+constexpr int kFirstDataBit = 44;
+constexpr int kBitsPerSymbol = 17;
+
+F3Frame decodeOneFrame(const std::vector<uint8_t>& tValues,
+                       bool collectDoubt = true) {
+  ChannelToF3Frame decoder;
+  decoder.setCollectDoubt(collectDoubt);
+  decoder.pushFrame(tValues);
+  EXPECT_TRUE(decoder.isReady());
+  return decoder.popFrame();
+}
+
+// ---------------------------------------------------------------------------
+// T-value framing
+// ---------------------------------------------------------------------------
+
+// The framing state machine reads T-values out of packed bytes, so it must
+// match a sync pair on the T-value alone - a T11 the producer distrusts is
+// still a T11. If it compared whole bytes, a doubted sync would be invisible
+// and the frame would be lost.
+TEST(EfmDoubtFraming, FindsASyncHeaderCarryingANonZeroDoubtNibble) {
+  TvaluesToChannel framer;
+
+  // Two frames of T3 bracketed by doubted T11+T11 sync pairs, plus enough
+  // trailing input to push the state machine past its buffer watermark.
+  std::vector<uint8_t> stream;
+  const uint8_t doubtedSync = orc::efm_pack(efm::kSyncSymbolT11, 15);
+  for (int frame = 0; frame < 4; ++frame) {
+    stream.push_back(doubtedSync);
+    stream.push_back(doubtedSync);
+    // 588 - 22 sync bits = 566 bits; 188 T3s plus a T2 pad is close enough
+    // for the framer's 550-600 bit acceptance band.
+    for (int i = 0; i < 188; ++i) {
+      stream.push_back(orc::efm_pack(kTValue, 0));
+    }
+  }
+  framer.pushFrame(stream);
+
+  ASSERT_TRUE(framer.isReady());
+  const std::vector<uint8_t> frame = framer.popFrame();
+  ASSERT_GE(frame.size(), 2u);
+  // The frame starts at the sync pair, doubt nibble intact.
+  EXPECT_EQ(frame[0], doubtedSync);
+  EXPECT_EQ(frame[1], doubtedSync);
+}
+
+// ---------------------------------------------------------------------------
+// Symbol attribution
+// ---------------------------------------------------------------------------
+
+// An .efm from a producer with no confidence information is all-zero doubt.
+// Such a frame must leave the doubt vector unset, so nothing downstream pays
+// for information that does not exist.
+TEST(EfmDoubtAttribution, LeavesDoubtUnsetWhenEveryTValueIsTrusted) {
+  const F3Frame frame = decodeOneFrame(uniformFrame(0));
+  EXPECT_TRUE(frame.doubtData().empty());
+}
+
+// Attributing the doubt is per-T-value work in the hottest loop of the decode,
+// so it must stay off until something downstream asks for it. A decoder that
+// was never told to collect it must produce the same frames as before the
+// doubt existed.
+TEST(EfmDoubtAttribution, CollectsNoDoubtUnlessAskedTo) {
+  const F3Frame frame = decodeOneFrame(uniformFrame(15), false);
+  EXPECT_TRUE(frame.doubtData().empty());
+
+  const F3Frame asked = decodeOneFrame(uniformFrame(15), true);
+  EXPECT_EQ(asked.doubtData().size(), 32u);
+  EXPECT_EQ(asked.data(), frame.data());
+  EXPECT_EQ(asked.errorData(), frame.errorData());
+}
+
+TEST(EfmDoubtAttribution, AttributesUniformDoubtToEverySymbol) {
+  const F3Frame frame = decodeOneFrame(uniformFrame(15));
+
+  const std::vector<uint8_t>& doubt = frame.doubtData();
+  ASSERT_EQ(doubt.size(), 32u);
+  for (size_t symbol = 0; symbol < doubt.size(); ++symbol) {
+    EXPECT_EQ(doubt[symbol], 15) << "symbol " << symbol;
+  }
+}
+
+// A single doubted T-value must reach only the symbols whose channel bits it
+// actually contributed to. T-value 20 spans bits 60-62, which lie inside
+// symbol 1 (bits 61-74) and no other.
+TEST(EfmDoubtAttribution, ConfinesDoubtToTheSymbolsTheTValueOverlaps) {
+  std::vector<uint8_t> tValues = uniformFrame(0);
+  constexpr int kDoubtedTValue = 20;
+  tValues[kDoubtedTValue] = orc::efm_pack(kTValue, 11);
+
+  // The bits this T-value produced, and the symbol range they fall in.
+  const int firstBit = kDoubtedTValue * kTValue;
+  const int lastBit = firstBit + kTValue - 1;
+  ASSERT_EQ(firstBit, 60);
+  ASSERT_EQ(lastBit, 62);
+
+  const F3Frame frame = decodeOneFrame(tValues);
+  const std::vector<uint8_t>& doubt = frame.doubtData();
+  ASSERT_EQ(doubt.size(), 32u);
+
+  for (int symbol = 0; symbol < 32; ++symbol) {
+    const int symbolFirst = kFirstDataBit + symbol * kBitsPerSymbol;
+    const int symbolLast = symbolFirst + 13;
+    const bool overlaps = symbolFirst <= lastBit && symbolLast >= firstBit;
+    EXPECT_EQ(doubt[symbol], overlaps ? 11 : 0) << "symbol " << symbol;
+  }
+  // Guard the fixture itself: exactly one symbol should be affected.
+  EXPECT_EQ(doubt[1], 11);
+  EXPECT_EQ(doubt[0], 0);
+  EXPECT_EQ(doubt[2], 0);
+}
+
+// A 14-bit symbol is wrong if any one of its bits is wrong, so a symbol built
+// from a trusted and a distrusted T-value takes the larger doubt, not a mean.
+TEST(EfmDoubtAttribution, TakesTheGreatestDoubtOfTheContributingTValues) {
+  std::vector<uint8_t> tValues = uniformFrame(0);
+  // Symbol 1 spans bits 61-74, i.e. T-values 20 through 24.
+  tValues[21] = orc::efm_pack(kTValue, 4);
+  tValues[22] = orc::efm_pack(kTValue, 12);
+  tValues[23] = orc::efm_pack(kTValue, 7);
+
+  const F3Frame frame = decodeOneFrame(tValues);
+  ASSERT_EQ(frame.doubtData().size(), 32u);
+  EXPECT_EQ(frame.doubtData()[1], 12);
+}
+
+// The bit count that decides whether a frame is well-formed must read the
+// T-value only; counting the packed byte would multiply every doubted pulse
+// and make clean frames look like gross overshoots.
+TEST(EfmDoubtAttribution, DoesNotCountTheDoubtNibbleAsChannelBits) {
+  // Same frame twice, once trusted and once wholly distrusted: the decoded
+  // symbols must be identical.
+  const F3Frame trusted = decodeOneFrame(uniformFrame(0));
+  const F3Frame distrusted = decodeOneFrame(uniformFrame(15));
+
+  EXPECT_EQ(trusted.data(), distrusted.data());
+  EXPECT_EQ(trusted.errorData(), distrusted.errorData());
+  EXPECT_EQ(trusted.f3FrameType(), distrusted.f3FrameType());
+  EXPECT_EQ(trusted.subcodeByte(), distrusted.subcodeByte());
+}
+
+}  // namespace

--- a/orc-tests/core/unit/stages/efm_common/reedsolomon_doubt_erasure_test.cpp
+++ b/orc-tests/core/unit/stages/efm_common/reedsolomon_doubt_erasure_test.cpp
@@ -1,0 +1,315 @@
+/*
+ * File:        reedsolomon_doubt_erasure_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Unit tests for issue #307 - seeding CIRC C1/C2 erasures from
+ *              the producer's per-symbol doubt
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "reedsolomon.h"
+
+namespace {
+
+// The all-zero word is a valid Reed-Solomon codeword, so any symbol set to a
+// non-zero value is an error the decoder has to find. That makes it the
+// simplest way to build a word with a known number of errors in known places.
+std::vector<uint8_t> zeroWord(size_t size) {
+  return std::vector<uint8_t>(size, 0);
+}
+
+// The doubt threshold used throughout: the suggested production default.
+constexpr uint8_t kThreshold = 13;
+
+// ---------------------------------------------------------------------------
+// Off by default
+// ---------------------------------------------------------------------------
+
+// A decoder that was never told a threshold must behave exactly as it did
+// before issue #307, whatever doubt the producer supplied.
+TEST(ReedSolomonDoubt_C1, IgnoresDoubtWhenThresholdIsUnset) {
+  ReedSolomon circ;
+  std::vector<uint8_t> data = zeroWord(32);
+  std::vector<uint8_t> errors = zeroWord(32);
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt(32, 15);
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  EXPECT_EQ(circ.doubtErasuresC1(), 0);
+  EXPECT_EQ(circ.doubtSeededC1s(), 0);
+  EXPECT_EQ(circ.validC1s(), 1);
+}
+
+// An explicit threshold of 0 is the documented "disabled" setting; doubt 0 is
+// the fully-trusted value, so it must not be read as "flag everything".
+TEST(ReedSolomonDoubt_C1, ThresholdZeroDisablesSeeding) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(0);
+  std::vector<uint8_t> data = zeroWord(32);
+  std::vector<uint8_t> errors = zeroWord(32);
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  EXPECT_EQ(circ.doubtErasuresC1(), 0);
+}
+
+TEST(ReedSolomonDoubt_C1, IgnoresDoubtBelowTheThreshold) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(32);
+  std::vector<uint8_t> errors = zeroWord(32);
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
+  doubt[3] = kThreshold - 1;
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  EXPECT_EQ(circ.doubtErasuresC1(), 0);
+  EXPECT_EQ(circ.doubtSeededC1s(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// The point of the exercise: doubt turns unknown errors into erasures
+// ---------------------------------------------------------------------------
+
+// Three symbol errors need 2e = 6 > 4 of capacity when their positions are
+// unknown, so C1 cannot correct them. Told where they are, the same word needs
+// s = 3 and decodes. This is the whole mechanism of issue #307 in one test:
+// nothing else in the decoder can see these errors, because a wrong symbol
+// that is still a legal EFM codeword raises no erasure of its own.
+TEST(ReedSolomonDoubt_C1, CorrectsThreeErrorsThatAreUncorrectableUnlocated) {
+  std::vector<uint8_t> corrupted = zeroWord(32);
+  corrupted[2] = 0x5A;
+  corrupted[9] = 0x33;
+  corrupted[17] = 0xC7;
+
+  // Without the doubt: too many unlocated errors, the word is rejected.
+  {
+    ReedSolomon circ;
+    std::vector<uint8_t> data = corrupted;
+    std::vector<uint8_t> errors = zeroWord(32);
+    std::vector<uint8_t> padded = zeroWord(32);
+    std::vector<uint8_t> doubt = zeroWord(32);
+
+    circ.c1Decode(data, errors, padded, doubt);
+
+    EXPECT_EQ(circ.errorC1s(), 1);
+    EXPECT_EQ(circ.fixedC1s(), 0);
+  }
+
+  // With the doubt naming the same three positions: corrected.
+  {
+    ReedSolomon circ;
+    circ.setDoubtErasureThreshold(kThreshold);
+    std::vector<uint8_t> data = corrupted;
+    std::vector<uint8_t> errors = zeroWord(32);
+    std::vector<uint8_t> padded = zeroWord(32);
+    std::vector<uint8_t> doubt = zeroWord(32);
+    doubt[2] = 15;
+    doubt[9] = 14;
+    doubt[17] = 13;
+
+    circ.c1Decode(data, errors, padded, doubt);
+
+    EXPECT_EQ(circ.fixedC1s(), 1);
+    EXPECT_EQ(circ.errorC1s(), 0);
+    EXPECT_EQ(circ.doubtErasuresC1(), 3);
+    EXPECT_EQ(circ.doubtSeededC1s(), 1);
+    EXPECT_EQ(data, std::vector<uint8_t>(28, 0));
+  }
+}
+
+TEST(ReedSolomonDoubt_C2, CorrectsThreeErrorsThatAreUncorrectableUnlocated) {
+  std::vector<uint8_t> corrupted = zeroWord(28);
+  corrupted[1] = 0x11;
+  corrupted[8] = 0x22;
+  corrupted[20] = 0x44;
+
+  {
+    ReedSolomon circ;
+    std::vector<uint8_t> data = corrupted;
+    std::vector<uint8_t> errors = zeroWord(28);
+    std::vector<uint8_t> padded = zeroWord(28);
+    std::vector<uint8_t> doubt = zeroWord(28);
+
+    circ.c2Decode(data, errors, padded, doubt);
+
+    EXPECT_EQ(circ.errorC2s(), 1);
+  }
+
+  {
+    ReedSolomon circ;
+    circ.setDoubtErasureThreshold(kThreshold);
+    std::vector<uint8_t> data = corrupted;
+    std::vector<uint8_t> errors = zeroWord(28);
+    std::vector<uint8_t> padded = zeroWord(28);
+    std::vector<uint8_t> doubt = zeroWord(28);
+    doubt[1] = 15;
+    doubt[8] = 15;
+    doubt[20] = 13;
+
+    circ.c2Decode(data, errors, padded, doubt);
+
+    EXPECT_EQ(circ.fixedC2s(), 1);
+    EXPECT_EQ(circ.errorC2s(), 0);
+    EXPECT_EQ(circ.doubtErasuresC2(), 3);
+    EXPECT_EQ(data, std::vector<uint8_t>(24, 0));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rank and cap
+// ---------------------------------------------------------------------------
+
+// A bad stretch can put more symbols over the threshold than the code can
+// erase. Taking the most-doubted four and stopping is what keeps a doubt seed
+// from tipping a word over capacity - a bare threshold would supply 8 erasures
+// here and trip the "> 4" early-out, turning a correctable word into a
+// failure.
+TEST(ReedSolomonDoubt_C1, NeverSuppliesMoreErasuresThanTheCodeCanCarry) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(32);
+  data[4] = 0x77;  // one real error, at the most-doubted position
+  std::vector<uint8_t> errors = zeroWord(32);
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
+  for (int i = 0; i < 8; ++i) doubt[i] = 13;
+  doubt[4] = 15;
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  EXPECT_EQ(circ.doubtErasuresC1(), ReedSolomon::kErasureCapacity);
+  EXPECT_EQ(circ.errorC1s(), 0);
+  EXPECT_EQ(data, std::vector<uint8_t>(28, 0));
+}
+
+// Symbols the EFM decode already condemned are erasures in their own right, so
+// the doubt may only top the list up to capacity - never past it.
+TEST(ReedSolomonDoubt_C1, LeavesRoomForTheErasuresTheEfmDecodeAlreadyRaised) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(32);
+  std::vector<uint8_t> errors = zeroWord(32);
+  errors[0] = 1;
+  errors[1] = 1;
+  errors[2] = 1;
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt(32, 15);
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  // Three erasures were already supplied, so exactly one doubt seed fits.
+  EXPECT_EQ(circ.doubtErasuresC1(), 1);
+}
+
+// A word already beyond capacity on its own erasures takes the early-out; the
+// doubt must not be consulted at all, or the counters would misreport why the
+// word failed.
+TEST(ReedSolomonDoubt_C1, DoesNotSeedAWordAlreadyBeyondCapacity) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(32);
+  std::vector<uint8_t> errors = zeroWord(32);
+  for (int i = 0; i < 5; ++i) errors[i] = 1;
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt(32, 15);
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  EXPECT_EQ(circ.doubtErasuresC1(), 0);
+  EXPECT_EQ(circ.errorC1s(), 1);
+  EXPECT_EQ(doubt.size(), 28u);
+}
+
+// A symbol the EFM decode already flagged must not also be counted as a doubt
+// seed: it is one erasure, not two, and double-counting it would understate
+// the remaining capacity.
+TEST(ReedSolomonDoubt_C1, DoesNotReseedASymbolAlreadyFlaggedAsAnError) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(32);
+  std::vector<uint8_t> errors = zeroWord(32);
+  errors[6] = 1;
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
+  doubt[6] = 15;
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  EXPECT_EQ(circ.doubtErasuresC1(), 0);
+  EXPECT_EQ(circ.doubtSeededC1s(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// The doubt vector itself
+// ---------------------------------------------------------------------------
+
+// The doubt travels with the symbols, so it must be trimmed exactly as the
+// data is: C1 drops the four parity symbols from the end, C2 drops positions
+// 12-15. Anything else would misalign the doubt with its symbols downstream.
+TEST(ReedSolomonDoubt_C1, TrimsTheParityDoubtWithTheParitySymbols) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(32);
+  std::vector<uint8_t> errors = zeroWord(32);
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
+  doubt[27] = 9;
+  doubt[31] = 9;
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  ASSERT_EQ(doubt.size(), 28u);
+  EXPECT_EQ(doubt[27], 9);
+}
+
+TEST(ReedSolomonDoubt_C2, TrimsTheParityDoubtWithTheParitySymbols) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(28);
+  std::vector<uint8_t> errors = zeroWord(28);
+  std::vector<uint8_t> padded = zeroWord(28);
+  std::vector<uint8_t> doubt = zeroWord(28);
+  doubt[11] = 7;
+  doubt[13] = 9;  // parity position, dropped
+  doubt[16] = 8;
+
+  circ.c2Decode(data, errors, padded, doubt);
+
+  ASSERT_EQ(doubt.size(), 24u);
+  EXPECT_EQ(doubt[11], 7);
+  EXPECT_EQ(doubt[12], 8);  // was position 16
+}
+
+// Doubt about a symbol the decoder replaced describes a byte that is no longer
+// there, so it is spent: leaving it set would spend C2's capacity on a value
+// C1's parity has already settled.
+TEST(ReedSolomonDoubt_C1, ClearsTheDoubtOfSymbolsItCorrected) {
+  ReedSolomon circ;
+  circ.setDoubtErasureThreshold(kThreshold);
+  std::vector<uint8_t> data = zeroWord(32);
+  data[5] = 0x9E;
+  std::vector<uint8_t> errors = zeroWord(32);
+  std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
+  doubt[5] = 15;
+  doubt[6] = 15;  // untouched symbol: its doubt survives to C2
+
+  circ.c1Decode(data, errors, padded, doubt);
+
+  ASSERT_EQ(circ.fixedC1s(), 1);
+  EXPECT_EQ(doubt[5], 0);
+  EXPECT_EQ(doubt[6], 15);
+}
+
+}  // namespace

--- a/orc-tests/core/unit/stages/efm_common/reedsolomon_padding_test.cpp
+++ b/orc-tests/core/unit/stages/efm_common/reedsolomon_padding_test.cpp
@@ -37,8 +37,9 @@ TEST(ReedSolomonScoring_C1, CountsCleanFullyPopulatedWordAsValid) {
   std::vector<uint8_t> data = zeroWord(32);
   std::vector<uint8_t> errors = zeroWord(32);
   std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
 
-  circ.c1Decode(data, errors, padded);
+  circ.c1Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.validC1s(), 1);
   EXPECT_EQ(circ.errorC1s(), 0);
@@ -50,8 +51,9 @@ TEST(ReedSolomonScoring_C1, CountsUncorrectableFullyPopulatedWordAsError) {
   std::vector<uint8_t> data = zeroWord(32);
   std::vector<uint8_t> errors = beyondCapacityErasures(32);
   std::vector<uint8_t> padded = zeroWord(32);
+  std::vector<uint8_t> doubt = zeroWord(32);
 
-  circ.c1Decode(data, errors, padded);
+  circ.c1Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.errorC1s(), 1);
   EXPECT_EQ(circ.paddedC1s(), 0);
@@ -66,8 +68,9 @@ TEST(ReedSolomonScoring_C1, ExcludesUncorrectableWordContainingPadding) {
   std::vector<uint8_t> errors = beyondCapacityErasures(32);
   std::vector<uint8_t> padded = zeroWord(32);
   padded[0] = 1;
+  std::vector<uint8_t> doubt = zeroWord(32);
 
-  circ.c1Decode(data, errors, padded);
+  circ.c1Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.paddedC1s(), 1);
   EXPECT_EQ(circ.errorC1s(), 0);
@@ -83,8 +86,9 @@ TEST(ReedSolomonScoring_C1, DetectsPaddingCarriedInTheParitySymbols) {
   std::vector<uint8_t> errors = zeroWord(32);
   std::vector<uint8_t> padded = zeroWord(32);
   padded[31] = 1;
+  std::vector<uint8_t> doubt = zeroWord(32);
 
-  circ.c1Decode(data, errors, padded);
+  circ.c1Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.paddedC1s(), 1);
   EXPECT_EQ(circ.validC1s(), 0);
@@ -95,8 +99,9 @@ TEST(ReedSolomonScoring_C2, CountsCleanFullyPopulatedWordAsValid) {
   std::vector<uint8_t> data = zeroWord(28);
   std::vector<uint8_t> errors = zeroWord(28);
   std::vector<uint8_t> padded = zeroWord(28);
+  std::vector<uint8_t> doubt = zeroWord(28);
 
-  circ.c2Decode(data, errors, padded);
+  circ.c2Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.validC2s(), 1);
   EXPECT_EQ(circ.errorC2s(), 0);
@@ -108,8 +113,9 @@ TEST(ReedSolomonScoring_C2, CountsUncorrectableFullyPopulatedWordAsError) {
   std::vector<uint8_t> data = zeroWord(28);
   std::vector<uint8_t> errors = beyondCapacityErasures(28);
   std::vector<uint8_t> padded = zeroWord(28);
+  std::vector<uint8_t> doubt = zeroWord(28);
 
-  circ.c2Decode(data, errors, padded);
+  circ.c2Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.errorC2s(), 1);
   EXPECT_EQ(circ.paddedC2s(), 0);
@@ -121,8 +127,9 @@ TEST(ReedSolomonScoring_C2, ExcludesUncorrectableWordContainingPadding) {
   std::vector<uint8_t> errors = beyondCapacityErasures(28);
   std::vector<uint8_t> padded = zeroWord(28);
   padded[27] = 1;
+  std::vector<uint8_t> doubt = zeroWord(28);
 
-  circ.c2Decode(data, errors, padded);
+  circ.c2Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.paddedC2s(), 1);
   EXPECT_EQ(circ.errorC2s(), 0);
@@ -137,8 +144,9 @@ TEST(ReedSolomonScoring_C2, DetectsPaddingCarriedInTheParitySymbols) {
   std::vector<uint8_t> errors = zeroWord(28);
   std::vector<uint8_t> padded = zeroWord(28);
   padded[13] = 1;
+  std::vector<uint8_t> doubt = zeroWord(28);
 
-  circ.c2Decode(data, errors, padded);
+  circ.c2Decode(data, errors, padded, doubt);
 
   EXPECT_EQ(circ.paddedC2s(), 1);
   EXPECT_EQ(circ.validC2s(), 0);

--- a/orc-tests/core/unit/stages/stacker/efm_confidence_stack_test.cpp
+++ b/orc-tests/core/unit/stages/stacker/efm_confidence_stack_test.cpp
@@ -1,0 +1,442 @@
+/*
+ * File:        efm_confidence_stack_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Unit tests for sync-anchored confidence stacking of EFM t-values
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include "../../../../orc/plugins/stages/stacker/efm_confidence_stack.h"
+
+#include <gtest/gtest.h>
+#include <orc/stage/video_frame_representation.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+namespace orc_unit_test {
+namespace {
+
+// IEC 60908 Section 20.2: 588 channel bits per frame, opening with T11+T11.
+constexpr int kChannelFrameBits = 588;
+constexpr int kSyncBits = 22;
+constexpr int kBodyBits = kChannelFrameBits - kSyncBits;
+
+// A legal channel-frame body of the requested bit length. T4 runs throughout
+// with a longer final run to make up the remainder, so no two adjacent runs
+// are ever T11 and no accidental frame sync appears inside the body.
+std::vector<int> make_body(int bits = kBodyBits) {
+  std::vector<int> runs;
+  int remaining = bits;
+  while (remaining > 11) {
+    runs.push_back(4);
+    remaining -= 4;
+  }
+  runs.push_back(remaining);
+  return runs;
+}
+
+// Pack a channel frame: the T11+T11 sync followed by |body|, every run
+// carrying |doubt|.
+std::vector<uint8_t> pack_frame(const std::vector<int>& body,
+                                uint8_t doubt = 0) {
+  EXPECT_EQ(std::accumulate(body.begin(), body.end(), 0), kBodyBits);
+  std::vector<uint8_t> packed;
+  packed.push_back(orc::efm_pack(11, doubt));
+  packed.push_back(orc::efm_pack(11, doubt));
+  for (int run : body) {
+    packed.push_back(orc::efm_pack(static_cast<uint8_t>(run), doubt));
+  }
+  return packed;
+}
+
+std::vector<uint8_t> pack_stream(const std::vector<int>& body, int frames,
+                                 uint8_t doubt = 0) {
+  std::vector<uint8_t> packed;
+  for (int i = 0; i < frames; ++i) {
+    const std::vector<uint8_t> frame = pack_frame(body, doubt);
+    packed.insert(packed.end(), frame.begin(), frame.end());
+  }
+  return packed;
+}
+
+// Only the channel frames bounded by a sync at both ends are combined, so a
+// frame under test needs a plain frame after it to close the slot.
+std::vector<uint8_t> pack_frame_then_plain(const std::vector<int>& body,
+                                           uint8_t doubt = 0) {
+  std::vector<uint8_t> packed = pack_frame(body, doubt);
+  const std::vector<uint8_t> plain = pack_frame(make_body(), doubt);
+  packed.insert(packed.end(), plain.begin(), plain.end());
+  return packed;
+}
+
+// A legal body distinct from every other variant, so that pairing frames from
+// two sources incorrectly shows up as disagreement rather than passing
+// unnoticed.
+std::vector<int> body_variant(int index) {
+  std::vector<int> runs = make_body(kBodyBits - 12);
+  const int split = 3 + (index % 7);
+  runs.insert(runs.begin(), {split, 12 - split});
+  return runs;
+}
+
+// Number of t-values in one packed channel frame built from |body|.
+size_t frame_length(const std::vector<int>& body) { return body.size() + 2; }
+
+// Channel-frame bodies with distinct opening runs, so that pairing frames from
+// two captures incorrectly cannot pass unnoticed. The three leading runs sum
+// to 24 and each stays within T3-T11, which gives 52 distinct openings.
+std::vector<std::vector<int>> distinct_openings() {
+  std::vector<std::vector<int>> openings;
+  for (int a = 3; a <= 11; ++a) {
+    for (int b = 3; b <= 11; ++b) {
+      const int c = 24 - a - b;
+      if (c >= 3 && c <= 11) {
+        openings.push_back({a, b, c});
+      }
+    }
+  }
+  return openings;
+}
+
+std::vector<int> body_unique(size_t index) {
+  const std::vector<std::vector<int>> openings = distinct_openings();
+  std::vector<int> runs = make_body(kBodyBits - 24);
+  const std::vector<int>& opening = openings[index % openings.size()];
+  runs.insert(runs.begin(), opening.begin(), opening.end());
+  return runs;
+}
+
+// A run of channel frames carrying disc content |first| onwards.
+std::vector<uint8_t> pack_run(size_t first, size_t count, uint8_t doubt = 0) {
+  std::vector<uint8_t> packed;
+  for (size_t i = 0; i < count; ++i) {
+    const std::vector<uint8_t> frame =
+        pack_frame(body_unique(first + i), doubt);
+    packed.insert(packed.end(), frame.begin(), frame.end());
+  }
+  return packed;
+}
+
+std::vector<uint8_t> tvalues_of(const std::vector<uint8_t>& packed) {
+  std::vector<uint8_t> values;
+  values.reserve(packed.size());
+  for (uint8_t byte : packed) {
+    values.push_back(orc::efm_tvalue(byte));
+  }
+  return values;
+}
+
+// Every T11+T11 sync in |packed| must sit exactly 588 bits after the last.
+void expect_intact_sync_grid(const std::vector<uint8_t>& packed) {
+  int bit = 0;
+  int previous_sync = -1;
+  for (size_t i = 0; i + 1 < packed.size(); ++i) {
+    if (orc::efm_tvalue(packed[i]) == 11 &&
+        orc::efm_tvalue(packed[i + 1]) == 11) {
+      if (previous_sync >= 0) {
+        EXPECT_EQ(bit - previous_sync, kChannelFrameBits)
+            << "sync grid broken at t-value " << i;
+      }
+      previous_sync = bit;
+      bit += 22;
+      ++i;
+      continue;
+    }
+    bit += orc::efm_tvalue(packed[i]);
+  }
+}
+
+void expect_legal_run_lengths(const std::vector<uint8_t>& packed) {
+  for (uint8_t byte : packed) {
+    const uint8_t value = orc::efm_tvalue(byte);
+    // IEC 60908 Section 20.1: the (2,10) run-length limit bounds runs to
+    // T3-T11.
+    EXPECT_GE(value, 3);
+    EXPECT_LE(value, 11);
+  }
+}
+
+}  // namespace
+
+// A lone source was not stacked with anything, so both its t-values and the
+// doubt its producer attached to them stand unaltered.
+TEST(EfmConfidenceStackTest, SingleSourceIsPassedThroughUnchanged) {
+  const std::vector<uint8_t> source = pack_stream(make_body(), 3, 7);
+  EXPECT_EQ(orc::stack_efm_confidence({source}, 0), source);
+}
+
+TEST(EfmConfidenceStackTest, NoSourcesYieldsNothing) {
+  EXPECT_TRUE(orc::stack_efm_confidence({}, 0).empty());
+}
+
+// Without a frame sync there is no axis to combine on, so the reference is
+// returned rather than a blend made on an assumption that does not hold.
+TEST(EfmConfidenceStackTest, StreamWithoutASyncFallsBackToTheReference) {
+  const std::vector<uint8_t> a = {orc::efm_pack(3, 0), orc::efm_pack(4, 0)};
+  const std::vector<uint8_t> b = {orc::efm_pack(5, 0), orc::efm_pack(6, 0)};
+  EXPECT_EQ(orc::stack_efm_confidence({a, b}, 1), b);
+}
+
+TEST(EfmConfidenceStackTest, AgreeingSourcesReproduceTheStreamWithNoDoubt) {
+  const std::vector<uint8_t> source = pack_stream(make_body(), 3);
+  const auto stacked = orc::stack_efm_confidence({source, source}, 0);
+
+  EXPECT_EQ(tvalues_of(stacked), tvalues_of(source));
+  for (uint8_t byte : stacked) {
+    EXPECT_EQ(orc::efm_doubt(byte), 0);
+  }
+}
+
+// Unanimity among sources that all distrusted what they read is not a reason
+// to trust it: the output keeps the doubt its vouchers had.
+TEST(EfmConfidenceStackTest, AgreeingSourcesKeepTheDoubtTheyVouchedWith) {
+  const std::vector<uint8_t> source = pack_stream(make_body(), 2, 6);
+  const auto stacked = orc::stack_efm_confidence({source, source}, 0);
+
+  ASSERT_FALSE(stacked.empty());
+  for (uint8_t byte : stacked) {
+    EXPECT_EQ(orc::efm_doubt(byte), 6);
+  }
+}
+
+// The lowest doubt among the sources that reported a run is the one that
+// carries: one capture being sure of a reading the others agree with is the
+// evidence that matters.
+TEST(EfmConfidenceStackTest, TakesTheLowestDoubtOfTheSourcesThatAgree) {
+  const std::vector<uint8_t> confident = pack_stream(make_body(), 2, 0);
+  const std::vector<uint8_t> unsure = pack_stream(make_body(), 2, 11);
+  const auto stacked = orc::stack_efm_confidence({unsure, confident}, 0);
+
+  const size_t combined = frame_length(make_body());
+  ASSERT_GE(stacked.size(), combined);
+  for (size_t i = 0; i < combined; ++i) {
+    EXPECT_EQ(orc::efm_doubt(stacked[i]), 0) << "at t-value " << i;
+  }
+}
+
+namespace {
+
+// Two sources that split the same 12 bits differently: one reads T3 then T9,
+// the other T9 then T3. Their arithmetic mean is T6+T6, a reading neither of
+// them made.
+struct DisagreeingPair {
+  std::vector<uint8_t> low_then_high;
+  std::vector<uint8_t> high_then_low;
+  size_t contested_index = 0;
+};
+
+DisagreeingPair make_disagreeing_pair(uint8_t low_doubt, uint8_t high_doubt) {
+  std::vector<int> body = make_body(kBodyBits - 12);
+  std::vector<int> first = body;
+  std::vector<int> second = body;
+  first.insert(first.begin(), {3, 9});
+  second.insert(second.begin(), {9, 3});
+
+  DisagreeingPair pair;
+  pair.low_then_high = pack_frame_then_plain(first, low_doubt);
+  pair.high_then_low = pack_frame_then_plain(second, high_doubt);
+  pair.contested_index = 2;  // straight after the two sync runs
+  return pair;
+}
+
+}  // namespace
+
+// The headline property: a stacked t-value is always one a source actually
+// reported. An average would put a T6 here that neither capture saw and that
+// the EFM demodulator would then decode with full confidence.
+TEST(EfmConfidenceStackTest, NeverEmitsAValueNoSourceReported) {
+  const DisagreeingPair pair = make_disagreeing_pair(0, 0);
+  const auto stacked =
+      orc::stack_efm_confidence({pair.low_then_high, pair.high_then_low}, 0);
+
+  ASSERT_GT(stacked.size(), pair.contested_index + 1);
+  const uint8_t first = orc::efm_tvalue(stacked[pair.contested_index]);
+  const uint8_t second = orc::efm_tvalue(stacked[pair.contested_index + 1]);
+  EXPECT_EQ(first + second, 12);
+  EXPECT_TRUE((first == 3 && second == 9) || (first == 9 && second == 3))
+      << "got T" << static_cast<int>(first) << " then T"
+      << static_cast<int>(second);
+}
+
+TEST(EfmConfidenceStackTest, TheMoreConfidentSourceWinsAContestedTransition) {
+  const DisagreeingPair trusted_low = make_disagreeing_pair(0, 12);
+  auto stacked = orc::stack_efm_confidence(
+      {trusted_low.low_then_high, trusted_low.high_then_low}, 0);
+  EXPECT_EQ(orc::efm_tvalue(stacked[trusted_low.contested_index]), 3);
+  EXPECT_EQ(orc::efm_tvalue(stacked[trusted_low.contested_index + 1]), 9);
+
+  const DisagreeingPair trusted_high = make_disagreeing_pair(12, 0);
+  stacked = orc::stack_efm_confidence(
+      {trusted_high.low_then_high, trusted_high.high_then_low}, 0);
+  EXPECT_EQ(orc::efm_tvalue(stacked[trusted_high.contested_index]), 9);
+  EXPECT_EQ(orc::efm_tvalue(stacked[trusted_high.contested_index + 1]), 3);
+}
+
+// Disagreement is information, and it is passed on: the runs the sources
+// argued over come out doubted even though both producers were sure, while
+// the runs they agreed on stay trusted.
+TEST(EfmConfidenceStackTest, ContestedRunsCarryDoubtAndAgreedRunsDoNot) {
+  const DisagreeingPair pair = make_disagreeing_pair(0, 12);
+  const auto stacked =
+      orc::stack_efm_confidence({pair.low_then_high, pair.high_then_low}, 0);
+
+  ASSERT_GT(stacked.size(), pair.contested_index + 2);
+  EXPECT_GT(orc::efm_doubt(stacked[pair.contested_index]), 0);
+  EXPECT_GT(orc::efm_doubt(stacked[pair.contested_index + 1]), 0);
+  EXPECT_EQ(orc::efm_doubt(stacked[0]), 0);
+  EXPECT_EQ(orc::efm_doubt(stacked.back()), 0);
+}
+
+// The reason for anchoring on the sync grid at all. One capture reads a single
+// T8 as T4+T4, which leaves it with one more t-value than the others for the
+// rest of the frame. Combining by sample index would pair every later run with
+// its neighbour's; on the bit axis the extra transition is simply outvoted and
+// nothing downstream of it moves.
+TEST(EfmConfidenceStackTest, AnInsertionInOneSourceDoesNotDisturbTheRest) {
+  std::vector<int> body = make_body(kBodyBits - 8);
+  std::vector<int> clean = body;
+  clean.insert(clean.begin(), 8);
+  std::vector<int> split = body;
+  split.insert(split.begin(), {4, 4});
+
+  const std::vector<uint8_t> a = pack_frame_then_plain(clean);
+  const std::vector<uint8_t> b = pack_frame_then_plain(split);
+
+  const auto stacked = orc::stack_efm_confidence({a, a, b}, 0);
+  EXPECT_EQ(tvalues_of(stacked), tvalues_of(a));
+  expect_intact_sync_grid(stacked);
+}
+
+// The mirror case: one capture misses a transition and merges two runs.
+TEST(EfmConfidenceStackTest, ADeletionInOneSourceDoesNotDisturbTheRest) {
+  std::vector<int> body = make_body(kBodyBits - 8);
+  std::vector<int> clean = body;
+  clean.insert(clean.begin(), {4, 4});
+  std::vector<int> merged = body;
+  merged.insert(merged.begin(), 8);
+
+  const std::vector<uint8_t> a = pack_frame_then_plain(clean);
+  const std::vector<uint8_t> b = pack_frame_then_plain(merged);
+
+  const auto stacked = orc::stack_efm_confidence({a, a, b}, 0);
+  EXPECT_EQ(tvalues_of(stacked), tvalues_of(a));
+}
+
+// A capture that missed its own first sync starts a channel frame later than
+// the others. Every frame here carries distinct content, so pairing a source's
+// frames with the neighbours they happen to be numbered alongside would show
+// up as disagreement; the output staying unanimous is the evidence that the
+// realignment found the right frames.
+TEST(EfmConfidenceStackTest, RealignsASourceThatMissedItsFirstSync) {
+  std::vector<uint8_t> reference;
+  for (int frame = 0; frame < 5; ++frame) {
+    const std::vector<uint8_t> packed = pack_frame(body_variant(frame));
+    reference.insert(reference.end(), packed.begin(), packed.end());
+  }
+
+  // Same disc content, but the leading sync reads as two T10s and a T2, so the
+  // source's own first detected sync is one channel frame in.
+  std::vector<uint8_t> shifted = reference;
+  shifted[0] = orc::efm_pack(10, 15);
+  shifted[1] = orc::efm_pack(10, 15);
+  shifted.insert(shifted.begin() + 2, orc::efm_pack(2, 15));
+
+  const auto stacked = orc::stack_efm_confidence({reference, shifted}, 0);
+  EXPECT_EQ(tvalues_of(stacked), tvalues_of(reference));
+  expect_intact_sync_grid(stacked);
+
+  // Frames one to three are the slots both sources hold; they agreed on every
+  // run, so nothing in them is doubted.
+  const size_t first = frame_length(body_variant(0));
+  const size_t last = first + frame_length(body_variant(1)) +
+                      frame_length(body_variant(2)) +
+                      frame_length(body_variant(3));
+  ASSERT_GE(stacked.size(), last);
+  for (size_t i = first; i < last; ++i) {
+    EXPECT_EQ(orc::efm_doubt(stacked[i]), 0) << "at t-value " << i;
+  }
+}
+
+// Captures of the same disc do not begin at the same place on it. Aligning
+// them by video frame leaves a steady fraction of a frame - the Domesday
+// National A sides sit 1.123 frames apart, tens of channel frames even once
+// the whole-frame part is taken out - so the offset between two sources has to
+// be found rather than assumed. Here two captures start eighteen channel
+// frames further along the disc than the reference does, and still correct a
+// misreading in it.
+TEST(EfmConfidenceStackTest, FindsALargeOffsetBetweenCapturesOfTheSameDisc) {
+  const size_t kShift = 18;
+  const size_t kFrames = 30;
+  const size_t kDamaged = 20;  // a frame both later captures also cover
+
+  const std::vector<uint8_t> intact = pack_run(0, kFrames);
+  std::vector<uint8_t> reference = intact;
+
+  // Misread one run of frame |kDamaged| as two, the way a spurious transition
+  // would: from here on the reference holds one more t-value than the others.
+  size_t at = 0;
+  for (size_t f = 0; f < kDamaged; ++f) {
+    at += frame_length(body_unique(f));
+  }
+  at += 2 + 3;  // past the sync and the three distinct opening runs
+  ASSERT_EQ(orc::efm_tvalue(reference[at]), 4);
+  reference[at] = orc::efm_pack(1, 0);
+  reference.insert(reference.begin() + static_cast<std::ptrdiff_t>(at) + 1,
+                   orc::efm_pack(3, 0));
+
+  const std::vector<uint8_t> later = pack_run(kShift, kFrames);
+  const auto stacked = orc::stack_efm_confidence({reference, later, later}, 0);
+
+  EXPECT_EQ(tvalues_of(stacked), tvalues_of(intact));
+  expect_intact_sync_grid(stacked);
+  expect_legal_run_lengths(stacked);
+}
+
+// t-values outside any complete channel frame - the partial frames at the head
+// and tail of a video frame's chunk - are the reference's, untouched.
+TEST(EfmConfidenceStackTest, MaterialOutsideTheSyncGridIsCarriedOverVerbatim) {
+  const std::vector<uint8_t> lead = {orc::efm_pack(5, 3), orc::efm_pack(7, 9),
+                                     orc::efm_pack(4, 0)};
+  std::vector<uint8_t> a = lead;
+  const std::vector<uint8_t> frames = pack_stream(make_body(), 3);
+  a.insert(a.end(), frames.begin(), frames.end());
+  a.push_back(orc::efm_pack(6, 2));
+
+  const auto stacked = orc::stack_efm_confidence({a, a}, 0);
+  ASSERT_GE(stacked.size(), lead.size());
+  EXPECT_TRUE(std::equal(lead.begin(), lead.end(), stacked.begin()));
+  EXPECT_EQ(stacked.back(), orc::efm_pack(6, 2));
+}
+
+// However badly the sources disagree, what comes out is a legal EFM stream:
+// runs within T3-T11 and an intact 588-bit sync grid. A combiner that can emit
+// an illegal channel frame is worse than useless - the demodulator would lose
+// frames the individual captures decoded perfectly well.
+TEST(EfmConfidenceStackTest, OutputIsAlwaysALegalStreamHoweverSourcesDisagree) {
+  std::vector<std::vector<uint8_t>> sources;
+  for (int variant = 0; variant < 4; ++variant) {
+    std::vector<int> runs = make_body(kBodyBits - 12);
+    // Each source splits the same twelve bits its own way, and doubts it.
+    runs.insert(runs.begin(), {3 + variant, 9 - variant});
+    sources.push_back(
+        pack_frame_then_plain(runs, static_cast<uint8_t>(variant * 4)));
+  }
+
+  const auto stacked = orc::stack_efm_confidence(sources, 0);
+  expect_legal_run_lengths(stacked);
+  expect_intact_sync_grid(stacked);
+  EXPECT_EQ(std::accumulate(stacked.begin(), stacked.end(), 0,
+                            [](int total, uint8_t byte) {
+                              return total + orc::efm_tvalue(byte);
+                            }),
+            std::accumulate(sources[0].begin(), sources[0].end(), 0,
+                            [](int total, uint8_t byte) {
+                              return total + orc::efm_tvalue(byte);
+                            }));
+}
+
+}  // namespace orc_unit_test

--- a/orc-tests/core/unit/stages/stacker/stacker_stage_test.cpp
+++ b/orc-tests/core/unit/stages/stacker/stacker_stage_test.cpp
@@ -603,13 +603,20 @@ TEST(StackerStageTest, EfmMeanStacking_StripsDoubtEvenFromASingleSource) {
             (std::vector<uint8_t>{4}));
 }
 
-// Confidence stacking is the default. With one contributing source nothing was
-// combined, so its bytes - doubt included - stand as they are.
-TEST(StackerStageTest,
-     EfmConfidenceStacking_IsTheDefaultAndKeepsSingleSourceDoubt) {
+// EFM combining is off by default: no mode has yet been shown to beat passing
+// the best source's t-values through untouched. With Confidence selected and
+// one contributing source nothing was combined either, so its bytes - doubt
+// included - stand as they are.
+TEST(StackerStageTest, EfmStacking_DefaultsToDisabled) {
   orc::StackerStage stage;
   EXPECT_EQ(std::get<std::string>(stage.get_parameters().at("efm_stacking")),
-            "Confidence");
+            "Disabled");
+}
+
+TEST(StackerStageTest, EfmConfidenceStacking_KeepsSingleSourceDoubt) {
+  orc::StackerStage stage;
+  ASSERT_TRUE(
+      stage.set_parameters({{"efm_stacking", std::string("Confidence")}}));
 
   const std::vector<uint8_t> packed = {orc::efm_pack(4, 12)};
   auto src0 = make_efm_stack_source(packed);
@@ -626,6 +633,8 @@ TEST(StackerStageTest,
 // itself is in efm_confidence_stack_test.cpp.
 TEST(StackerStageTest, EfmConfidenceStacking_FallsBackWithoutASyncGrid) {
   orc::StackerStage stage;
+  ASSERT_TRUE(
+      stage.set_parameters({{"efm_stacking", std::string("Confidence")}}));
   const std::vector<uint8_t> packed = {orc::efm_pack(3, 9),
                                        orc::efm_pack(4, 15)};
   auto src0 = make_efm_stack_source(packed);

--- a/orc-tests/core/unit/stages/stacker/stacker_stage_test.cpp
+++ b/orc-tests/core/unit/stages/stacker/stacker_stage_test.cpp
@@ -557,7 +557,8 @@ std::shared_ptr<NiceMock<MockVideoFrameRepresentation>> make_efm_stack_source(
 // producer's doubt into the high one. Stacking combines the t-values alone:
 // mean/median of the whole bytes would fold the doubt into the t-value field.
 TEST(StackerStageTest, EfmMeanStacking_CombinesTValuesAndDropsDoubt) {
-  orc::StackerStage stage;  // efm_stacking defaults to Mean
+  orc::StackerStage stage;
+  ASSERT_TRUE(stage.set_parameters({{"efm_stacking", std::string("Mean")}}));
   // t-values 3 and 5 (mean 4), 11 and 7 (mean 9) - carried with wildly
   // different doubt, which must not reach the result.
   auto src0 =
@@ -587,10 +588,12 @@ TEST(StackerStageTest, EfmMedianStacking_CombinesTValuesAndDropsDoubt) {
             (std::vector<uint8_t>{8}));
 }
 
-// A single contributing source is still an EFM-stacking output, so it is
-// reported the same way: t-values with no doubt of their own.
-TEST(StackerStageTest, EfmStacking_StripsDoubtEvenFromASingleSource) {
-  orc::StackerStage stage;  // Mean
+// Mean and median produce a value no source vouched for, so a single
+// contributing source is reported the same way as any other of their outputs:
+// t-values with no doubt of their own.
+TEST(StackerStageTest, EfmMeanStacking_StripsDoubtEvenFromASingleSource) {
+  orc::StackerStage stage;
+  ASSERT_TRUE(stage.set_parameters({{"efm_stacking", std::string("Mean")}}));
   auto src0 = make_efm_stack_source({orc::efm_pack(4, 12)});
   auto src1 = make_audio_stack_source();  // no EFM to contribute
 
@@ -598,6 +601,39 @@ TEST(StackerStageTest, EfmStacking_StripsDoubtEvenFromASingleSource) {
 
   EXPECT_EQ(stacked.get_efm_samples(orc::FrameID{0}),
             (std::vector<uint8_t>{4}));
+}
+
+// Confidence stacking is the default. With one contributing source nothing was
+// combined, so its bytes - doubt included - stand as they are.
+TEST(StackerStageTest,
+     EfmConfidenceStacking_IsTheDefaultAndKeepsSingleSourceDoubt) {
+  orc::StackerStage stage;
+  EXPECT_EQ(std::get<std::string>(stage.get_parameters().at("efm_stacking")),
+            "Confidence");
+
+  const std::vector<uint8_t> packed = {orc::efm_pack(4, 12)};
+  auto src0 = make_efm_stack_source(packed);
+  auto src1 = make_audio_stack_source();  // no EFM to contribute
+
+  const orc::StackedVideoFrameRepresentation stacked({src0, src1}, &stage);
+
+  EXPECT_EQ(stacked.get_efm_samples(orc::FrameID{0}), packed);
+}
+
+// Two sources whose t-values carry no frame sync give confidence stacking no
+// axis to combine on, so it returns a source unaltered rather than blending on
+// an assumption that does not hold. The stage-level cover for the combining
+// itself is in efm_confidence_stack_test.cpp.
+TEST(StackerStageTest, EfmConfidenceStacking_FallsBackWithoutASyncGrid) {
+  orc::StackerStage stage;
+  const std::vector<uint8_t> packed = {orc::efm_pack(3, 9),
+                                       orc::efm_pack(4, 15)};
+  auto src0 = make_efm_stack_source(packed);
+  auto src1 = make_efm_stack_source(packed);
+
+  const orc::StackedVideoFrameRepresentation stacked({src0, src1}, &stage);
+
+  EXPECT_EQ(stacked.get_efm_samples(orc::FrameID{0}), packed);
 }
 
 // Disabled does not combine anything, so the chosen source's bytes - doubt

--- a/orc/plugins/stages/common/efm-decode/decoders/dec_channeltof3frame.cpp
+++ b/orc/plugins/stages/common/efm-decode/decoders/dec_channeltof3frame.cpp
@@ -8,6 +8,7 @@
 
 #include "dec_channeltof3frame.h"
 
+#include <orc/stage/video_frame_representation.h>
 #include <orc/support/logging.h>
 
 #include <algorithm>
@@ -16,6 +17,33 @@
 
 #include "efm_constants.h"
 #include "efm_exception.h"
+
+namespace {
+
+// Channel-frame layout (IEC 60908 §18, and the diagram in createF3Frame
+// below): the 32 data symbols start at channel bit 44 and repeat every 17 bits
+// - 14 symbol bits followed by 3 merging bits.
+constexpr int kFirstDataBit = 44;
+constexpr int kBitsPerSymbol = 17;
+constexpr int kSymbolBits = 14;
+constexpr int kDataSymbolsPerFrame = 32;
+
+// Index of the first data symbol whose 14 bits reach bit `bitPos` or beyond.
+int firstSymbolReaching(int bitPos) {
+  const int offset = bitPos - (kFirstDataBit + kSymbolBits - 1);
+  if (offset <= 0) return 0;
+  return (offset + kBitsPerSymbol - 1) / kBitsPerSymbol;
+}
+
+// Index of the last data symbol that starts at or before bit `bitPos`; -1 when
+// the first symbol has not started yet.
+int lastSymbolStartingBy(int bitPos) {
+  const int offset = bitPos - kFirstDataBit;
+  if (offset < 0) return -1;
+  return offset / kBitsPerSymbol;
+}
+
+}  // namespace
 
 ChannelToF3Frame::ChannelToF3Frame() {
   // Statistics
@@ -64,10 +92,12 @@ void ChannelToF3Frame::processQueue() {
     std::vector<uint8_t> frameData = m_inputBuffer.front();
     m_inputBuffer.pop();
 
-    // Count the number of bits in the frame
+    // Count the number of bits in the frame. The frame carries *packed* EFM
+    // bytes (t-value in the low nibble, producer doubt in the high nibble), so
+    // only the t-value contributes to the bit count.
     int bitCount = 0;
     for (int i = 0; i < frameData.size(); ++i) {
-      bitCount += frameData.at(i);
+      bitCount += orc::efm_tvalue(frameData.at(i));
     }
 
     // Generate statistics
@@ -103,8 +133,10 @@ F3Frame ChannelToF3Frame::createF3Frame(const std::vector<uint8_t>& tValues) {
   //
   // Giving a total of 588 bits
 
-  // Convert the T-values to data
-  std::vector<uint8_t> frameData = tvaluesToData(tValues);
+  // Convert the T-values to data, attributing each data symbol the doubt of
+  // the T-values that produced it (issue #307).
+  std::vector<uint8_t> frameData;
+  const bool anyDoubt = tvaluesToData(tValues, frameData, m_symbolDoubt);
 
   // Extract the subcode in bits 27-40
   uint16_t subcode = m_efm.fourteenToEight(getBits(frameData, 27, 40));
@@ -135,7 +167,8 @@ F3Frame ChannelToF3Frame::createF3Frame(const std::vector<uint8_t>& tValues) {
   }
 
   // If the data values are not a multiple of 32 (due to undershoot), pad with
-  // zeros
+  // zeros. The padding is already flagged as an erasure, and no channel bits
+  // were emitted for it, so its doubt is 0 in m_symbolDoubt already.
   while (dataValues.size() < 32) {
     dataValues.push_back(0);
     errorValues.push_back(1);
@@ -155,22 +188,42 @@ F3Frame ChannelToF3Frame::createF3Frame(const std::vector<uint8_t>& tValues) {
   // Set the frame data
   f3Frame.setData(dataValues);
   f3Frame.setErrorData(errorValues);
+  // Left unset (empty) when the producer trusted every symbol, which is the
+  // whole-stream case for an .efm with no confidence information - see
+  // Frame::doubtData().
+  if (anyDoubt) f3Frame.setDoubtData(m_symbolDoubt);
 
   return f3Frame;
 }
 
-std::vector<uint8_t> ChannelToF3Frame::tvaluesToData(
-    const std::vector<uint8_t>& tValues) {
+bool ChannelToF3Frame::tvaluesToData(const std::vector<uint8_t>& tValues,
+                                     std::vector<uint8_t>& outputData,
+                                     std::vector<uint8_t>& symbolDoubt) {
   // P-7: each T-value emits 3-11 *bits* (not 1), so a full 588-bit frame is ~74
   // bytes. Reserving tValues.size()/8 under-reserved ~4x and caused several
   // reallocations per frame; reserve for the maximum 11 bits per T-value.
-  std::vector<uint8_t> outputData;
+  outputData.clear();
   outputData.reserve((tValues.size() * 11 + 7) / 8);
+  if (m_collectDoubt) symbolDoubt.assign(kDataSymbolsPerFrame, 0);
 
   uint32_t bitBuffer = 0;  // Use 32-bit buffer to avoid frequent byte writes
   int bitsInBuffer = 0;
 
-  for (uint8_t tValue : tValues) {
+  // Issue #307: the doubt is attributed to symbols as the bits are laid down,
+  // from the running bit position, rather than by building a per-channel-bit
+  // vector and reducing it afterwards. Both give the same answer - a symbol
+  // takes the greatest doubt of the T-values overlapping its 14 bits - but
+  // this one is proportional to T-values (~74 per frame) instead of channel
+  // bits (588), and this runs ~11.8M times per disc side.
+  int bitPos = 0;
+  bool anyDoubt = false;
+
+  for (uint8_t packed : tValues) {
+    // The input carries packed EFM bytes: t-value in the low nibble, the
+    // producer's doubt about it in the high nibble.
+    uint8_t tValue = orc::efm_tvalue(packed);
+    const uint8_t doubt = m_collectDoubt ? orc::efm_doubt(packed) : 0;
+
     // R-1: an out-of-range T-value on this path is dirty-capture data, not an
     // invariant violation, so clamp into the valid IEC 60908 §13 range [3, 11]
     // instead of aborting the whole decode. A clamped symbol corrupts the local
@@ -188,6 +241,22 @@ std::vector<uint8_t> ChannelToF3Frame::tvaluesToData(
     bitBuffer = (bitBuffer << tValue) | (1U << (tValue - 1));
     bitsInBuffer += tValue;
 
+    // Attribute this T-value's doubt to every data symbol its bits fall in. A
+    // T-value landing wholly in the 3 merging bits between two symbols reaches
+    // neither, which the empty [first, last] range expresses naturally.
+    if (m_collectDoubt && doubt != 0) {
+      const int first = firstSymbolReaching(bitPos);
+      const int last = std::min(lastSymbolStartingBy(bitPos + tValue - 1),
+                                kDataSymbolsPerFrame - 1);
+      for (int symbol = first; symbol <= last; ++symbol) {
+        if (doubt > symbolDoubt[symbol]) {
+          symbolDoubt[symbol] = doubt;
+          anyDoubt = true;
+        }
+      }
+    }
+    bitPos += tValue;
+
     // Write complete bytes when we have 8 or more bits
     while (bitsInBuffer >= 8) {
       outputData.push_back(static_cast<char>(bitBuffer >> (bitsInBuffer - 8)));
@@ -201,7 +270,7 @@ std::vector<uint8_t> ChannelToF3Frame::tvaluesToData(
     outputData.push_back(static_cast<char>(bitBuffer));
   }
 
-  return outputData;
+  return anyDoubt;
 }
 
 uint16_t ChannelToF3Frame::getBits(const std::vector<uint8_t>& data,

--- a/orc/plugins/stages/common/efm-decode/decoders/dec_channeltof3frame.h
+++ b/orc/plugins/stages/common/efm-decode/decoders/dec_channeltof3frame.h
@@ -24,16 +24,39 @@ class ChannelToF3Frame : public Decoder {
   F3Frame popFrame();
   bool isReady() const;
 
+  // Issue #307: whether to attribute the producer's per-T-value doubt to the
+  // symbols it produced. Off by default: it is per-T-value work in the hottest
+  // loop of the decode, and nothing downstream reads the result unless the
+  // CIRC has been asked to seed erasures from it.
+  void setCollectDoubt(bool collectDoubt) { m_collectDoubt = collectDoubt; }
+
   void showStatistics() const;
 
  private:
   void processQueue();
   F3Frame createF3Frame(const std::vector<uint8_t>& data);
 
-  std::vector<uint8_t> tvaluesToData(const std::vector<uint8_t>& tvalues);
+  // Expand packed T-values into the frame's channel bit stream. `outputData`
+  // receives the bits packed 8-to-a-byte (MSB first); `symbolDoubt` receives
+  // one entry per data symbol (32), holding the greatest doubt of the T-values
+  // overlapping that symbol's 14 bits - a symbol is wrong if any one of its
+  // bits is, so the maximum, not the mean, describes the producer's distrust
+  // of it. Returns true when any symbol carries doubt; always false (and
+  // `symbolDoubt` untouched) unless setCollectDoubt(true) was called.
+  bool tvaluesToData(const std::vector<uint8_t>& tvalues,
+                     std::vector<uint8_t>& outputData,
+                     std::vector<uint8_t>& symbolDoubt);
   uint16_t getBits(const std::vector<uint8_t>& data, int startBit, int endBit);
 
   Efm m_efm;
+
+  // See setCollectDoubt().
+  bool m_collectDoubt = false;
+
+  // Reusable per-symbol doubt scratch (32 entries). A member rather than a
+  // local so the per-frame decode does not allocate; createF3Frame() is the
+  // only user and is not re-entrant.
+  std::vector<uint8_t> m_symbolDoubt;
 
   std::queue<std::vector<uint8_t>> m_inputBuffer;
   std::queue<F3Frame> m_outputBuffer;

--- a/orc/plugins/stages/common/efm-decode/decoders/dec_f2sectiontof1section.cpp
+++ b/orc/plugins/stages/common/efm-decode/decoders/dec_f2sectiontof1section.cpp
@@ -115,6 +115,15 @@ void F2SectionToF1Section::processQueue() {
       std::vector<uint8_t> data = f2Frame.data();
       std::vector<uint8_t> errorData = f2Frame.errorData();
       std::vector<uint8_t> paddedData = f2Frame.paddedData();
+      // Issue #307: an empty doubt vector means the producer trusted every
+      // symbol (see Frame::doubtData()); the CIRC needs one entry per symbol
+      // either way, because the delay lines must carry it in lockstep.
+      const std::vector<uint8_t>& frameDoubt = f2Frame.doubtData();
+      if (frameDoubt.size() == data.size()) {
+        m_doubtScratch.assign(frameDoubt.begin(), frameDoubt.end());
+      } else {
+        m_doubtScratch.assign(data.size(), 0);
+      }
 
       // Check F2 frame for errors (counts only when errorData = 1)
       uint32_t inFrameErrors = f2Frame.countErrors();
@@ -126,7 +135,7 @@ void F2SectionToF1Section::processQueue() {
       }
 
       processF2FrameData(std::move(data), std::move(errorData),
-                         std::move(paddedData), f1Section);
+                         std::move(paddedData), m_doubtScratch, f1Section);
     }
 
     // All frames in the section are processed
@@ -163,8 +172,9 @@ void F2SectionToF1Section::pushSubstituteF1Frame(F1Section& f1Section) {
 void F2SectionToF1Section::processF2FrameData(std::vector<uint8_t> data,
                                               std::vector<uint8_t> errorData,
                                               std::vector<uint8_t> paddedData,
+                                              std::vector<uint8_t>& doubtData,
                                               F1Section& f1Section) {
-  m_delayLine1.push(data, errorData, paddedData);
+  m_delayLine1.push(data, errorData, paddedData, doubtData);
   if (data.empty()) {
     pushSubstituteF1Frame(f1Section);
     return;
@@ -174,25 +184,25 @@ void F2SectionToF1Section::processF2FrameData(std::vector<uint8_t> data,
   // Note: We will only get valid data if the delay lines are all full
   m_inverter.invertParity(data);
 
-  m_circ.c1Decode(data, errorData, paddedData);
+  m_circ.c1Decode(data, errorData, paddedData, doubtData);
 
-  m_delayLineM.push(data, errorData, paddedData);
+  m_delayLineM.push(data, errorData, paddedData, doubtData);
   if (data.empty()) {
     pushSubstituteF1Frame(f1Section);
     return;
   }
 
   // Only perform C2 decode if delay line 1 is full and delay line M is full
-  m_circ.c2Decode(data, errorData, paddedData);
+  m_circ.c2Decode(data, errorData, paddedData, doubtData);
 
   if (std::any_of(errorData.begin(), errorData.end(),
                   [](uint8_t value) { return value != 0; })) {
     ORC_LOG_DEBUG("F2SectionToF1Section - F2 Frame: C2 Failed");
   }
 
-  m_interleave.deinterleave(data, errorData, paddedData);
+  m_interleave.deinterleave(data, errorData, paddedData, doubtData);
 
-  m_delayLine2.push(data, errorData, paddedData);
+  m_delayLine2.push(data, errorData, paddedData, doubtData);
   if (data.empty()) {
     pushSubstituteF1Frame(f1Section);
     return;
@@ -263,9 +273,10 @@ void F2SectionToF1Section::flush() {
     F1Section f1Section;
     for (int32_t index = 0; index < kFramesPerSection; ++index) {
       // Feed an all-padding F2 frame (32 symbols) into the chain.
-      processF2FrameData(std::vector<uint8_t>(32, 0),
-                         std::vector<uint8_t>(32, 0),
-                         std::vector<uint8_t>(32, 1), f1Section);
+      m_doubtScratch.assign(32, 0);
+      processF2FrameData(
+          std::vector<uint8_t>(32, 0), std::vector<uint8_t>(32, 0),
+          std::vector<uint8_t>(32, 1), m_doubtScratch, f1Section);
     }
     f1Section.metadata = metadata;
     m_outputBuffer.push_back(f1Section);
@@ -341,4 +352,11 @@ void F2SectionToF1Section::showStatistics() const {
   ORC_LOG_INFO("    Error C2s: {}", m_circ.errorC2s());
   ORC_LOG_INFO("    Padded C2s (warm-up/drain, not scored): {}",
                m_circ.paddedC2s());
+
+  // Issue #307: erasures raised on the producer's doubt alone.
+  ORC_LOG_INFO("  Producer-doubt erasures:");
+  ORC_LOG_INFO("    C1: {} in {} codewords", m_circ.doubtErasuresC1(),
+               m_circ.doubtSeededC1s());
+  ORC_LOG_INFO("    C2: {} in {} codewords", m_circ.doubtErasuresC2(),
+               m_circ.doubtSeededC2s());
 }

--- a/orc/plugins/stages/common/efm-decode/decoders/dec_f2sectiontof1section.h
+++ b/orc/plugins/stages/common/efm-decode/decoders/dec_f2sectiontof1section.h
@@ -31,6 +31,13 @@ class F2SectionToF1Section : public Decoder {
   // lead-out, but real data for a truncated capture).
   void flush();
 
+  // Issue #307: the smallest producer doubt (0 trusted - 15 distrusted) that
+  // makes an otherwise-clean symbol a C1/C2 erasure candidate. 0 disables
+  // doubt-derived erasures, which is the bit-exact legacy behaviour.
+  void setDoubtErasureThreshold(uint8_t threshold) {
+    m_circ.setDoubtErasureThreshold(threshold);
+  }
+
   void showStatistics() const;
 
   // Accessors for the curated decode report (CIRC C1/C2 health). valid/fixed/
@@ -45,6 +52,13 @@ class F2SectionToF1Section : public Decoder {
   int32_t errorC2s() const { return m_circ.errorC2s(); }
   int32_t paddedC2s() const { return m_circ.paddedC2s(); }
 
+  // Issue #307: erasures raised on the strength of the producer's doubt alone,
+  // and the codewords that received at least one.
+  int64_t doubtErasuresC1() const { return m_circ.doubtErasuresC1(); }
+  int64_t doubtErasuresC2() const { return m_circ.doubtErasuresC2(); }
+  int64_t doubtSeededC1s() const { return m_circ.doubtSeededC1s(); }
+  int64_t doubtSeededC2s() const { return m_circ.doubtSeededC2s(); }
+
   // Substitute F1 frames emitted while the delay lines were still filling
   // (warm-up) versus those emitted by flush() once the genuine tail had been
   // carried out (drain). Both are structural, not input defects.
@@ -57,9 +71,14 @@ class F2SectionToF1Section : public Decoder {
   // Push a single F2 frame's data through the CIRC delay-line / Reed-Solomon
   // chain, appending exactly one F1 frame to f1Section (a padded substitute
   // while the delay lines are still filling, otherwise the decoded frame).
+  // doubtData is taken by reference (unlike the by-value buffers above) so
+  // the caller can hand it the same scratch vector every frame; the CIRC runs
+  // ~11.8M frames per disc side and an owned vector here would be an
+  // allocation per frame for what is usually a run of zeros.
   void processF2FrameData(std::vector<uint8_t> data,
                           std::vector<uint8_t> errorData,
                           std::vector<uint8_t> paddedData,
+                          std::vector<uint8_t>& doubtData,
                           F1Section& f1Section);
 
   // Append a padded substitute F1 frame (fabricated filler emitted while the
@@ -82,6 +101,10 @@ class F2SectionToF1Section : public Decoder {
 
   Interleave m_interleave;
   Inverter m_inverter;
+
+  // Reusable per-frame doubt buffer for processF2FrameData(); see the note on
+  // that declaration.
+  std::vector<uint8_t> m_doubtScratch;
 
   // Statistics
   uint64_t m_invalidInputF2FramesCount;

--- a/orc/plugins/stages/common/efm-decode/decoders/dec_f3frametof2section.cpp
+++ b/orc/plugins/stages/common/efm-decode/decoders/dec_f3frametof2section.cpp
@@ -324,6 +324,11 @@ void F3FrameToF2Section::outputSection(bool showAddress) {
     F2Frame f2Frame;
     f2Frame.setData(m_sectionFrames[index].data());
     f2Frame.setErrorData(m_sectionFrames[index].errorData());
+    // Issue #307: carry the producer's per-symbol doubt down to the CIRC,
+    // which seeds C1/C2 erasures from it. Empty means "all trusted" and is
+    // passed on as such (see Frame::doubtData()).
+    const std::vector<uint8_t>& doubtData = m_sectionFrames[index].doubtData();
+    if (!doubtData.empty()) f2Frame.setDoubtData(doubtData);
     f2Section.pushFrame(f2Frame);
   }
 

--- a/orc/plugins/stages/common/efm-decode/decoders/dec_tvaluestochannel.cpp
+++ b/orc/plugins/stages/common/efm-decode/decoders/dec_tvaluestochannel.cpp
@@ -8,6 +8,7 @@
 
 #include "dec_tvaluestochannel.h"
 
+#include <orc/stage/video_frame_representation.h>
 #include <orc/support/logging.h>
 
 #include <algorithm>
@@ -17,6 +18,35 @@
 
 #include "efm_constants.h"
 #include "efm_exception.h"
+
+namespace {
+
+// The buffers handled here carry *packed* EFM bytes: the t-value in the low
+// nibble and the producer's doubt in the high nibble (CVBS File Format
+// Specification, EFM extension format - "Binary Data File"). Framing only ever
+// needs the t-value, so every read of one masks the doubt away; the doubt is
+// otherwise untouched and rides out with the frame it belongs to.
+
+// True if the two packed bytes at `it` are the T11+T11 frame sync pair.
+inline bool isSyncPair(std::vector<uint8_t>::const_iterator it) {
+  return orc::efm_tvalue(*it) == efm::kSyncSymbolT11 &&
+         orc::efm_tvalue(*(it + 1)) == efm::kSyncSymbolT11;
+}
+
+// Iterator to the first T11+T11 sync pair in [first, last), or `last` if there
+// is none. Replaces std::search over a plain {T11, T11} pattern, which would
+// match only bytes whose doubt nibble happened to be zero.
+std::vector<uint8_t>::const_iterator findSyncPair(
+    std::vector<uint8_t>::const_iterator first,
+    std::vector<uint8_t>::const_iterator last) {
+  if (std::distance(first, last) < 2) return last;
+  for (auto it = first; it != last - 1; ++it) {
+    if (isSyncPair(it)) return it;
+  }
+  return last;
+}
+
+}  // namespace
 
 TvaluesToChannel::TvaluesToChannel() {
   // Statistics
@@ -107,15 +137,11 @@ void TvaluesToChannel::processStateMachine() {
 TvaluesToChannel::State TvaluesToChannel::expectingInitialSync() {
   State nextState = ExpectingInitialSync;
 
-  // Expected sync header
-  std::vector<uint8_t> t11_t11 = {efm::kSyncSymbolT11, efm::kSyncSymbolT11};
-
   // Does the buffer contain a T11+T11 sequence?
-  auto it = std::search(m_internalBuffer.begin(), m_internalBuffer.end(),
-                        t11_t11.begin(), t11_t11.end());
+  auto it = findSyncPair(m_internalBuffer.cbegin(), m_internalBuffer.cend());
   int initialSyncIndex =
-      (it != m_internalBuffer.end())
-          ? static_cast<int>(std::distance(m_internalBuffer.begin(), it))
+      (it != m_internalBuffer.cend())
+          ? static_cast<int>(std::distance(m_internalBuffer.cbegin(), it))
           : -1;
 
   if (initialSyncIndex != -1) {
@@ -146,12 +172,11 @@ TvaluesToChannel::State TvaluesToChannel::expectingSync() {
 
   // The internal buffer contains a valid sync at the start
   // Find the next sync header after it
-  std::vector<uint8_t> t11_t11 = {efm::kSyncSymbolT11, efm::kSyncSymbolT11};
-  auto it = std::search(m_internalBuffer.begin() + 2, m_internalBuffer.end(),
-                        t11_t11.begin(), t11_t11.end());
+  auto it =
+      findSyncPair(m_internalBuffer.cbegin() + 2, m_internalBuffer.cend());
   int syncIndex =
-      (it != m_internalBuffer.end())
-          ? static_cast<int>(std::distance(m_internalBuffer.begin(), it))
+      (it != m_internalBuffer.cend())
+          ? static_cast<int>(std::distance(m_internalBuffer.cbegin(), it))
           : -1;
 
   // Do we have a valid second sync header?
@@ -230,12 +255,11 @@ TvaluesToChannel::State TvaluesToChannel::handleUndershoot() {
   m_undershootSyncs++;
 
   // Find the second sync header
-  std::vector<uint8_t> t11_t11 = {efm::kSyncSymbolT11, efm::kSyncSymbolT11};
-  auto it = std::search(m_internalBuffer.begin() + 2, m_internalBuffer.end(),
-                        t11_t11.begin(), t11_t11.end());
+  auto it =
+      findSyncPair(m_internalBuffer.cbegin() + 2, m_internalBuffer.cend());
   int secondSyncIndex =
-      (it != m_internalBuffer.end())
-          ? static_cast<int>(std::distance(m_internalBuffer.begin(), it))
+      (it != m_internalBuffer.cend())
+          ? static_cast<int>(std::distance(m_internalBuffer.cbegin(), it))
           : -1;
 
   // R-5(d): if there is no second sync header there cannot be a third one
@@ -258,12 +282,11 @@ TvaluesToChannel::State TvaluesToChannel::handleUndershoot() {
   }
 
   // Find the third sync header
-  auto it3 =
-      std::search(m_internalBuffer.begin() + secondSyncIndex + 2,
-                  m_internalBuffer.end(), t11_t11.begin(), t11_t11.end());
+  auto it3 = findSyncPair(m_internalBuffer.cbegin() + secondSyncIndex + 2,
+                          m_internalBuffer.cend());
   int thirdSyncIndex =
-      (it3 != m_internalBuffer.end())
-          ? static_cast<int>(std::distance(m_internalBuffer.begin(), it3))
+      (it3 != m_internalBuffer.cend())
+          ? static_cast<int>(std::distance(m_internalBuffer.cbegin(), it3))
           : -1;
 
   // So, unless the data is completely corrupt we should have 588 bits between
@@ -403,14 +426,13 @@ TvaluesToChannel::State TvaluesToChannel::handleOvershoot() {
   // Is the overshoot due to a missing/corrupt sync header?
   // Count the bits between the first and second sync headers, if they are
   // 588*2, split the frame data into two frames
-  std::vector<uint8_t> t11_t11 = {efm::kSyncSymbolT11, efm::kSyncSymbolT11};
 
   // Find the second sync header
-  auto it = std::search(m_internalBuffer.begin() + 2, m_internalBuffer.end(),
-                        t11_t11.begin(), t11_t11.end());
+  auto it =
+      findSyncPair(m_internalBuffer.cbegin() + 2, m_internalBuffer.cend());
   int syncIndex =
-      (it != m_internalBuffer.end())
-          ? static_cast<int>(std::distance(m_internalBuffer.begin(), it))
+      (it != m_internalBuffer.cend())
+          ? static_cast<int>(std::distance(m_internalBuffer.cbegin(), it))
           : -1;
 
   // Do we have a valid second sync header?
@@ -446,7 +468,7 @@ TvaluesToChannel::State TvaluesToChannel::handleOvershoot() {
           std::vector<uint8_t> singleFrameData;
           while (accumulatedBits < frameSize &&
                  endOfFrameIndex < frameData.size()) {
-            accumulatedBits += frameData.at(endOfFrameIndex);
+            accumulatedBits += orc::efm_tvalue(frameData.at(endOfFrameIndex));
             ++endOfFrameIndex;
           }
 
@@ -584,7 +606,7 @@ uint32_t TvaluesToChannel::countBits(const std::vector<uint8_t>& data,
 
   uint32_t bitCount = 0;
   for (int i = startPosition; i < endPosition; i++) {
-    bitCount += data.at(i);
+    bitCount += orc::efm_tvalue(data.at(i));
   }
   return bitCount;
 }

--- a/orc/plugins/stages/common/efm-decode/efm-lib/delay_lines.cpp
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/delay_lines.cpp
@@ -24,7 +24,8 @@ DelayLines::DelayLines(std::vector<int32_t> delayLengths) {
 
 void DelayLines::push(std::vector<uint8_t>& data,
                       std::vector<uint8_t>& errorData,
-                      std::vector<uint8_t>& paddedData) {
+                      std::vector<uint8_t>& paddedData,
+                      std::vector<uint8_t>& doubtData) {
   if (data.size() != m_delayLines.size()) {
     ORC_LOG_ERROR("Input data size does not match the number of delay lines.");
     throw efm::EfmDecodeError(__func__);
@@ -35,12 +36,14 @@ void DelayLines::push(std::vector<uint8_t>& data,
     uint8_t datum = data[i];
     bool datum_error = (errorData[i] != 0);
     bool datum_padded = (paddedData[i] != 0);
+    uint8_t datum_doubt = doubtData[i];
 
-    m_delayLines[i].push(datum, datum_error, datum_padded);
+    m_delayLines[i].push(datum, datum_error, datum_padded, datum_doubt);
 
     data[i] = datum;
     errorData[i] = datum_error ? 1 : 0;
     paddedData[i] = datum_padded ? 1 : 0;
+    doubtData[i] = datum_doubt;
   }
 
   // Clear the vector if delay lines aren't ready (in order to
@@ -49,6 +52,7 @@ void DelayLines::push(std::vector<uint8_t>& data,
     data.clear();
     errorData.clear();
     paddedData.clear();
+    doubtData.clear();
   }
 }
 
@@ -79,7 +83,8 @@ DelayLine::DelayLine(int32_t delayLength)
 // DelayLine class implementation
 DelayLine::DelayLine() : DelayLine(0) {}
 
-void DelayLine::push(uint8_t& datum, bool& datumError, bool& datumPadded) {
+void DelayLine::push(uint8_t& datum, bool& datumError, bool& datumPadded,
+                     uint8_t& datumDoubt) {
   if (m_delayLength == 0) {
     return;
   }
@@ -88,6 +93,7 @@ void DelayLine::push(uint8_t& datum, bool& datumError, bool& datumPadded) {
   uint8_t tempInput = datum;
   bool tempInputError = datumError;
   bool tempInputPadded = datumPadded;
+  uint8_t tempInputDoubt = datumDoubt;
 
   // Ring-buffer: m_head points to the oldest slot (the output value).
   // Read the output, overwrite the slot with the new input, then advance the
@@ -95,10 +101,12 @@ void DelayLine::push(uint8_t& datum, bool& datumError, bool& datumPadded) {
   datum = m_buffer[m_head].datum;
   datumError = m_buffer[m_head].error;
   datumPadded = m_buffer[m_head].padded;
+  datumDoubt = m_buffer[m_head].doubt;
 
   m_buffer[m_head].datum = tempInput;
   m_buffer[m_head].error = tempInputError;
   m_buffer[m_head].padded = tempInputPadded;
+  m_buffer[m_head].doubt = tempInputDoubt;
 
   m_head = (m_head + 1 >= m_delayLength) ? 0 : m_head + 1;
 
@@ -118,6 +126,7 @@ void DelayLine::flush() {
     temp.datum = 0;
     temp.error = false;
     temp.padded = false;
+    temp.doubt = 0;
     std::fill(m_buffer.begin(), m_buffer.end(), temp);
 
     m_head = 0;

--- a/orc/plugins/stages/common/efm-decode/efm-lib/delay_lines.h
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/delay_lines.h
@@ -17,7 +17,8 @@ class DelayLine {
   DelayLine(int32_t _delayLength);
   // Constructor taking no argument needed for std::vector in C++
   DelayLine();
-  void push(uint8_t& datum, bool& datumError, bool& datumPadded);
+  void push(uint8_t& datum, bool& datumError, bool& datumPadded,
+            uint8_t& datumDoubt);
   bool isReady();
   void flush();
 
@@ -26,6 +27,10 @@ class DelayLine {
     uint8_t datum;
     bool error;
     bool padded;
+    // Issue #307: the producer's doubt about this symbol. It must be delayed
+    // in lockstep with the symbol itself, otherwise the CIRC would seed its
+    // erasures from another symbol's confidence.
+    uint8_t doubt;
   };
 
   std::vector<DelayContents_t> m_buffer;
@@ -41,7 +46,7 @@ class DelayLines {
  public:
   DelayLines(std::vector<int32_t> _delayLengths);
   void push(std::vector<uint8_t>& data, std::vector<uint8_t>& errorData,
-            std::vector<uint8_t>& paddedData);
+            std::vector<uint8_t>& paddedData, std::vector<uint8_t>& doubtData);
   bool isReady();
   void flush();
 

--- a/orc/plugins/stages/common/efm-decode/efm-lib/frame.cpp
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/frame.cpp
@@ -70,6 +70,31 @@ const std::vector<uint8_t>& Frame::errorData() const {
   return m_frameErrorData;
 }
 
+// Set the per-symbol doubt data for the frame, ensuring it matches the frame
+// size. Note: this is a vector of uint8_t in the range 0-15, where 0 means the
+// producer fully trusted the symbol and 15 that it positively distrusted it.
+void Frame::setDoubtData(const std::vector<uint8_t>& doubtData) {
+  if (static_cast<int>(doubtData.size()) != frameSize()) {
+    ORC_LOG_ERROR(
+        "Frame::setDoubtData(): Doubt data size of {} does not match frame "
+        "size of {}",
+        doubtData.size(), frameSize());
+    throw efm::EfmDecodeError(__func__);
+  }
+
+  m_frameDoubtData = doubtData;
+}
+
+// Get the doubt data for the frame. An EMPTY vector is returned when no doubt
+// was ever set, which the caller must read as "every symbol fully trusted" -
+// the ordinary case for a producer that emits no confidence information. It is
+// deliberately not materialised as a zero-filled vector: the CIRC path runs
+// ~26M frames per stereo disc and would pay an allocation per frame for
+// information it already has.
+const std::vector<uint8_t>& Frame::doubtData() const {
+  return m_frameDoubtData;
+}
+
 // Count the number of errors in the frame
 uint32_t Frame::countErrors() const {
   uint32_t errorCount = 0;

--- a/orc/plugins/stages/common/efm-decode/efm-lib/frame.h
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/frame.h
@@ -26,6 +26,15 @@ class Frame {
   virtual const std::vector<uint8_t>& errorData() const;
   virtual uint32_t countErrors() const;
 
+  // Per-symbol doubt carried up from the producer's EFM t-values (0 trusted,
+  // 15 distrusted - CVBS File Format Specification, EFM extension format).
+  // Unlike the error and padded vectors this one is left EMPTY when every
+  // symbol is trusted, which is the whole-stream case for a producer that
+  // emits no confidence information; consumers must read an empty vector as
+  // "all zero" rather than assuming frameSize() entries.
+  virtual void setDoubtData(const std::vector<uint8_t>& doubtData);
+  virtual const std::vector<uint8_t>& doubtData() const;
+
   virtual void setPaddedData(const std::vector<uint8_t>& paddedData);
   virtual const std::vector<uint8_t>& paddedData() const;
   virtual uint32_t countPadded() const;
@@ -37,6 +46,7 @@ class Frame {
   std::vector<uint8_t> m_frameData;
   std::vector<uint8_t> m_frameErrorData;
   std::vector<uint8_t> m_framePaddedData;
+  std::vector<uint8_t> m_frameDoubtData;
 };
 
 class Data24 : public Frame {

--- a/orc/plugins/stages/common/efm-decode/efm-lib/interleave.cpp
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/interleave.cpp
@@ -10,6 +10,7 @@
 
 #include <orc/support/logging.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <utility>
 
@@ -19,7 +20,8 @@ Interleave::Interleave() {}
 
 void Interleave::deinterleave(std::vector<uint8_t>& inputData,
                               std::vector<uint8_t>& inputError,
-                              std::vector<uint8_t>& inputPadded) {
+                              std::vector<uint8_t>& inputPadded,
+                              std::vector<uint8_t>& inputDoubt) {
   // Ensure input data is 24 bytes long
   if (inputData.size() != 24) {
     ORC_LOG_ERROR(
@@ -31,6 +33,10 @@ void Interleave::deinterleave(std::vector<uint8_t>& inputData,
   std::vector<uint8_t> outputData(24);
   std::vector<uint8_t> outputError(24);
   std::vector<uint8_t> outputPadded(24);
+  // Issue #307: the doubt permutation uses a stack buffer rather than a fourth
+  // heap vector - this runs ~11.8M times per disc side, and the doubt is
+  // usually a run of zeros that is not worth an allocate/free per frame.
+  uint8_t outputDoubt[24];
 
   outputData[0] = inputData[0];
   outputData[1] = inputData[1];
@@ -107,8 +113,34 @@ void Interleave::deinterleave(std::vector<uint8_t>& inputData,
   outputPadded[22] = inputPadded[22];
   outputPadded[23] = inputPadded[23];
 
+  outputDoubt[0] = inputDoubt[0];
+  outputDoubt[1] = inputDoubt[1];
+  outputDoubt[8] = inputDoubt[2];
+  outputDoubt[9] = inputDoubt[3];
+  outputDoubt[16] = inputDoubt[4];
+  outputDoubt[17] = inputDoubt[5];
+  outputDoubt[2] = inputDoubt[6];
+  outputDoubt[3] = inputDoubt[7];
+  outputDoubt[10] = inputDoubt[8];
+  outputDoubt[11] = inputDoubt[9];
+  outputDoubt[18] = inputDoubt[10];
+  outputDoubt[19] = inputDoubt[11];
+  outputDoubt[4] = inputDoubt[12];
+  outputDoubt[5] = inputDoubt[13];
+  outputDoubt[12] = inputDoubt[14];
+  outputDoubt[13] = inputDoubt[15];
+  outputDoubt[20] = inputDoubt[16];
+  outputDoubt[21] = inputDoubt[17];
+  outputDoubt[6] = inputDoubt[18];
+  outputDoubt[7] = inputDoubt[19];
+  outputDoubt[14] = inputDoubt[20];
+  outputDoubt[15] = inputDoubt[21];
+  outputDoubt[22] = inputDoubt[22];
+  outputDoubt[23] = inputDoubt[23];
+
   // P-6: move the deinterleaved buffers back rather than copy-assigning them.
   inputData = std::move(outputData);
   inputError = std::move(outputError);
   inputPadded = std::move(outputPadded);
+  std::copy(std::begin(outputDoubt), std::end(outputDoubt), inputDoubt.begin());
 }

--- a/orc/plugins/stages/common/efm-decode/efm-lib/interleave.h
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/interleave.h
@@ -17,7 +17,8 @@ class Interleave {
   Interleave();
   void deinterleave(std::vector<uint8_t>& inputData,
                     std::vector<uint8_t>& inputError,
-                    std::vector<uint8_t>& inputPadded);
+                    std::vector<uint8_t>& inputPadded,
+                    std::vector<uint8_t>& inputDoubt);
 };
 
 #endif  // INTERLEAVE_H

--- a/orc/plugins/stages/common/efm-decode/efm-lib/reedsolomon.cpp
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/reedsolomon.cpp
@@ -36,6 +36,14 @@ struct CircRS<255, PAYLOAD>
 CircRS<255, 255 - 4> circRs;
 
 ReedSolomon::ReedSolomon() {
+  // Doubt-derived erasures are off until a caller opts in (issue #307).
+  m_doubtErasureThreshold = 0;
+
+  m_doubtErasuresC1 = 0;
+  m_doubtErasuresC2 = 0;
+  m_doubtSeededC1s = 0;
+  m_doubtSeededC2s = 0;
+
   // Initialise statistics
   m_validC1s = 0;
   m_fixedC1s = 0;
@@ -59,16 +67,82 @@ bool containsPadding(const std::vector<uint8_t>& paddedData) {
                      [](uint8_t value) { return value != 0; });
 }
 
+// Drop the four C2 parity positions (12-15) from a 28-entry per-symbol
+// vector, leaving the 24 payload entries in payload order.
+void dropC2Parity(std::vector<uint8_t>& values) {
+  values.erase(values.begin() + 12, values.begin() + 16);
+}
+
 }  // namespace
+
+void ReedSolomon::setDoubtErasureThreshold(uint8_t threshold) {
+  m_doubtErasureThreshold = threshold;
+}
+
+// Issue #307: the errors that dominate data-disc sector loss are invisible to
+// every check the decoder has of its own - the frame is 588 bits, the symbols
+// are legal EFM codewords, the 14->8 decode raises nothing - so C1/C2 are left
+// correcting unknown errors instead of erasures, roughly halving their
+// correction power. The producer knows better: the .efm carries its per-t-value
+// doubt, which arrives here as a per-symbol doubt.
+//
+// Positions are taken most-doubted first and stopped at the code's capacity.
+// Ranking rather than a bare threshold is what makes this safe: a bad stretch
+// can put more than four symbols over any fixed threshold, and the "> 4
+// supplied erasures" early-out in c1Decode/c2Decode would then convert words
+// the code could have corrected into outright failures. Rank-and-cap cannot
+// exceed capacity by construction.
+int ReedSolomon::seedDoubtErasures(const std::vector<uint8_t>& errorData,
+                                   const std::vector<uint8_t>& doubtData) {
+  if (m_doubtErasureThreshold == 0) return 0;
+  if (static_cast<int>(m_erasures.size()) >= kErasureCapacity) return 0;
+
+  m_doubtCandidates.clear();
+  for (int index = 0; index < static_cast<int>(doubtData.size()); ++index) {
+    // Symbols the EFM decode already condemned are erasures in their own
+    // right; seeding them again would double-count against the capacity.
+    if (errorData[index] != 0) continue;
+    if (doubtData[index] < m_doubtErasureThreshold) continue;
+    m_doubtCandidates.emplace_back(doubtData[index], index);
+  }
+  if (m_doubtCandidates.empty()) return 0;
+
+  // Most-doubted first; ties broken by position so the choice is deterministic.
+  std::sort(
+      m_doubtCandidates.begin(), m_doubtCandidates.end(),
+      [](const std::pair<uint8_t, int>& a, const std::pair<uint8_t, int>& b) {
+        if (a.first != b.first) return a.first > b.first;
+        return a.second < b.second;
+      });
+
+  int added = 0;
+  for (const auto& candidate : m_doubtCandidates) {
+    if (static_cast<int>(m_erasures.size()) >= kErasureCapacity) break;
+    m_erasures.push_back(candidate.second);
+    ++added;
+  }
+
+  // ezpwd does not require sorted erasure positions, but keeping the list in
+  // position order matches what the errorData scan produces and keeps the
+  // decoder's inputs reproducible.
+  std::sort(m_erasures.begin(), m_erasures.end());
+  return added;
+}
 
 // Perform a C1 Reed-Solomon decoding operation on the input data
 // This is a (32,28) Reed-Solomon encode - 32 bytes in, 28 bytes out
 void ReedSolomon::c1Decode(std::vector<uint8_t>& inputData,
                            std::vector<uint8_t>& errorData,
-                           std::vector<uint8_t>& paddedData) {
+                           std::vector<uint8_t>& paddedData,
+                           std::vector<uint8_t>& doubtData) {
   // Ensure input data is 32 bytes long
   if (inputData.size() != 32) {
     ORC_LOG_ERROR("ReedSolomon::c1Decode - Input data must be 32 bytes long");
+    throw efm::EfmDecodeError(__func__);
+  }
+
+  if (doubtData.size() != 32) {
+    ORC_LOG_ERROR("ReedSolomon::c1Decode - Doubt data must be 32 bytes long");
     throw efm::EfmDecodeError(__func__);
   }
 
@@ -100,17 +174,18 @@ void ReedSolomon::c1Decode(std::vector<uint8_t>& inputData,
     if (errorData[index]) m_erasures.push_back(index);
   }
 
-  // Snapshot the supplied erasures before decode prunes them (see c2Decode).
-  const std::vector<int> suppliedErasures = m_erasures;
-
   // E-2: the (32,28) C1 code has minimum distance 5, so it can attempt an
   // in-capacity erasure decode for up to 4 supplied erasures. C1 erasure flags
   // come from the EFM demodulator (invalid 14-bit symbols - reliable erasures),
   // so passing 3-4 of them straight through as uncorrectable without attempting
   // the decode discarded correctable words. More than 4 exceeds capacity.
-  if (suppliedErasures.size() > 4) {
+  //
+  // Tested before the doubt-derived erasures are added, so a doubt seed can
+  // never be what tips a word over capacity (see seedDoubtErasures()).
+  if (static_cast<int>(m_erasures.size()) > kErasureCapacity) {
     inputData.resize(inputData.size() - 4);  // keep received bytes 0..27
     errorData.assign(inputData.size(), 1);
+    doubtData.resize(doubtData.size() - 4);  // drop the parity doubt (32 -> 28)
     if (partiallyPopulated) {
       ++m_paddedC1s;
     } else {
@@ -118,6 +193,16 @@ void ReedSolomon::c1Decode(std::vector<uint8_t>& inputData,
     }
     return;
   }
+
+  // Issue #307: top up the erasure list from the producer's doubt.
+  const int doubtErasures = seedDoubtErasures(errorData, doubtData);
+  if (doubtErasures > 0) {
+    m_doubtErasuresC1 += doubtErasures;
+    ++m_doubtSeededC1s;
+  }
+
+  // Snapshot the supplied erasures before decode prunes them (see c2Decode).
+  const std::vector<int> suppliedErasures = m_erasures;
 
   // Decode the data
   int result = circRs.decode(m_scratchData, m_erasures, &m_position);
@@ -133,15 +218,30 @@ void ReedSolomon::c1Decode(std::vector<uint8_t>& inputData,
         ++locatedErrors;
       }
     }
-    if (2 * locatedErrors + static_cast<int>(suppliedErasures.size()) <= 4) {
+    if (2 * locatedErrors + static_cast<int>(suppliedErasures.size()) <=
+        kErasureCapacity) {
       accept = true;
     }
   }
 
   if (accept) {
+    // Doubt describes a specific received byte, so a byte the decoder actually
+    // replaced carries none: clear it rather than let a stale value seed a C2
+    // erasure for a symbol C1's parity has already settled. Positions ezpwd
+    // reports but left unchanged keep their doubt - the producer's distrust
+    // still describes the byte that is there. Done before inputData is
+    // overwritten, while it still holds the received word.
+    for (int p : m_position) {
+      if (p >= 0 && p < static_cast<int>(inputData.size()) &&
+          m_scratchData[p] != inputData[p]) {
+        doubtData[p] = 0;
+      }
+    }
+
     // Strip the parity bytes (32 → 28) from the corrected data
     inputData.assign(m_scratchData.begin(), m_scratchData.end() - 4);
     errorData.assign(inputData.size(), 0);
+    doubtData.resize(doubtData.size() - 4);
 
     if (partiallyPopulated) {
       ++m_paddedC1s;
@@ -156,6 +256,7 @@ void ReedSolomon::c1Decode(std::vector<uint8_t>& inputData,
   // Rejected: propagate the RECEIVED bytes (first 28) and flag all as corrupt.
   inputData.resize(inputData.size() - 4);
   errorData.assign(inputData.size(), 1);
+  doubtData.resize(doubtData.size() - 4);
   if (partiallyPopulated) {
     ++m_paddedC1s;
   } else {
@@ -168,7 +269,8 @@ void ReedSolomon::c1Decode(std::vector<uint8_t>& inputData,
 // This is a (28,24) Reed-Solomon encode - 28 bytes in, 24 bytes out
 void ReedSolomon::c2Decode(std::vector<uint8_t>& inputData,
                            std::vector<uint8_t>& errorData,
-                           std::vector<uint8_t>& paddedData) {
+                           std::vector<uint8_t>& paddedData,
+                           std::vector<uint8_t>& doubtData) {
   // Ensure input data is 28 bytes long
   if (inputData.size() != 28) {
     ORC_LOG_ERROR("ReedSolomon::c2Decode - Input data must be 28 bytes long");
@@ -177,6 +279,11 @@ void ReedSolomon::c2Decode(std::vector<uint8_t>& inputData,
 
   if (errorData.size() != 28) {
     ORC_LOG_ERROR("ReedSolomon::c2Decode - Error data must be 28 bytes long");
+    throw efm::EfmDecodeError(__func__);
+  }
+
+  if (doubtData.size() != 28) {
+    ORC_LOG_ERROR("ReedSolomon::c2Decode - Doubt data must be 28 bytes long");
     throw efm::EfmDecodeError(__func__);
   }
 
@@ -204,17 +311,14 @@ void ReedSolomon::c2Decode(std::vector<uint8_t>& inputData,
     if (errorData[index] != 0) m_erasures.push_back(index);
   }
 
-  // Snapshot the supplied erasures: ezpwd's decode() prunes erasures it finds
-  // were actually correct, so we need the original list to classify the
-  // corrections it reports in 'position'.
-  const std::vector<int> suppliedErasures = m_erasures;
-
   // The (28,24) C2 code has minimum distance 5, so more than 4 supplied
-  // erasures already exceeds capacity and cannot be corrected.
-  if (suppliedErasures.size() > 4) {
+  // erasures already exceeds capacity and cannot be corrected. Tested before
+  // the doubt-derived erasures are added (see c1Decode).
+  if (static_cast<int>(m_erasures.size()) > kErasureCapacity) {
     // Remove parity byte positions 12-15 and assign result
     inputData.erase(inputData.begin() + 12, inputData.begin() + 16);
     errorData.assign(inputData.size(), 1);
+    dropC2Parity(doubtData);
     if (partiallyPopulated) {
       ++m_paddedC2s;
     } else {
@@ -222,6 +326,21 @@ void ReedSolomon::c2Decode(std::vector<uint8_t>& inputData,
     }
     return;
   }
+
+  // Issue #307: top up the erasure list from the producer's doubt. This is
+  // where the doubt earns its keep - after C1 has passed a word the EFM decode
+  // could find nothing wrong with, the doubt is the only remaining evidence
+  // that some of its symbols are not what the disc carried.
+  const int doubtErasures = seedDoubtErasures(errorData, doubtData);
+  if (doubtErasures > 0) {
+    m_doubtErasuresC2 += doubtErasures;
+    ++m_doubtSeededC2s;
+  }
+
+  // Snapshot the supplied erasures: ezpwd's decode() prunes erasures it finds
+  // were actually correct, so we need the original list to classify the
+  // corrections it reports in 'position'.
+  const std::vector<int> suppliedErasures = m_erasures;
 
   // Decode the data
   int result = circRs.decode(m_scratchData, m_erasures, &m_position);
@@ -244,12 +363,22 @@ void ReedSolomon::c2Decode(std::vector<uint8_t>& inputData,
         ++locatedErrors;
       }
     }
-    if (2 * locatedErrors + static_cast<int>(suppliedErasures.size()) <= 4) {
+    if (2 * locatedErrors + static_cast<int>(suppliedErasures.size()) <=
+        kErasureCapacity) {
       accept = true;
     }
   }
 
   if (accept) {
+    // As in c1Decode: doubt about a byte the decoder replaced is spent, and
+    // must be cleared while inputData still holds the received word.
+    for (int p : m_position) {
+      if (p >= 0 && p < static_cast<int>(inputData.size()) &&
+          m_scratchData[p] != inputData[p]) {
+        doubtData[p] = 0;
+      }
+    }
+
     // Keep the 24 payload bytes of the decoded (corrected) data, dropping
     // parity byte positions 12-15. Written straight into inputData (reusing its
     // capacity) so the scratch buffer is left intact for the next call.
@@ -259,6 +388,7 @@ void ReedSolomon::c2Decode(std::vector<uint8_t>& inputData,
     std::copy(m_scratchData.begin() + 16, m_scratchData.begin() + 28,
               inputData.begin() + 12);
     errorData.assign(inputData.size(), 0);
+    dropC2Parity(doubtData);
 
     if (partiallyPopulated) {
       ++m_paddedC2s;
@@ -274,6 +404,7 @@ void ReedSolomon::c2Decode(std::vector<uint8_t>& inputData,
   // which may hold a miscorrection) and flag all outputs as corrupt.
   inputData.erase(inputData.begin() + 12, inputData.begin() + 16);
   errorData.assign(inputData.size(), 1);
+  dropC2Parity(doubtData);
   if (partiallyPopulated) {
     ++m_paddedC2s;
   } else {

--- a/orc/plugins/stages/common/efm-decode/efm-lib/reedsolomon.h
+++ b/orc/plugins/stages/common/efm-decode/efm-lib/reedsolomon.h
@@ -10,6 +10,7 @@
 #define REEDSOLOMON_H
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 // ezpwd __RS() macro parameters are:
@@ -38,12 +39,35 @@
 class ReedSolomon {
  public:
   ReedSolomon();
+
+  // Both CIRC codes have minimum distance 5, so either corrects any
+  // combination of e located errors and s supplied erasures satisfying
+  // 2e + s <= 4. Four is therefore the hard erasure capacity of a codeword.
+  // (IEC 60908 §16.3 / ECMA-130 Annex C.)
+  static constexpr int kErasureCapacity = 4;
+
+  // Issue #307: the smallest producer doubt (0 trusted - 15 distrusted) that
+  // makes a symbol an erasure candidate. 0 disables doubt-derived erasures
+  // entirely, which is the bit-exact legacy behaviour.
+  void setDoubtErasureThreshold(uint8_t threshold);
+
   void c1Decode(std::vector<uint8_t>& inputData,
                 std::vector<uint8_t>& errorData,
-                std::vector<uint8_t>& paddedData);
+                std::vector<uint8_t>& paddedData,
+                std::vector<uint8_t>& doubtData);
   void c2Decode(std::vector<uint8_t>& inputData,
                 std::vector<uint8_t>& errorData,
-                std::vector<uint8_t>& paddedData);
+                std::vector<uint8_t>& paddedData,
+                std::vector<uint8_t>& doubtData);
+
+  // Symbols that were made erasures on the strength of the producer's doubt
+  // alone (i.e. the 14->8 EFM decode found nothing wrong with them), and the
+  // codewords that received at least one such erasure. Reported so the
+  // threshold's cost can be seen in the decode report.
+  int64_t doubtErasuresC1() const { return m_doubtErasuresC1; }
+  int64_t doubtErasuresC2() const { return m_doubtErasuresC2; }
+  int64_t doubtSeededC1s() const { return m_doubtSeededC1s; }
+  int64_t doubtSeededC2s() const { return m_doubtSeededC2s; }
 
   // Codewords that were fully populated with received disc data. These are the
   // only ones whose outcome says anything about the input's quality.
@@ -64,6 +88,13 @@ class ReedSolomon {
   int32_t paddedC2s() const;
 
  private:
+  // Append doubt-derived erasure positions to m_erasures, most-doubted first,
+  // stopping at the code's erasure capacity. Positions already flagged by
+  // errorData are skipped (they are erasures already). Returns the number of
+  // positions added.
+  int seedDoubtErasures(const std::vector<uint8_t>& errorData,
+                        const std::vector<uint8_t>& doubtData);
+
   // P-6: reusable scratch buffers so the CIRC hot path (decode() is called
   // ~26M times per stereo disc) does not allocate per call. Each pipeline owns
   // its own ReedSolomon and calls c1/c2Decode sequentially, so plain members
@@ -71,6 +102,18 @@ class ReedSolomon {
   std::vector<uint8_t> m_scratchData;
   std::vector<int> m_erasures;
   std::vector<int> m_position;
+
+  // Reusable (doubt, position) candidate scratch for seedDoubtErasures(), kept
+  // out of the hot path's allocation budget for the same reason as the buffers
+  // above.
+  std::vector<std::pair<uint8_t, int>> m_doubtCandidates;
+
+  uint8_t m_doubtErasureThreshold;
+
+  int64_t m_doubtErasuresC1;
+  int64_t m_doubtErasuresC2;
+  int64_t m_doubtSeededC1s;
+  int64_t m_doubtSeededC2s;
 
   int32_t m_validC1s;
   int32_t m_fixedC1s;

--- a/orc/plugins/stages/common/efm-decode/efm_processor.cpp
+++ b/orc/plugins/stages/common/efm-decode/efm_processor.cpp
@@ -22,6 +22,7 @@
 EfmProcessor::EfmProcessor()
     : m_audioMode(true),
       m_noTimecodes(false),
+      m_doubtErasureThreshold(0),
       m_audacityLabels(false),
       m_noAudioConcealment(false),
       m_ignorePreemphasis(false),
@@ -47,6 +48,10 @@ void EfmProcessor::setAudioMode(bool audioMode) { m_audioMode = audioMode; }
 
 void EfmProcessor::setNoTimecodes(bool noTimecodes) {
   m_noTimecodes = noTimecodes;
+}
+
+void EfmProcessor::setDoubtErasureThreshold(uint8_t threshold) {
+  m_doubtErasureThreshold = threshold;
 }
 
 void EfmProcessor::setAudacityLabels(bool audacityLabels) {
@@ -113,6 +118,11 @@ bool EfmProcessor::beginStream(const std::string& outputFilename,
 
   // Apply decoder configuration
   m_f2SectionCorrection.setNoTimecodes(m_noTimecodes);
+  m_f2SectionToF1Section.setDoubtErasureThreshold(m_doubtErasureThreshold);
+  // Attributing the doubt to symbols is per-T-value work in the hottest loop
+  // of the decode, so it is only done when the CIRC has been asked to seed
+  // erasures from the result (issue #307).
+  m_channelToF3.setCollectDoubt(m_doubtErasureThreshold > 0);
 
   // Open output writers based on mode
   if (m_audioMode) {
@@ -1353,6 +1363,19 @@ void EfmProcessor::showQuality() const {
   ORC_LOG_INFO(
       "              or end-of-stream drain symbols and so could not be "
       "scored.");
+  if (m_doubtErasureThreshold > 0) {
+    // Issue #307: how much of the correction budget the producer's doubt is
+    // actually spending. An erasure counted here was raised on the doubt
+    // alone - the EFM decode found nothing wrong with the symbol.
+    ORC_LOG_INFO(
+        "    Producer-doubt erasures (threshold {}): C1 {} in {} codeword(s), "
+        "C2 {} in {} codeword(s)",
+        static_cast<int>(m_doubtErasureThreshold),
+        commas(m_f2SectionToF1Section.doubtErasuresC1()),
+        commas(m_f2SectionToF1Section.doubtSeededC1s()),
+        commas(m_f2SectionToF1Section.doubtErasuresC2()),
+        commas(m_f2SectionToF1Section.doubtSeededC2s()));
+  }
   ORC_LOG_INFO("");
 
   showDecodeBoundaries();

--- a/orc/plugins/stages/common/efm-decode/efm_processor.h
+++ b/orc/plugins/stages/common/efm-decode/efm_processor.h
@@ -61,6 +61,12 @@ class EfmProcessor {
   // Streaming API: feed t-values field-by-field without a temporary buffer.
   // Call beginStream() once, then pushChunk() for each field's samples,
   // then finishStream() to flush and finalise output.
+  //
+  // The chunk carries PACKED EFM bytes exactly as they appear in an .efm file:
+  // the t-value in the low nibble and the producer's doubt in the high nibble
+  // (CVBS File Format Specification, EFM extension format). A caller with no
+  // confidence information simply passes plain t-values, which is the same
+  // stream with an all-zero doubt nibble.
   bool beginStream(const std::string& outputFilename, int64_t totalTValues = 0);
   void pushChunk(const std::vector<uint8_t>& chunk);
   bool finishStream();
@@ -74,6 +80,13 @@ class EfmProcessor {
 
   // EFM options
   void setNoTimecodes(bool noTimecodes);
+
+  // Issue #307: the smallest producer doubt (0 trusted - 15 distrusted) that
+  // makes an otherwise-clean symbol a C1/C2 erasure candidate. Every .efm byte
+  // carries the producer's doubt in its high nibble; the CIRC uses it to seed
+  // erasures for the symbols that demodulate cleanly but are wrong anyway.
+  // 0 disables doubt-derived erasures (bit-exact legacy behaviour).
+  void setDoubtErasureThreshold(uint8_t threshold);
 
   // Audio options
   void setAudacityLabels(bool audacityLabels);
@@ -126,6 +139,7 @@ class EfmProcessor {
   // -----------------------------------------------------------------------
   bool m_audioMode;  // true = audio path, false = data path
   bool m_noTimecodes;
+  uint8_t m_doubtErasureThreshold;
   bool m_audacityLabels;
   bool m_noAudioConcealment;
   bool m_ignorePreemphasis;

--- a/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage.cpp
+++ b/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage.cpp
@@ -28,6 +28,22 @@ namespace {
 // IEC 60908 (CD-DA): EFM decodes to 44.1 kHz 16-bit stereo audio.
 constexpr double kCdSampleRateHz = 44100.0;
 
+// Issue #307: bounds for the doubt_erasure_threshold parameter. Doubt is the
+// 4-bit field the producer packs into the high nibble of every .efm byte
+// (CVBS File Format Specification, EFM extension format), so it spans 0-15;
+// 0 as a threshold means "never seed an erasure from doubt" rather than "seed
+// every symbol", since doubt 0 is the fully-trusted value.
+constexpr int32_t kDoubtErasureThresholdOff = 0;
+constexpr int32_t kDoubtErasureThresholdMax = 15;
+// Off by default. Measured over BBC Domesday DS2 National A (CAV PAL, 54,000
+// frames, 120,219 sections) with thresholds 15 down to 11: seeding erasures
+// from the doubt improves C1 slightly (4,047 -> 3,963 uncorrectable at 13) but
+// never changes the recovered-sector count, and below 13 it costs sectors as
+// the spurious erasures eat C2's capacity. Until a disc is found where it pays,
+// the default leaves the decode bit-exact and the setting is there to be
+// tried. 13 is the value to start from.
+constexpr int32_t kDoubtErasureThresholdDefault = kDoubtErasureThresholdOff;
+
 }  // namespace
 
 // ============================================================================
@@ -223,6 +239,9 @@ std::shared_ptr<const VideoFrameRepresentation> EFMAudioDecodeStage::process(
   options.report_path = report_ ? report_path_ : std::string{};
   options.pair_name = pair_name_;
   options.offset_ms = offset_ms_;
+  options.doubt_erasure_threshold = static_cast<uint8_t>(
+      std::clamp(doubt_erasure_threshold_, kDoubtErasureThresholdOff,
+                 kDoubtErasureThresholdMax));
   return std::make_shared<EFMAudioChannelPairRepresentation>(
       std::move(source), std::move(deps), options);
 }
@@ -301,6 +320,28 @@ std::vector<ParameterDescriptor> EFMAudioDecodeStage::get_parameter_descriptors(
 
   {
     ParameterDescriptor desc;
+    desc.name = "doubt_erasure_threshold";
+    desc.display_name = "Doubt Erasure Threshold";
+    desc.description =
+        "Treat an EFM symbol as a Reed-Solomon erasure when the producer's "
+        "doubt about it (0 trusted to 15 distrusted, carried in the .efm) "
+        "reaches this value. Symbols that demodulate to a legal EFM codeword "
+        "but are still wrong are invisible to C1/C2 otherwise, which leaves "
+        "them correcting unknown errors instead of erasures. Only the four "
+        "most-doubted symbols of a codeword are ever flagged, so the code's "
+        "capacity cannot be exceeded. 0 (the default) disables this and keeps "
+        "the decode bit-exact; 13 is the value to start from if you want to "
+        "try it. An .efm from a producer that carries no confidence "
+        "information is unaffected either way.";
+    desc.type = ParameterType::INT32;
+    desc.constraints.min_value = kDoubtErasureThresholdOff;
+    desc.constraints.max_value = kDoubtErasureThresholdMax;
+    desc.constraints.default_value = kDoubtErasureThresholdDefault;
+    descriptors.push_back(desc);
+  }
+
+  {
+    ParameterDescriptor desc;
     desc.name = "report";
     desc.display_name = "Write Decode Report";
     desc.description = "Write a detailed decode statistics report file";
@@ -332,6 +373,7 @@ std::map<std::string, ParameterValue> EFMAudioDecodeStage::get_parameters()
           {"ignore_preemphasis", ignore_preemphasis_},
           {"pair_name", pair_name_},
           {"offset_ms", offset_ms_},
+          {"doubt_erasure_threshold", doubt_erasure_threshold_},
           {"report", report_},
           {"report_path", report_path_}};
 }
@@ -354,6 +396,13 @@ bool EFMAudioDecodeStage::set_parameters(
   if (name_it != params.end()) {
     if (const std::string* s = std::get_if<std::string>(&name_it->second)) {
       pair_name_ = *s;
+    }
+  }
+
+  const auto doubt_it = params.find("doubt_erasure_threshold");
+  if (doubt_it != params.end()) {
+    if (const int32_t* v = std::get_if<int32_t>(&doubt_it->second)) {
+      doubt_erasure_threshold_ = *v;
     }
   }
 

--- a/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage.h
+++ b/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage.h
@@ -186,6 +186,10 @@ class EFMAudioDecodeStage : public DAGStage,
   // User sync slip in milliseconds on top of the automatic video-timeline
   // alignment; positive delays the audio, negative advances it (issue #231).
   double offset_ms_ = 0.0;
+  // Issue #307: smallest producer doubt (0 trusted - 15 distrusted) that makes
+  // an otherwise-clean EFM symbol a C1/C2 erasure candidate; 0 (the default)
+  // disables it, leaving the decode bit-exact.
+  int32_t doubt_erasure_threshold_ = 0;
 
   mutable std::shared_ptr<const VideoFrameRepresentation> cached_output_;
   std::shared_ptr<IEFMAudioDecodeDeps> deps_override_;

--- a/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage_deps.cpp
+++ b/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage_deps.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstddef>
 #include <fstream>
 #include <system_error>
 
@@ -85,6 +86,7 @@ EFMAudioDecodeResult EFMAudioDecodeDeps::decode_to_cache(
   processor.setAudioMode(true);
   processor.setNoWavHeader(true);
   processor.setNoTimecodes(options.no_timecodes);
+  processor.setDoubtErasureThreshold(options.doubt_erasure_threshold);
   processor.setNoAudioConcealment(options.no_audio_concealment);
   processor.setIgnorePreemphasis(options.ignore_preemphasis);
 
@@ -132,13 +134,13 @@ EFMAudioDecodeResult EFMAudioDecodeDeps::decode_to_cache(
         const size_t take =
             std::min(kChunkSize - staging.size(), samples.size() - pos);
         // The pipeline carries the producer's per-t-value doubt in the high
-        // nibble of each byte. It travels the DAG intact, but the decoder
-        // consumes t-values, so strip it here at the point of consumption.
-        // (The doubt is not yet used; when the C1/C2 stages learn to take
-        // erasure hints it should be forwarded rather than discarded.)
-        for (size_t i = 0; i < take; ++i) {
-          staging.push_back(efm_tvalue(samples[pos + i]));
-        }
+        // nibble of each byte, and the decoder now consumes packed bytes
+        // (issue #307): the CIRC uses the doubt to seed C1/C2 erasures for the
+        // symbols that demodulate cleanly but are wrong anyway. Forward the
+        // bytes untouched.
+        const auto first = samples.begin() + static_cast<std::ptrdiff_t>(pos);
+        staging.insert(staging.end(), first,
+                       first + static_cast<std::ptrdiff_t>(take));
         pos += take;
         if (staging.size() == kChunkSize) {
           processor.pushChunk(staging);

--- a/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage_deps_interface.h
+++ b/orc/plugins/stages/efm_audio_decode/efm_audio_decode_stage_deps_interface.h
@@ -39,6 +39,10 @@ struct EFMAudioDecodeOptions {
   // input-timeline (video) alignment; positive delays the audio relative to
   // the video, negative advances it (issue #231).
   double offset_ms{0.0};
+  // Issue #307: smallest producer doubt (0 trusted - 15 distrusted) that makes
+  // an otherwise-clean EFM symbol a C1/C2 erasure candidate. 0 disables
+  // doubt-derived erasures (bit-exact legacy output).
+  uint8_t doubt_erasure_threshold{0};
 };
 
 struct EFMAudioDecodeResult {

--- a/orc/plugins/stages/efm_audio_decode/instructions.md
+++ b/orc/plugins/stages/efm_audio_decode/instructions.md
@@ -44,7 +44,11 @@ Treat an EFM symbol as a Reed-Solomon erasure when the producer's doubt about it
 
 Symbols that demodulate to a legal EFM codeword but are still wrong are invisible to every check the decoder can make on its own, which leaves C1/C2 correcting unknown errors instead of erasures — and each code corrects 2 unknown errors but 4 erasures. Only the four most-doubted symbols of a codeword are ever flagged, and only after the erasures the EFM decode raised in its own right, so the code's erasure capacity can never be exceeded.
 
-Default: `0`, which disables doubt-derived erasures and leaves the decode bit-exact. This is a setting to experiment with rather than one to leave on — see the EFM Decoder Sink's `doubt_erasure_threshold` notes for the measurements behind that default. `13` is the value to start from if you want to try it.
+Default: `0`, which disables doubt-derived erasures and leaves the decode bit-exact. Leave it there.
+
+Measured on a PAL CLV audio side, no setting improves the decoded audio. Thresholds of 11 and above leave it byte-identical to the baseline: C1 uncorrectable falls by up to 9%, but C2 was already correcting those codewords, so nothing reaches the output. Thresholds below 9 do change the audio, and the changes are impulses rather than repairs — at threshold 1 the 8,841 altered samples have a median second difference of 11,844 against 78 for the same positions with the setting off, and the largest single change is more than half of full scale.
+
+The reason to be careful rather than merely unimpressed is that the report does not reveal this. At threshold 1 the C2 uncorrectable count, the concealed count and the muted count all sit exactly at their baseline values while the audio carries several thousand clicks, because an erasure-assisted C1 miscorrection is a confidently wrong answer that C2 has no reason to question. If you experiment here, compare the decoded audio, not the statistics. See the EFM Decoder Sink's `doubt_erasure_threshold` notes for the full measurements, including the data-disc case.
 
 ### report
 Boolean, default `false`. Enable to write a detailed decode statistics report (the same per-stage CIRC/error/timing statistics the EFM Decoder Sink writes) once the lazy decode runs. When enabled, set the report destination in **report_path**.

--- a/orc/plugins/stages/efm_audio_decode/instructions.md
+++ b/orc/plugins/stages/efm_audio_decode/instructions.md
@@ -14,7 +14,7 @@ This transform is audio-only. EFM data discs (ECMA-130 sectors) cannot become an
 
 The stage wraps the incoming frame representation and appends one audio channel pair (named from the `Channel Pair Name` parameter, default `EFM digital audio`; origin EFM). The name surfaces in the CVBS container and as the embedded stream title in the Video Sink. Video, dropout hints, undecoded EFM/AC3 signal data, and all existing audio channel pairs pass through untouched.
 
-Each EFM byte on the pipeline packs the t-value into its low nibble and the producer's confidence — as a doubt value, 0 trusted to 15 distrusted — into its high nibble. That confidence travels the DAG intact, but this stage consumes t-values, so it strips the doubt nibble as the t-values enter the decoder. The decode is therefore unaffected by whether the source recorded any confidence. (The doubt is not yet used as an error-correction erasure hint; that is a future refinement of the CIRC stages.)
+Each EFM byte on the pipeline packs the t-value into its low nibble and the producer's confidence — as a doubt value, 0 trusted to 15 distrusted — into its high nibble. Both are handed to the decoder: the doubt is carried through EFM framing, attributed to the 14-bit symbols the doubted t-values contributed to, and used to seed C1/C2 Reed-Solomon erasures (see `doubt_erasure_threshold`). A source that recorded no confidence is all-zero doubt and decodes exactly as before.
 
 EFM decoding is whole-stream sequential (the CIRC interleaving spans sectors), so it cannot run frame-by-frame. The decode therefore runs lazily, at most once, on the first access to the appended pair's audio: the stage gathers the t-values across the input's full frame range, runs the shared EFM decode pipeline, widens the decoded 44.1 kHz 16-bit CD audio to 24-bit, resamples it to 48 kHz (SoXR HQ), and caches the converted frame-locked PCM in a scratch file on disk. Video-only preview and project validation never trigger the decode.
 
@@ -38,6 +38,13 @@ String, default `EFM digital audio`. Human-readable name for the decoded EFM aud
 
 ### offset_ms
 Double, default `0`. Additional sync slip in milliseconds applied on top of the automatic video-timeline alignment. Positive values delay the audio relative to the video; negative values advance it. Leave at 0 unless the decoded audio still needs nudging after the automatic alignment.
+
+### doubt_erasure_threshold
+Treat an EFM symbol as a Reed-Solomon erasure when the producer's doubt about it (0 trusted to 15 distrusted, carried in the high nibble of every `.efm` byte) reaches this value.
+
+Symbols that demodulate to a legal EFM codeword but are still wrong are invisible to every check the decoder can make on its own, which leaves C1/C2 correcting unknown errors instead of erasures — and each code corrects 2 unknown errors but 4 erasures. Only the four most-doubted symbols of a codeword are ever flagged, and only after the erasures the EFM decode raised in its own right, so the code's erasure capacity can never be exceeded.
+
+Default: `0`, which disables doubt-derived erasures and leaves the decode bit-exact. This is a setting to experiment with rather than one to leave on — see the EFM Decoder Sink's `doubt_erasure_threshold` notes for the measurements behind that default. `13` is the value to start from if you want to try it.
 
 ### report
 Boolean, default `false`. Enable to write a detailed decode statistics report (the same per-stage CIRC/error/timing statistics the EFM Decoder Sink writes) once the lazy decode runs. When enabled, set the report destination in **report_path**.

--- a/orc/plugins/stages/efm_sink/efm_sink_stage.cpp
+++ b/orc/plugins/stages/efm_sink/efm_sink_stage.cpp
@@ -13,12 +13,40 @@
 #include <orc/stage/common_types.h>
 #include <orc/support/logging.h>
 
+#include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 
 #include "efm_sink_stage_deps.h"
 #include "efm_sink_stage_deps_interface.h"
 
 namespace orc {
+namespace {
+// Issue #307: bounds for the doubt_erasure_threshold parameter. Doubt is the
+// 4-bit field the producer packs into the high nibble of every .efm byte
+// (CVBS File Format Specification, EFM extension format), so it spans 0-15;
+// 0 as a threshold means "never seed an erasure from doubt" rather than "seed
+// every symbol", since doubt 0 is the fully-trusted value.
+constexpr int32_t kDoubtErasureThresholdOff = 0;
+constexpr int32_t kDoubtErasureThresholdMax = 15;
+// Off by default. Measured over BBC Domesday DS2 National A (CAV PAL, 54,000
+// frames, 120,219 sections) with thresholds 15 down to 11: seeding erasures
+// from the doubt improves C1 slightly (4,047 -> 3,963 uncorrectable at 13) but
+// never changes the recovered-sector count, and below 13 it costs sectors as
+// the spurious erasures eat C2's capacity. Until a disc is found where it pays,
+// the default leaves the decode bit-exact and the setting is there to be
+// tried. 13 is the value to start from.
+constexpr int32_t kDoubtErasureThresholdDefault = kDoubtErasureThresholdOff;
+
+int32_t get_int32_param(const std::map<std::string, ParameterValue>& params,
+                        const std::string& name, int32_t default_val) {
+  auto it = params.find(name);
+  if (it == params.end()) return default_val;
+  if (const int32_t* v = std::get_if<int32_t>(&it->second)) return *v;
+  return default_val;
+}
+
+}  // namespace
 
 EFMSinkStage::EFMSinkStage() {
   set_configuration_status(orc::ConfigurationStatus::Red);
@@ -215,6 +243,29 @@ std::vector<ParameterDescriptor> EFMSinkStage::get_parameter_descriptors(
     descriptors.push_back(desc);
   }
 
+  // doubt_erasure_threshold  (audio + data)
+  {
+    ParameterDescriptor desc;
+    desc.name = "doubt_erasure_threshold";
+    desc.display_name = "Doubt Erasure Threshold";
+    desc.description =
+        "Treat an EFM symbol as a Reed-Solomon erasure when the producer's "
+        "doubt about it (0 trusted to 15 distrusted, carried in the .efm) "
+        "reaches this value. Symbols that demodulate to a legal EFM codeword "
+        "but are still wrong are invisible to C1/C2 otherwise, which leaves "
+        "them correcting unknown errors instead of erasures. Only the four "
+        "most-doubted symbols of a codeword are ever flagged, so the code's "
+        "capacity cannot be exceeded. 0 (the default) disables this and keeps "
+        "the decode bit-exact; 13 is the value to start from if you want to "
+        "try it. An .efm from a producer that carries no confidence "
+        "information is unaffected either way.";
+    desc.type = ParameterType::INT32;
+    desc.constraints.min_value = kDoubtErasureThresholdOff;
+    desc.constraints.max_value = kDoubtErasureThresholdMax;
+    desc.constraints.default_value = kDoubtErasureThresholdDefault;
+    descriptors.push_back(desc);
+  }
+
   // report
   {
     ParameterDescriptor desc;
@@ -331,6 +382,10 @@ bool EFMSinkStage::trigger(
     const bool no_wav_header = get_bool_param(parameters, "no_wav_header");
     const bool output_metadata = get_bool_param(parameters, "output_metadata");
     const bool report = get_bool_param(parameters, "report");
+    const int32_t doubt_erasure_threshold =
+        std::clamp(get_int32_param(parameters, "doubt_erasure_threshold",
+                                   kDoubtErasureThresholdDefault),
+                   kDoubtErasureThresholdOff, kDoubtErasureThresholdMax);
     const bool video_sync = get_bool_param(parameters, "video_sync", true);
     const double offset_ms = get_double_param(parameters, "offset_ms");
 
@@ -348,6 +403,8 @@ bool EFMSinkStage::trigger(
     options.no_wav_header = no_wav_header;
     options.output_metadata = output_metadata;
     options.report = report;
+    options.doubt_erasure_threshold =
+        static_cast<uint8_t>(doubt_erasure_threshold);
     options.video_sync = video_sync;
     options.offset_ms = offset_ms;
 

--- a/orc/plugins/stages/efm_sink/efm_sink_stage_deps.cpp
+++ b/orc/plugins/stages/efm_sink/efm_sink_stage_deps.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 
 #include "efm-decode/efm-lib/efm_exception.h"
 #include "efm-decode/efm_processor.h"
@@ -58,6 +59,7 @@ EFMSinkDecodeResult EFMSinkStageDeps::decode_efm(
     EfmProcessor processor;
     processor.setAudioMode(options.audio_mode);
     processor.setNoTimecodes(options.no_timecodes);
+    processor.setDoubtErasureThreshold(options.doubt_erasure_threshold);
     processor.setAudacityLabels(options.audacity_labels);
     processor.setNoAudioConcealment(options.no_audio_concealment);
     processor.setIgnorePreemphasis(options.ignore_preemphasis);
@@ -97,13 +99,13 @@ EFMSinkDecodeResult EFMSinkStageDeps::decode_efm(
         const size_t take =
             std::min(CHUNK_SIZE - staging.size(), samples.size() - pos);
         // The pipeline carries the producer's per-t-value doubt in the high
-        // nibble of each byte. It travels the DAG intact, but the decoder
-        // consumes t-values, so strip it here at the point of consumption.
-        // (The doubt is not yet used; when the C1/C2 stages learn to take
-        // erasure hints it should be forwarded rather than discarded.)
-        for (size_t i = 0; i < take; ++i) {
-          staging.push_back(efm_tvalue(samples[pos + i]));
-        }
+        // nibble of each byte, and the decoder now consumes packed bytes
+        // (issue #307): the CIRC uses the doubt to seed C1/C2 erasures for the
+        // symbols that demodulate cleanly but are wrong anyway. Forward the
+        // bytes untouched.
+        const auto first = samples.begin() + static_cast<std::ptrdiff_t>(pos);
+        staging.insert(staging.end(), first,
+                       first + static_cast<std::ptrdiff_t>(take));
         pos += take;
         if (staging.size() == CHUNK_SIZE) {
           processor.pushChunk(staging);

--- a/orc/plugins/stages/efm_sink/efm_sink_stage_deps_interface.h
+++ b/orc/plugins/stages/efm_sink/efm_sink_stage_deps_interface.h
@@ -14,6 +14,7 @@
 #include <orc/stage/video_frame_representation.h>
 
 #include <atomic>
+#include <cstdint>
 #include <string>
 
 namespace orc {
@@ -36,6 +37,10 @@ struct EFMSinkOptions {
   // User sync slip in milliseconds applied on top of the alignment; positive
   // delays the audio relative to the video, negative advances it.
   double offset_ms{0.0};
+  // Issue #307: smallest producer doubt (0 trusted - 15 distrusted) that makes
+  // an otherwise-clean EFM symbol a C1/C2 erasure candidate. 0 disables
+  // doubt-derived erasures (bit-exact legacy output).
+  uint8_t doubt_erasure_threshold{0};
 };
 
 struct EFMSinkDecodeResult {

--- a/orc/plugins/stages/efm_sink/instructions.md
+++ b/orc/plugins/stages/efm_sink/instructions.md
@@ -54,7 +54,31 @@ This matters because the errors that dominate data-disc sector loss are invisibl
 
 Only the four most-doubted symbols of a codeword are ever flagged, and only after the erasures the EFM decode raised in its own right, so the code's erasure capacity can never be exceeded — ranking and capping, rather than a bare threshold, is what stops a bad stretch from pushing a codeword past what it can correct.
 
-Default: `0`, which disables doubt-derived erasures and leaves the decode bit-exact. This is a setting to experiment with rather than one to leave on: measured over a full BBC Domesday side (CAV PAL, 120,219 sections), thresholds of 13 to 15 improved C1 slightly but did not change the recovered-sector count at all, and thresholds below 13 lost sectors as the spurious erasures ate into C2's capacity. `13` is the value to start from if you want to try it. An `.efm` from a producer that carries no confidence information is all-zero doubt and so decodes identically at any setting.
+Default: `0`, which disables doubt-derived erasures and leaves the decode bit-exact. Leave it there. Two measurements say so, and the second one is the reason the default is not merely cautious.
+
+On a data disc — a full BBC Domesday side, CAV PAL, 120,219 sections — thresholds of 13 to 15 improved C1 slightly but did not change the recovered-sector count at all, and thresholds below 13 lost sectors as the spurious erasures ate into C2's capacity.
+
+On an audio disc — a PAL CLV side, 2.94 M sections, 73% of its t-values carrying no doubt at all — the picture is worse than neutral:
+
+| threshold | C1 uncorrectable | C2 uncorrectable | concealed samples | decoded audio |
+|-----------|------------------|------------------|-------------------|---------------|
+| 0 (off)   | 247              | 350              | 48                | baseline |
+| 15        | 248              | 350              | 48                | byte-identical |
+| 13        | 247              | 350              | 48                | byte-identical |
+| 11        | 225              | 350              | 48                | byte-identical |
+| 9         | 230              | 351              | 60                | 14 bytes differ |
+| 7         | 248              | 363              | 204               | 166 bytes differ |
+| 5         | 286              | 585              | 2,868             | 3,511 bytes differ |
+| 3         | 208              | 454              | 1,272             | 9,888 bytes differ |
+| 1         | 198              | 350              | 48                | 9,604 bytes differ |
+
+Threshold 11 gives the best honest result and it is worth nothing: C1 uncorrectable falls 9%, and the decoded audio is byte-identical, because C2 was already correcting every one of those codewords.
+
+Threshold 1 looks better still on the counters — C1 down 20%, C2 and the concealment figures exactly at their baseline values — and it is the dangerous setting. It changes 8,841 samples that both decodes consider valid, and those samples are impulses, not repairs: their median second difference is 11,844 against 78 for the same positions in the baseline and 80 for the file at large, and 7,928 of them come out rougher rather than smoother. The largest single change is 35,114, more than half of full scale. These are erasure-assisted miscorrections — C1 given four erasures can solve a codeword that in truth had errors outside the erased positions, and it then hands C2 a confidently wrong answer that C2 has no reason to question.
+
+That is the trap: the decode statistics do not show it. A reader tuning on the reported C1, C2 and concealment counts would conclude threshold 1 was free, and ship audio with several thousand clicks in it. If you experiment here, compare the decoded output, not the report.
+
+An `.efm` from a producer that carries no confidence information is all-zero doubt and so decodes identically at any setting.
 
 ### report (boolean)
 Write a detailed decode statistics report file alongside the main output. Default: `false`.

--- a/orc/plugins/stages/efm_sink/instructions.md
+++ b/orc/plugins/stages/efm_sink/instructions.md
@@ -47,6 +47,15 @@ Output raw PCM samples without a RIFF WAV header. Useful when the output will be
 ### output_metadata (boolean)
 Write a bad-sector map file alongside the sector output recording the position of any missing or corrupt sectors. Data mode only. Default: `false`.
 
+### doubt_erasure_threshold (integer, 0-15)
+Treat an EFM symbol as a Reed-Solomon erasure when the producer's doubt about it reaches this value. Every byte of an `.efm` file carries a t-value in its low nibble and the producer's doubt about that t-value in its high nibble (0 = fully trusted, 15 = positively distrusted).
+
+This matters because the errors that dominate data-disc sector loss are invisible to every check the decoder can make on its own: the frame is 588 channel bits, the symbols are legal EFM codewords, and the 14→8 decode finds nothing wrong — so C1 raises no erasure and C2 is left correcting unknown errors instead of erasures. Since each code corrects 2 unknown errors but 4 erasures, losing the flag roughly halves its correction power.
+
+Only the four most-doubted symbols of a codeword are ever flagged, and only after the erasures the EFM decode raised in its own right, so the code's erasure capacity can never be exceeded — ranking and capping, rather than a bare threshold, is what stops a bad stretch from pushing a codeword past what it can correct.
+
+Default: `0`, which disables doubt-derived erasures and leaves the decode bit-exact. This is a setting to experiment with rather than one to leave on: measured over a full BBC Domesday side (CAV PAL, 120,219 sections), thresholds of 13 to 15 improved C1 slightly but did not change the recovered-sector count at all, and thresholds below 13 lost sectors as the spurious erasures ate into C2's capacity. `13` is the value to start from if you want to try it. An `.efm` from a producer that carries no confidence information is all-zero doubt and so decodes identically at any setting.
+
 ### report (boolean)
 Write a detailed decode statistics report file alongside the main output. Default: `false`.
 

--- a/orc/plugins/stages/stacker/efm_confidence_stack.cpp
+++ b/orc/plugins/stages/stacker/efm_confidence_stack.cpp
@@ -1,0 +1,566 @@
+/*
+ * File:        efm_confidence_stack.cpp
+ * Module:      orc-core
+ * Purpose:     Sync-anchored confidence-weighted combining of EFM t-values
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include "efm_confidence_stack.h"
+
+#include <orc/stage/video_frame_representation.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+
+namespace orc {
+namespace {
+
+// IEC 60908 Section 20.2: an EFM channel frame is 588 channel bits long and
+// opens with the frame sync pattern, two consecutive T11 runs.
+constexpr int kChannelFrameBits = 588;
+constexpr uint8_t kSyncSymbolT11 = 11;
+
+// IEC 60908 Section 20.1: the (2,10) run-length limit of EFM bounds every run
+// to T3..T11.
+constexpr int kMinRunBits = 3;
+constexpr int kMaxRunBits = 11;
+
+// Whole-slot alignment offsets tried either side of the computed one, to
+// absorb a source whose own first sync was missed or spurious.
+constexpr int64_t kAlignmentSearchRadius = 1;
+
+// Repair is a fixed-point loop over at most a few hundred boundaries; the cap
+// only exists so a pathological slot cannot spin.
+constexpr int kMaxRepairPasses = 64;
+
+// A source's weight for one run, from the producer's doubt nibble. The band is
+// deliberately narrow - 32 for a fully trusted run down to 17 for a fully
+// distrusted one - so that two sources which agree (34) always outweigh one
+// that does not (32), however sure of itself it is. A producer's doubt is one
+// capture's opinion of its own reading; two independent captures agreeing is
+// an observation, and the better evidence of the two. With a wider band a
+// single confident capture can delete a transition that two doubtful ones both
+// saw, which restructures the whole channel frame around it.
+constexpr int kMinRunWeight = 17;
+constexpr int kMaxRunWeight = kMinRunWeight + static_cast<int>(kEfmDoubtMax);
+
+int run_weight(uint8_t packed) {
+  return kMaxRunWeight - static_cast<int>(efm_doubt(packed));
+}
+
+// One complete 588-bit channel frame within a source's t-value stream.
+struct Segment {
+  size_t begin = 0;  // index of the first sync symbol
+  size_t count = 0;  // t-values in the channel frame
+};
+
+// A source's t-values cut on its own sync grid. |slots| is ascending by slot
+// number and holds only channel frames that measured exactly 588 bits.
+struct SourceGrid {
+  std::vector<std::pair<int64_t, Segment>> slots;
+  int64_t first_sync_bit = 0;
+  bool has_sync = false;
+};
+
+// Cut |packed| on its T11+T11 syncs and number the resulting channel frames
+// from the source's own first sync. Slot numbers advance by the rounded
+// number of channel frames between consecutive syncs, so a missed sync
+// consumes the slot it should have occupied instead of shifting every later
+// frame.
+SourceGrid build_grid(const std::vector<uint8_t>& packed) {
+  SourceGrid grid;
+  const size_t count = packed.size();
+
+  std::vector<int64_t> sync_bit;
+  std::vector<size_t> sync_index;
+  int64_t bit = 0;
+  size_t i = 0;
+  while (i + 1 < count) {
+    if (efm_tvalue(packed[i]) == kSyncSymbolT11 &&
+        efm_tvalue(packed[i + 1]) == kSyncSymbolT11) {
+      sync_index.push_back(i);
+      sync_bit.push_back(bit);
+      // The sync pattern is two runs, so it cannot overlap the next one.
+      bit += static_cast<int64_t>(efm_tvalue(packed[i])) +
+             static_cast<int64_t>(efm_tvalue(packed[i + 1]));
+      i += 2;
+    } else {
+      bit += static_cast<int64_t>(efm_tvalue(packed[i]));
+      ++i;
+    }
+  }
+
+  if (sync_index.empty()) {
+    return grid;
+  }
+
+  grid.has_sync = true;
+  grid.first_sync_bit = sync_bit.front();
+
+  int64_t slot = 0;
+  for (size_t j = 0; j + 1 < sync_index.size(); ++j) {
+    const int64_t span = sync_bit[j + 1] - sync_bit[j];
+    if (span == kChannelFrameBits) {
+      grid.slots.push_back(
+          {slot, Segment{sync_index[j], sync_index[j + 1] - sync_index[j]}});
+    }
+    slot += std::max<int64_t>(
+        1, (span + kChannelFrameBits / 2) / kChannelFrameBits);
+  }
+  return grid;
+}
+
+// Locate the channel frame a source holds for |slot|, or nullptr.
+const Segment* find_slot(const SourceGrid& grid, int64_t offset, int64_t slot) {
+  const int64_t local = slot - offset;
+  const auto it =
+      std::lower_bound(grid.slots.begin(), grid.slots.end(), local,
+                       [](const std::pair<int64_t, Segment>& entry,
+                          int64_t value) { return entry.first < value; });
+  if (it == grid.slots.end() || it->first != local) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+// Signature of a channel frame: its first few data runs, one nibble each. Two
+// captures of the same channel frame nearly always agree on these, and with
+// only a few hundred slots in a video frame the collisions that do occur are
+// swamped by the offset histogram below.
+constexpr size_t kSyncRuns = 2;
+constexpr int kSignatureRuns = 6;
+
+// Fewest agreeing slots before a histogram peak is believed rather than the
+// bit-position estimate.
+constexpr size_t kMinAlignmentVotes = 8;
+
+uint32_t slot_signature(const std::vector<uint8_t>& packed,
+                        const Segment& segment) {
+  if (segment.count < kSyncRuns + kSignatureRuns) {
+    return 0;
+  }
+  uint32_t signature = 0;
+  for (size_t k = 0; k < kSignatureRuns; ++k) {
+    signature =
+        (signature << 4) | efm_tvalue(packed[segment.begin + kSyncRuns + k]);
+  }
+  return signature;
+}
+
+// Whole-slot offset that maps a source's slot numbers onto the reference's.
+//
+// Captures of the same disc do not start at the same place on it. Aligning the
+// sources by video frame gets the offset down to a fraction of a frame, but a
+// fraction of a frame is still hundreds of channel frames - two Domesday
+// captures of the same side sit a steady 1.123 frames apart, which is around
+// 36 channel frames even after the whole-frame part is taken out. So the
+// offset is found rather than assumed: every slot the two sides sign
+// identically votes for the offset it implies, and the winning offset is the
+// one the most slots agree on. That is one pass over each source's slots, not
+// a search over candidate offsets.
+int64_t align_to_reference(const std::vector<uint8_t>& source,
+                           const SourceGrid& grid,
+                           const std::vector<uint8_t>& reference,
+                           const SourceGrid& reference_grid,
+                           std::vector<std::pair<uint32_t, int64_t>>& index,
+                           std::vector<int64_t>& votes) {
+  const auto bit_gap =
+      static_cast<double>(grid.first_sync_bit - reference_grid.first_sync_bit);
+  const auto estimate = static_cast<int64_t>(
+      std::llround(bit_gap / static_cast<double>(kChannelFrameBits)));
+
+  index.clear();
+  index.reserve(reference_grid.slots.size());
+  for (const auto& entry : reference_grid.slots) {
+    index.emplace_back(slot_signature(reference, entry.second), entry.first);
+  }
+  std::sort(index.begin(), index.end());
+
+  votes.clear();
+  for (const auto& entry : grid.slots) {
+    const uint32_t signature = slot_signature(source, entry.second);
+    if (signature == 0) {
+      continue;
+    }
+    auto it =
+        std::lower_bound(index.begin(), index.end(), signature,
+                         [](const std::pair<uint32_t, int64_t>& row,
+                            uint32_t value) { return row.first < value; });
+    for (; it != index.end() && it->first == signature; ++it) {
+      votes.push_back(it->second - entry.first);
+    }
+  }
+  if (votes.size() < kMinAlignmentVotes) {
+    return estimate;
+  }
+
+  std::sort(votes.begin(), votes.end());
+  int64_t best = estimate;
+  size_t best_count = 0;
+  size_t run_start = 0;
+  for (size_t i = 1; i <= votes.size(); ++i) {
+    if (i == votes.size() || votes[i] != votes[run_start]) {
+      const size_t count = i - run_start;
+      if (count > best_count) {
+        best_count = count;
+        best = votes[run_start];
+      }
+      run_start = i;
+    }
+  }
+  return best_count >= kMinAlignmentVotes ? best : estimate;
+}
+
+// One source's contribution to a slot.
+struct Contribution {
+  const std::vector<uint8_t>* packed = nullptr;
+  Segment segment;
+  bool is_reference = false;
+};
+
+using BitTally = std::array<int, kChannelFrameBits + 1>;
+
+// Tally the votes for and against a transition at each interior bit offset of
+// a channel frame. A source votes for an offset it has a transition at, with
+// the weight of the weaker of the two runs that meet there, and against an
+// offset that falls strictly inside one of its runs, with that run's weight.
+void tally_votes(const std::vector<Contribution>& contributions, BitTally& yes,
+                 BitTally& no, std::vector<bool>& reference_transition) {
+  yes.fill(0);
+  no.fill(0);
+  reference_transition.assign(kChannelFrameBits + 1, false);
+
+  for (const auto& contribution : contributions) {
+    const std::vector<uint8_t>& packed = *contribution.packed;
+    const Segment& segment = contribution.segment;
+    int bit = 0;
+    for (size_t k = 0; k < segment.count; ++k) {
+      const uint8_t byte = packed[segment.begin + k];
+      const int length = static_cast<int>(efm_tvalue(byte));
+      const int weight = run_weight(byte);
+
+      if (k > 0 && bit > 0 && bit < kChannelFrameBits) {
+        const int previous = run_weight(packed[segment.begin + k - 1]);
+        yes[static_cast<size_t>(bit)] += std::min(previous, weight);
+        if (contribution.is_reference) {
+          reference_transition[static_cast<size_t>(bit)] = true;
+        }
+      }
+      for (int inside = bit + 1; inside < bit + length; ++inside) {
+        if (inside > 0 && inside < kChannelFrameBits) {
+          no[static_cast<size_t>(inside)] += weight;
+        }
+      }
+      bit += length;
+    }
+  }
+}
+
+int vote_margin(const BitTally& yes, const BitTally& no, int bit) {
+  return yes[static_cast<size_t>(bit)] - no[static_cast<size_t>(bit)];
+}
+
+// Doubt implied by how strongly a transition won its vote: none when the
+// sources were unanimous, total when it scraped in on a bare majority or had
+// to be forced in by run-length repair.
+uint8_t agreement_doubt(const BitTally& yes, const BitTally& no, int bit) {
+  const int total =
+      yes[static_cast<size_t>(bit)] + no[static_cast<size_t>(bit)];
+  if (total <= 0) {
+    return kEfmDoubtMax;
+  }
+  const double margin = static_cast<double>(vote_margin(yes, no, bit)) /
+                        static_cast<double>(total);
+  const auto doubt = static_cast<int>(
+      std::lround(static_cast<double>(kEfmDoubtMax) * (1.0 - margin)));
+  return static_cast<uint8_t>(
+      std::clamp(doubt, 0, static_cast<int>(kEfmDoubtMax)));
+}
+
+// Working buffers reused across every channel frame of a video frame. There
+// are around 290 of them per frame and several thousand frames in a decode, so
+// nothing in the per-slot path should be allocating.
+struct VoteScratch {
+  std::vector<bool> accepted = std::vector<bool>(kChannelFrameBits + 1, false);
+  std::vector<int> boundaries;
+  std::vector<bool> reference_transition;
+  std::vector<size_t> cursor;
+  std::vector<int> cursor_bit;
+  std::vector<std::pair<uint32_t, int64_t>> signature_index;
+  std::vector<int64_t> offset_votes;
+};
+
+// Force the accepted transitions into a legal T3..T11 run sequence. A run that
+// came out too short loses its weaker bounding transition; one that came out
+// too long regains the best transition the vote rejected inside it, if there
+// is one that leaves both halves legal.
+void repair_run_lengths(const BitTally& yes, const BitTally& no,
+                        std::vector<bool>& accepted,
+                        std::vector<int>& boundaries) {
+  for (int pass = 0; pass < kMaxRepairPasses; ++pass) {
+    boundaries.clear();
+    boundaries.push_back(0);
+    for (int bit = 1; bit < kChannelFrameBits; ++bit) {
+      if (accepted[static_cast<size_t>(bit)]) {
+        boundaries.push_back(bit);
+      }
+    }
+    boundaries.push_back(kChannelFrameBits);
+
+    bool changed = false;
+    for (size_t r = 0; r + 1 < boundaries.size(); ++r) {
+      const int start = boundaries[r];
+      const int end = boundaries[r + 1];
+      const int length = end - start;
+
+      if (length < kMinRunBits) {
+        // Drop whichever bounding transition the sources believed least. The
+        // channel-frame boundaries are grid anchors and are never dropped.
+        const bool can_drop_start = start > 0;
+        const bool can_drop_end = end < kChannelFrameBits;
+        if (!can_drop_start && !can_drop_end) {
+          continue;
+        }
+        int victim = can_drop_start ? start : end;
+        if (can_drop_start && can_drop_end) {
+          victim = vote_margin(yes, no, start) <= vote_margin(yes, no, end)
+                       ? start
+                       : end;
+        }
+        accepted[static_cast<size_t>(victim)] = false;
+        changed = true;
+        break;
+      }
+
+      if (length > kMaxRunBits) {
+        int best = -1;
+        int best_margin = 0;
+        for (int bit = start + kMinRunBits; bit <= end - kMinRunBits; ++bit) {
+          if (accepted[static_cast<size_t>(bit)]) {
+            continue;
+          }
+          const int margin = vote_margin(yes, no, bit);
+          if (best < 0 || margin > best_margin) {
+            best = bit;
+            best_margin = margin;
+          }
+        }
+        if (best < 0) {
+          continue;
+        }
+        accepted[static_cast<size_t>(best)] = true;
+        changed = true;
+        break;
+      }
+    }
+
+    if (!changed) {
+      return;
+    }
+  }
+}
+
+// Walks each source's runs forward alongside the combined run sequence, so the
+// question "which sources reported exactly this run, and how sure were they?"
+// is answered in one pass over the channel frame rather than a search per run.
+class ReportedDoubt {
+ public:
+  ReportedDoubt(const std::vector<Contribution>& contributions,
+                VoteScratch& scratch)
+      : contributions_(contributions),
+        cursor_(scratch.cursor),
+        cursor_bit_(scratch.cursor_bit) {
+    cursor_.assign(contributions.size(), 0);
+    cursor_bit_.assign(contributions.size(), 0);
+  }
+
+  // Lowest doubt among the sources that reported exactly this run. A run no
+  // source reported - one the vote or the repair pass constructed - is
+  // maximally doubtful, which is the honest answer and the one the CIRC
+  // erasure machinery can act on. |start| must not decrease between calls.
+  uint8_t of(int start, int end) {
+    int lowest = -1;
+    for (size_t c = 0; c < contributions_.size(); ++c) {
+      const std::vector<uint8_t>& packed = *contributions_[c].packed;
+      const Segment& segment = contributions_[c].segment;
+      while (cursor_[c] < segment.count && cursor_bit_[c] < start) {
+        cursor_bit_[c] +=
+            static_cast<int>(efm_tvalue(packed[segment.begin + cursor_[c]]));
+        ++cursor_[c];
+      }
+      if (cursor_[c] >= segment.count || cursor_bit_[c] != start) {
+        continue;
+      }
+      const uint8_t byte = packed[segment.begin + cursor_[c]];
+      if (cursor_bit_[c] + static_cast<int>(efm_tvalue(byte)) != end) {
+        continue;
+      }
+      const int doubt = static_cast<int>(efm_doubt(byte));
+      if (lowest < 0 || doubt < lowest) {
+        lowest = doubt;
+      }
+    }
+    return lowest < 0 ? kEfmDoubtMax : static_cast<uint8_t>(lowest);
+  }
+
+ private:
+  const std::vector<Contribution>& contributions_;
+  std::vector<size_t>& cursor_;
+  std::vector<int>& cursor_bit_;
+};
+
+// Combine the channel frames two or more sources hold for one slot, appending
+// the combined runs to |out|. Returns false, having appended nothing, when the
+// vote could not be repaired into a legal T3..T11 channel frame; the caller
+// then keeps the reference's own frame rather than emitting an illegal one.
+bool vote_slot(const std::vector<Contribution>& contributions,
+               VoteScratch& scratch, std::vector<uint8_t>& out) {
+  BitTally yes;
+  BitTally no;
+  std::vector<bool>& reference_transition = scratch.reference_transition;
+  tally_votes(contributions, yes, no, reference_transition);
+
+  // A tie is no evidence either way, so it is settled the only honest way
+  // available: keep what the source with the fewest dropouts read. Dropping
+  // the transition instead would leave a run neither side reported.
+  std::vector<bool>& accepted = scratch.accepted;
+  accepted.assign(kChannelFrameBits + 1, false);
+  for (int bit = 1; bit < kChannelFrameBits; ++bit) {
+    const int margin = vote_margin(yes, no, bit);
+    accepted[static_cast<size_t>(bit)] =
+        margin > 0 ||
+        (margin == 0 && reference_transition[static_cast<size_t>(bit)]);
+  }
+  repair_run_lengths(yes, no, accepted, scratch.boundaries);
+
+  std::vector<int>& boundaries = scratch.boundaries;
+  boundaries.clear();
+  boundaries.push_back(0);
+  for (int bit = 1; bit < kChannelFrameBits; ++bit) {
+    if (accepted[static_cast<size_t>(bit)]) {
+      boundaries.push_back(bit);
+    }
+  }
+  boundaries.push_back(kChannelFrameBits);
+
+  for (size_t r = 0; r + 1 < boundaries.size(); ++r) {
+    const int length = boundaries[r + 1] - boundaries[r];
+    if (length < kMinRunBits || length > kMaxRunBits) {
+      return false;
+    }
+  }
+
+  ReportedDoubt reported(contributions, scratch);
+  for (size_t r = 0; r + 1 < boundaries.size(); ++r) {
+    const int start = boundaries[r];
+    const int end = boundaries[r + 1];
+
+    // A run is trusted only where the sources agreed on both of its ends and
+    // at least one of them vouched for the run itself.
+    uint8_t doubt = reported.of(start, end);
+    if (start > 0) {
+      doubt = std::max(doubt, agreement_doubt(yes, no, start));
+    }
+    if (end < kChannelFrameBits) {
+      doubt = std::max(doubt, agreement_doubt(yes, no, end));
+    }
+
+    out.push_back(efm_pack(static_cast<uint8_t>(end - start), doubt));
+  }
+  return true;
+}
+
+}  // namespace
+
+std::vector<uint8_t> stack_efm_confidence(
+    const std::vector<std::vector<uint8_t>>& sources, size_t reference) {
+  if (sources.empty()) {
+    return {};
+  }
+  if (reference >= sources.size()) {
+    reference = 0;
+  }
+  // Nothing was stacked, so the source's own doubt still stands.
+  if (sources.size() == 1) {
+    return sources.front();
+  }
+
+  std::vector<SourceGrid> grids;
+  grids.reserve(sources.size());
+  for (const auto& source : sources) {
+    grids.push_back(build_grid(source));
+  }
+
+  const SourceGrid& reference_grid = grids[reference];
+  if (!reference_grid.has_sync || reference_grid.slots.empty()) {
+    // Without a sync grid in the reference there is no axis to combine on.
+    return sources[reference];
+  }
+
+  VoteScratch scratch;
+  std::vector<int64_t> offsets(sources.size(), 0);
+  for (size_t s = 0; s < sources.size(); ++s) {
+    if (s == reference || !grids[s].has_sync) {
+      continue;
+    }
+    offsets[s] = align_to_reference(sources[s], grids[s], sources[reference],
+                                    reference_grid, scratch.signature_index,
+                                    scratch.offset_votes);
+  }
+
+  // The output follows the reference stream run for run, with each of its
+  // complete channel frames replaced by the combined one. Everything the sync
+  // grid does not cover - the partial frames at each end, and any stretch
+  // where the grid broke down - is carried over from the reference unchanged,
+  // so the output is always a continuous stream of the reference's bit length.
+  const std::vector<uint8_t>& base = sources[reference];
+  std::vector<uint8_t> out;
+  out.reserve(base.size());
+
+  std::vector<Contribution> contributions;
+  contributions.reserve(sources.size());
+
+  size_t copied = 0;
+  for (const auto& entry : reference_grid.slots) {
+    const Segment& segment = entry.second;
+    if (segment.begin < copied) {
+      continue;
+    }
+    out.insert(out.end(), base.begin() + static_cast<std::ptrdiff_t>(copied),
+               base.begin() + static_cast<std::ptrdiff_t>(segment.begin));
+
+    contributions.clear();
+    for (size_t s = 0; s < sources.size(); ++s) {
+      if (s == reference) {
+        contributions.push_back({&base, segment, true});
+        continue;
+      }
+      if (!grids[s].has_sync) {
+        continue;
+      }
+      const Segment* candidate = find_slot(grids[s], offsets[s], entry.first);
+      if (candidate != nullptr) {
+        contributions.push_back({&sources[s], *candidate, false});
+      }
+    }
+
+    if (contributions.size() < 2 || !vote_slot(contributions, scratch, out)) {
+      out.insert(
+          out.end(), base.begin() + static_cast<std::ptrdiff_t>(segment.begin),
+          base.begin() +
+              static_cast<std::ptrdiff_t>(segment.begin + segment.count));
+    }
+    copied = segment.begin + segment.count;
+  }
+
+  out.insert(out.end(), base.begin() + static_cast<std::ptrdiff_t>(copied),
+             base.end());
+  return out;
+}
+
+}  // namespace orc

--- a/orc/plugins/stages/stacker/efm_confidence_stack.h
+++ b/orc/plugins/stages/stacker/efm_confidence_stack.h
@@ -1,0 +1,79 @@
+/*
+ * File:        efm_confidence_stack.h
+ * Module:      orc-core
+ * Purpose:     Sync-anchored confidence-weighted combining of EFM t-values
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace orc {
+
+// ============================================================================
+// Sync-anchored confidence stacking of EFM t-value streams
+// ============================================================================
+//
+// EFM t-values are run lengths, not samples on a shared time axis, so two
+// captures of the same disc cannot be combined by sample index: one spurious
+// or missed transition shifts every following index in that capture, after
+// which an index-wise mean or median is averaging unrelated runs. A whole
+// video frame carries around 36,600 t-values, so a single early insertion
+// spoils the rest of the frame.
+//
+// What two captures do share is the channel bit axis. An inserted transition
+// splits one run into two that sum to the same length, and a missed transition
+// merges two runs into one of the same length, so neither moves the bit
+// position of any later transition. Only a genuinely mis-measured run length
+// shifts what follows, and IEC 60908 gives a grid that re-anchors that every
+// 588 bits: the T11+T11 frame sync. Measured over 130,422 sync intervals of a
+// Domesday side, 99.95% are exactly 588 bits and 99.96% an exact multiple.
+//
+// So this combiner works on channel frames, not on the whole stream:
+//
+//   1. Each source's t-values are cut on its own detected T11+T11 syncs into
+//      588-bit channel frames, and each is given a slot number from its bit
+//      distance to that source's first sync. Sources are then aligned to the
+//      reference source by a single whole-slot offset, which absorbs a source
+//      that missed its own first sync.
+//   2. Within a slot, sources vote on where the transitions are. A source
+//      votes for a bit offset it has a transition at, and against an offset
+//      that falls strictly inside one of its runs, each with a weight taken
+//      from the producer's doubt nibble. An offset is accepted when the votes
+//      for it outweigh the votes against.
+//   3. The accepted offsets are repaired to legal T3-T11 run lengths and
+//      emitted as t-values, each carrying a doubt derived from how strongly
+//      its bounding transitions won their votes and from how much the sources
+//      that reported it doubted it.
+//
+// A stacked t-value is therefore always one that some source actually
+// reported, never a synthesised average of two readings that disagree, and it
+// arrives downstream with an honest doubt that the CIRC erasure machinery can
+// use.
+//
+// Regions no slot covers - the partial channel frame before the first sync,
+// the one after the last, and any stretch where the sync grid breaks down -
+// are copied from the reference source unchanged, doubt included.
+
+// Combine the packed EFM bytes of two or more captures of one video frame.
+//
+// |sources| holds one packed byte stream per contributing capture (t-value in
+// the low nibble, producer doubt in the high nibble; see
+// orc/stage/video_frame_representation.h). |reference| indexes the source to
+// fall back on where voting cannot apply; it is clamped into range.
+//
+// Returns the combined packed byte stream. With fewer than two sources the
+// single source is returned unchanged - nothing was stacked, so its doubt
+// still stands.
+//
+// Complexity is O(T * S) in the total t-value count T and source count S.
+// Thread-safe: holds no state.
+std::vector<uint8_t> stack_efm_confidence(
+    const std::vector<std::vector<uint8_t>>& sources, size_t reference);
+
+}  // namespace orc

--- a/orc/plugins/stages/stacker/instructions.md
+++ b/orc/plugins/stages/stacker/instructions.md
@@ -39,7 +39,7 @@ When `true`, pixels that are in dropout across all sources are passed through un
 Method used to combine audio samples from multiple sources. Values: `Disabled`, `Mean`, `Median`. Default: `Mean`. When `Disabled`, audio from the source with the fewest dropouts is used. The method applies per channel pair, to every channel pair present in all inputs; channel pairs not common to all inputs pass through from the source with the fewest dropouts. All pipeline audio is 48 kHz frame-locked 24-bit stereo, so sources are combined sample by sample at the same frame position; combined values saturate at the 24-bit range.
 
 ### efm_stacking (string)
-Method used to combine EFM t-values from multiple sources. Values: `Disabled`, `Confidence`, `Mean`, `Median`. Default: `Confidence`. When `Disabled`, EFM from the source with the fewest dropouts is used, bytes untouched.
+Method used to combine EFM t-values from multiple sources. Values: `Disabled`, `Confidence`, `Mean`, `Median`. Default: `Disabled`, which passes the EFM of the source with the fewest dropouts through untouched. That is the default because no combining mode has yet been shown to beat it — see *Choosing a mode* below.
 
 Each EFM byte on the pipeline packs the t-value into its low nibble and the producing source's doubt about that t-value into the high nibble.
 
@@ -50,7 +50,21 @@ Each EFM byte on the pipeline packs the t-value into its low nibble and the prod
 | `Mean` | Arithmetic mean of the t-values at each sample index, emitted with zero doubt. |
 | `Median` | Median of the t-values at each sample index, emitted with zero doubt. |
 
-`Confidence` is the mode to use. `Mean` and `Median` are kept for comparison with earlier results and have two problems it does not.
+### Choosing a mode
+
+`Disabled` is the default and, on the evidence so far, the mode to use. Measured against six independent captures of the same BBC Domesday side (National A, aligned on the EFM stream, 8,000 frames each), passing the best single source through recovered more sectors than any combining mode:
+
+| mode | good sectors | uncorrectable | C1 uncorrectable | C2 uncorrectable |
+|------|--------------|---------------|------------------|------------------|
+| `Disabled` (best source alone) | 21,695 | 8 | 4,209 | 553 |
+| `Confidence`, three captures | 21,577 | 140 | 929 | 10,800 |
+| `Mean`, six captures | 5 | 10 | 6,826 | 29,932 |
+
+`Mean` is not merely worse, it is destructive: five good sectors out of some 21,700. On a synthetic three-capture ensemble it made the decode fail outright.
+
+`Confidence` behaves far better than that and improves C1 - it more than halved C1 uncorrectable in the run above - but C2 uncorrectable rises sharply at the same time, and the recovered-sector count falls below a single capture. Combining three copies of one capture reproduces that capture exactly, so the fault is in the voting rather than in the surrounding machinery; the working theory is that the whole-slot alignment is occasionally off by one channel frame, which would yield exactly this signature, a clean copy of the wrong frame. Until that is settled, treat `Confidence` as experimental.
+
+`Mean` and `Median` are kept only for reproducing earlier results, and have two problems `Confidence` does not.
 
 The first is that they average. A t-value is a quantised symbol, not a measurement: where one source reads T3 and another T11, their mean of T7 is a reading neither source made and one that is wrong for both, and the demodulator then decodes it with full confidence. `Confidence` only ever emits a t-value some source actually reported.
 

--- a/orc/plugins/stages/stacker/instructions.md
+++ b/orc/plugins/stages/stacker/instructions.md
@@ -39,9 +39,26 @@ When `true`, pixels that are in dropout across all sources are passed through un
 Method used to combine audio samples from multiple sources. Values: `Disabled`, `Mean`, `Median`. Default: `Mean`. When `Disabled`, audio from the source with the fewest dropouts is used. The method applies per channel pair, to every channel pair present in all inputs; channel pairs not common to all inputs pass through from the source with the fewest dropouts. All pipeline audio is 48 kHz frame-locked 24-bit stereo, so sources are combined sample by sample at the same frame position; combined values saturate at the 24-bit range.
 
 ### efm_stacking (string)
-Method used to combine EFM t-values from multiple sources. Values: `Disabled`, `Mean`, `Median`. Default: `Mean`. When `Disabled`, EFM from the source with the fewest dropouts is used.
+Method used to combine EFM t-values from multiple sources. Values: `Disabled`, `Confidence`, `Mean`, `Median`. Default: `Confidence`. When `Disabled`, EFM from the source with the fewest dropouts is used, bytes untouched.
 
-Each EFM byte on the pipeline packs the t-value into its low nibble and the producing source's doubt about that t-value into the high nibble. `Disabled` passes the chosen source's bytes through untouched, doubt included. `Mean` and `Median` combine the t-values alone and emit the combined value with zero doubt: the stacked t-value is a new value that no source vouched for, so the sources' doubt says nothing about it. Combining the whole bytes instead would fold the doubt nibble into the t-value and corrupt it.
+Each EFM byte on the pipeline packs the t-value into its low nibble and the producing source's doubt about that t-value into the high nibble.
+
+| Mode | Behaviour |
+|------|-----------|
+| `Disabled` | The chosen source's bytes pass through untouched, doubt included. |
+| `Confidence` | Sources are aligned on the EFM frame-sync grid and vote on where the transitions are, weighted by their doubt. Emits a doubt of its own. |
+| `Mean` | Arithmetic mean of the t-values at each sample index, emitted with zero doubt. |
+| `Median` | Median of the t-values at each sample index, emitted with zero doubt. |
+
+`Confidence` is the mode to use. `Mean` and `Median` are kept for comparison with earlier results and have two problems it does not.
+
+The first is that they average. A t-value is a quantised symbol, not a measurement: where one source reads T3 and another T11, their mean of T7 is a reading neither source made and one that is wrong for both, and the demodulator then decodes it with full confidence. `Confidence` only ever emits a t-value some source actually reported.
+
+The second, and the more serious, is that they combine by sample index. EFM t-values are run lengths, not samples on a shared time axis, so one spurious or missed transition in a capture shifts every following index in it and the two streams are averaged out of step from there on. A video frame carries around 36,600 t-values, so a single early insertion spoils the rest of the frame. `Confidence` combines on the channel bit axis instead, cut into channel frames on each source's own T11+T11 frame sync (IEC 60908 §20.2, 588 bits). An inserted transition splits a run into two that sum to the same length and a missed one merges two runs into one of the same length, so on that axis neither moves anything after it, and the sync grid re-anchors the alignment every 588 bits regardless.
+
+Within a channel frame each source votes on the bit offsets its transitions sit at, with a weight taken from its doubt, and against offsets falling inside its runs. Offsets that win are kept, the result is repaired to legal T3–T11 run lengths, and each output run carries a doubt derived from how strongly its bounding transitions won and from how much the sources that reported it doubted it. Where only one source covers a channel frame, or the vote cannot be repaired into a legal frame, the frame from the source with the fewest dropouts is used unchanged; so are the partial channel frames at each end of a video frame's t-values.
+
+The doubt this mode emits is worth more than the doubt on its inputs, because it is evidence of a different kind: a producer's doubt is one capture's opinion of its own reading, while a disagreement between independent captures is an observation. Both `efm_sink` and `efm_audio_decode` can act on it through their `doubt_erasure_threshold` parameter, which turns doubted t-values into C1/C2 erasure hints.
 
 ## Tools
 

--- a/orc/plugins/stages/stacker/stacker_stage.cpp
+++ b/orc/plugins/stages/stacker/stacker_stage.cpp
@@ -18,6 +18,8 @@
 #include <cstddef>
 #include <stdexcept>
 
+#include "efm_confidence_stack.h"
+
 namespace orc {
 
 // ============================================================================
@@ -475,6 +477,13 @@ bool StackedVideoFrameRepresentation::has_efm() const {
   return false;
 }
 
+// An estimate, not a promise. Stacking preserves the combined stream's length
+// in channel bits, not its t-value count: a transition the sources disagree
+// about is one t-value in the capture that saw it and none in the capture that
+// did not. Consumers that need the exact count must read the samples. This is
+// used only to size progress reporting, so the first contributing source's
+// count is close enough - and unlike asking which source is best, it costs
+// nothing per frame.
 uint32_t StackedVideoFrameRepresentation::get_efm_sample_count(
     FrameID id) const {
   for (const auto& src : sources_) {
@@ -1173,6 +1182,7 @@ std::vector<uint8_t> StackerStage::stack_efm(
   }
 
   std::vector<std::vector<uint8_t>> all_efm;
+  size_t reference = 0;
   for (size_t i = 0; i < sources.size(); ++i) {
     if (source_ids[i] == UINT64_MAX || !sources[i]) {
       continue;
@@ -1182,15 +1192,8 @@ std::vector<uint8_t> StackerStage::stack_efm(
     }
     auto s = sources[i]->get_efm_samples(source_ids[i]);
     if (!s.empty()) {
-      // Combining is defined on t-values, not on the packed byte: taking the
-      // mean or median of whole bytes would fold each producer's doubt nibble
-      // into the t-value field and corrupt it. Strip the doubt as the samples
-      // are collected, so a stacked t-value comes out with zero doubt - which
-      // packs to the bare t-value. That is honest: the stacked value is a new
-      // one that no producer vouched for, and the doubt of the inputs says
-      // nothing about it.
-      for (auto& value : s) {
-        value = efm_tvalue(value);
+      if (i == best_src) {
+        reference = all_efm.size();
       }
       all_efm.push_back(std::move(s));
     }
@@ -1199,6 +1202,26 @@ std::vector<uint8_t> StackerStage::stack_efm(
   if (all_efm.empty()) {
     return {};
   }
+
+  // Confidence stacking works on the packed bytes: the doubt nibble is what it
+  // weighs the sources by, and it emits a doubt of its own derived from how
+  // far the sources agreed. See efm_confidence_stack.h.
+  if (m_efm_stacking_mode == EFMStackingMode::CONFIDENCE) {
+    return stack_efm_confidence(all_efm, reference);
+  }
+
+  // Mean and median are defined on t-values, not on the packed byte: taking
+  // the mean or median of whole bytes would fold each producer's doubt nibble
+  // into the t-value field and corrupt it. Strip the doubt first, so a stacked
+  // t-value comes out with zero doubt - which packs to the bare t-value. That
+  // is honest for these two modes: the stacked value is an average that no
+  // producer vouched for, and the doubt of the inputs says nothing about it.
+  for (auto& stream : all_efm) {
+    for (auto& value : stream) {
+      value = efm_tvalue(value);
+    }
+  }
+
   if (all_efm.size() == 1) {
     return all_efm[0];
   }
@@ -1343,15 +1366,16 @@ std::vector<ParameterDescriptor> StackerStage::get_parameter_descriptors(
                                     {"Disabled", "Mean", "Median"},
                                     false,
                                     std::nullopt}});
-  d.push_back({"efm_stacking", "EFM Stacking Mode",
-               "How to combine EFM t-values: Disabled | Mean | Median",
-               ParameterType::STRING,
-               ParameterConstraints{std::nullopt,
-                                    std::nullopt,
-                                    ParameterValue{std::string("Mean")},
-                                    {"Disabled", "Mean", "Median"},
-                                    false,
-                                    std::nullopt}});
+  d.push_back(
+      {"efm_stacking", "EFM Stacking Mode",
+       "How to combine EFM t-values: Disabled | Confidence | Mean | Median",
+       ParameterType::STRING,
+       ParameterConstraints{std::nullopt,
+                            std::nullopt,
+                            ParameterValue{std::string("Confidence")},
+                            {"Disabled", "Confidence", "Mean", "Median"},
+                            false,
+                            std::nullopt}});
   return d;
 }
 
@@ -1364,7 +1388,7 @@ std::map<std::string, ParameterValue> StackerStage::get_parameters() const {
   }
 
   const char* audio_names[] = {"Disabled", "Mean", "Median"};
-  const char* efm_names[] = {"Disabled", "Mean", "Median"};
+  const char* efm_names[] = {"Disabled", "Mean", "Median", "Confidence"};
 
   return {
       {"mode", ParameterValue{std::string(mode_names[mi])}},
@@ -1453,6 +1477,8 @@ bool StackerStage::set_parameters(
           m_efm_stacking_mode = EFMStackingMode::MEAN;
         } else if (*v == "Median") {
           m_efm_stacking_mode = EFMStackingMode::MEDIAN;
+        } else if (*v == "Confidence") {
+          m_efm_stacking_mode = EFMStackingMode::CONFIDENCE;
         } else {
           ORC_LOG_WARN("StackerStage: unknown efm_stacking '{}'", *v);
           return false;

--- a/orc/plugins/stages/stacker/stacker_stage.cpp
+++ b/orc/plugins/stages/stacker/stacker_stage.cpp
@@ -1372,7 +1372,7 @@ std::vector<ParameterDescriptor> StackerStage::get_parameter_descriptors(
        ParameterType::STRING,
        ParameterConstraints{std::nullopt,
                             std::nullopt,
-                            ParameterValue{std::string("Confidence")},
+                            ParameterValue{std::string("Disabled")},
                             {"Disabled", "Confidence", "Mean", "Median"},
                             false,
                             std::nullopt}});

--- a/orc/plugins/stages/stacker/stacker_stage.h
+++ b/orc/plugins/stages/stacker/stacker_stage.h
@@ -197,7 +197,7 @@ class StackerStage : public DAGStage,
       const std::map<std::string, ParameterValue>& params) override;
 
   enum class AudioStackingMode { DISABLED, MEAN, MEDIAN };
-  enum class EFMStackingMode { DISABLED, MEAN, MEDIAN };
+  enum class EFMStackingMode { DISABLED, MEAN, MEDIAN, CONFIDENCE };
 
   using sample_type = VideoFrameRepresentation::sample_type;
 
@@ -210,7 +210,7 @@ class StackerStage : public DAGStage,
   bool m_passthrough = false;
   int32_t m_thread_count = 0;
   AudioStackingMode m_audio_stacking_mode = AudioStackingMode::MEAN;
-  EFMStackingMode m_efm_stacking_mode = EFMStackingMode::MEAN;
+  EFMStackingMode m_efm_stacking_mode = EFMStackingMode::CONFIDENCE;
 
   std::map<std::string, ParameterValue> parameters_;
 

--- a/orc/plugins/stages/stacker/stacker_stage.h
+++ b/orc/plugins/stages/stacker/stacker_stage.h
@@ -210,7 +210,7 @@ class StackerStage : public DAGStage,
   bool m_passthrough = false;
   int32_t m_thread_count = 0;
   AudioStackingMode m_audio_stacking_mode = AudioStackingMode::MEAN;
-  EFMStackingMode m_efm_stacking_mode = EFMStackingMode::CONFIDENCE;
+  EFMStackingMode m_efm_stacking_mode = EFMStackingMode::DISABLED;
 
   std::map<std::string, ParameterValue> parameters_;
 


### PR DESCRIPTION
## Summary

Implements issue #307: the ld-decode doubt nibble is now available as a C1/C2
Reed-Solomon erasure hint via a new `doubt_erasure_threshold` parameter on
`efm_sink` and `efm_audio_decode`. It defaults to `0` (off), and the measurements
below say it should stay off — on a data disc the hint is neutral, and on an audio
disc it silently miscorrects. The default keeps the decode byte-identical to
before, so the value here is the documented evidence rather than a behaviour change.

Also adds a `Confidence` EFM stacking mode to `stacker`, which aligns sources on
the EFM frame-sync grid and lets them vote on each transition weighted by doubt,
instead of averaging by sample index. It is **not** the default and is documented
as experimental: it improves C1 but loses sectors overall, and the cause is not yet
settled.

Separately, this changes the `efm_stacking` default from `Mean` to `Disabled`.
`Mean` combines run-length streams by sample index, which desynchronises after a
single spurious transition; on six real captures it recovered 5 good sectors out of
~21,700, and on a synthetic ensemble it failed the decode outright. `Disabled`
passes the best source's EFM through untouched and beat every combining mode tested.

## Type of change

- [x] Bug fix (the `Mean` EFM stacking default)
- [x] New feature (`doubt_erasure_threshold`, `Confidence` stacking mode)
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Validation

**Bit-exactness.** With `doubt_erasure_threshold=0` the decoded output is
byte-identical to the pre-change decoder across a full Domesday side (`cmp` over
250 MB, run twice). Wall-clock at the default is at parity; the opt-in path costs
~23%.

**Data disc** (Domesday DS2 National A, 120,219 sections): thresholds 13–15 improve
C1 (4,047 → 3,963 uncorrectable) but never change the recovered-sector count; below
13 sectors are lost as spurious erasures eat C2's capacity.

**Audio disc** (Grosse Pointe Blank, PAL CLV side 2, 2.94 M sections): thresholds
≥11 leave the WAV byte-identical — C1 uncorrectable falls 247 → 225 at threshold 11,
but C2 was already correcting those codewords. Below 9 the audio changes and the
changes are impulses, not repairs: at threshold 1 the 8,841 altered samples have a
median second difference of 11,844 against 78 for the same positions at baseline
(80 file-wide), 7,928 of them come out rougher, and the largest single change is
35,114. The decode report does not reveal this — C2, concealed and muted all sit
exactly at their baseline values — so both stage docs now say to compare decoded
output rather than statistics.

**EFM stacking** (six independent captures of one Domesday side, aligned on the EFM
stream, 8,000 frames each):

| mode | good sectors | uncorrectable | C1 unc. | C2 unc. |
|------|--------------|---------------|---------|---------|
| `Disabled` (best source alone) | 21,695 | 8 | 4,209 | 553 |
| `Confidence`, three captures | 21,577 | 140 | 929 | 10,800 |
| `Mean`, six captures | 5 | 10 | 6,826 | 29,932 |

Stacking three copies of one capture reproduces it exactly, so the `Confidence`
shortfall is in the voting rather than the surrounding machinery.

**Tests.** 3,377 unit tests plus the `sdk` and `mvp` gates pass. 15 new tests cover
the confidence combiner and 12 the erasure seeding; both sets were mutation-checked
— removing the confidence weighting, the whole-slot realignment, the against-votes,
the tie rule or the emitted doubt each fails a distinct test.

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [x] Related docs were updated if needed
- [x] Linked issue (if applicable)

## Related issue

Closes #307
