### PR TITLE
Fix decoded-chroma scaling in the preview, raw export and vectorscope

### DIFF
--- a/orc-tests/core/unit/preview_types/preview_carrier_conversion_test.cpp
+++ b/orc-tests/core/unit/preview_types/preview_carrier_conversion_test.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <string>
 #include <vector>
 
 namespace orc_unit_test {
@@ -99,6 +100,161 @@ TEST(ColourCarrierConversionTest, MatrixSelection_AffectsRgbResult) {
                        ntsc_image.rgb_data[2] != fcc_image.rgb_data[2];
 
   EXPECT_TRUE(differs);
+}
+
+// =============================================================================
+// Chroma matrix — the carrier's U/V are composite-modulated
+// =============================================================================
+
+namespace {
+
+// The composite modulation factors the decoders apply to the colour-difference
+// signals, and which the conversion must remove.
+constexpr double kCompositeU = 0.49211104112248356308804691718185;
+constexpr double kCompositeV = 0.87728321993817866838972487283129;
+
+// CVBS_U10_4FSC levels for the systems under test.  PAL has no setup
+// pedestal; standard NTSC and PAL-M put picture black 7.5 IRE above blanking;
+// NTSC-J is NTSC without the pedestal, which tbc_source reports by setting
+// black to the blanking level.
+struct SystemLevels {
+  double blanking;
+  double black;
+  double white;
+};
+constexpr SystemLevels kPalLevels{256.0, 256.0, 844.0};
+constexpr SystemLevels kNtscLevels{240.0, 282.0, 800.0};
+constexpr SystemLevels kNtscJLevels{240.0, 240.0, 800.0};
+
+// Builds a single-pixel carrier holding the given non-linear R'G'B'
+// (components in [0, 1]) encoded the way the decoders deliver it: Y' offset by
+// picture black, and U/V as kU (B'-Y') and kV (R'-Y').  All three ride the
+// black-to-white picture excursion, which the setup pedestal shortens — a
+// 7.5 IRE setup leaves 92.5 IRE for one unit of Y'/U/V, not 100.
+orc::ColourFrameCarrier makePixel(double r, double g, double b,
+                                  const SystemLevels& levels,
+                                  const orc::ColorimetricMetadata& metadata) {
+  const double y = (0.299 * r) + (0.587 * g) + (0.114 * b);
+  const double excursion = levels.white - levels.black;
+
+  orc::ColourFrameCarrier carrier{};
+  carrier.width = 1;
+  carrier.height = 1;
+  carrier.cvbs_blanking = levels.blanking;
+  carrier.cvbs_black = levels.black;
+  carrier.cvbs_white = levels.white;
+  carrier.colorimetry = metadata;
+  carrier.y_plane = {levels.black + (y * excursion)};
+  carrier.u_plane = {kCompositeU * (b - y) * excursion};
+  carrier.v_plane = {kCompositeV * (r - y) * excursion};
+  return carrier;
+}
+
+orc::ColourFrameCarrier makePalPixel(double r, double g, double b) {
+  return makePixel(r, g, b, kPalLevels,
+                   orc::ColorimetricMetadata::default_pal());
+}
+
+// The rendered byte for one non-linear component: the source transfer decoded
+// to linear, then sRGB encoded, as render_preview_from_colour_carrier does.
+int expectedByte(double non_linear, double gamma) {
+  const double linear = std::pow(std::clamp(non_linear, 0.0, 1.0), gamma);
+  const double srgb = linear <= 0.0031308
+                          ? 12.92 * linear
+                          : (1.055 * std::pow(linear, 1.0 / 2.4)) - 0.055;
+  return static_cast<int>((srgb * 255.0) + 0.5);
+}
+
+// The 75% colour bars, plus a mid grey.
+constexpr double kBars[][3] = {
+    {0.75, 0.75, 0.75}, {0.75, 0.75, 0.00}, {0.00, 0.75, 0.75},
+    {0.00, 0.75, 0.00}, {0.75, 0.00, 0.75}, {0.75, 0.00, 0.00},
+    {0.00, 0.00, 0.75}, {0.50, 0.50, 0.50},
+};
+
+// Renders every bar on the given system and checks each channel comes back as
+// the R'G'B' that went in.  One code of slack for the transfer table's
+// interpolation.
+void expectBarsRoundTrip(const SystemLevels& levels,
+                         const orc::ColorimetricMetadata& metadata,
+                         double gamma, const char* system_name) {
+  for (const auto& bar : kBars) {
+    const auto image = orc::render_preview_from_colour_carrier(
+        makePixel(bar[0], bar[1], bar[2], levels, metadata));
+    ASSERT_TRUE(image.is_valid());
+
+    const std::string where =
+        std::string(system_name) + " bar " + std::to_string(bar[0]) + "," +
+        std::to_string(bar[1]) + "," + std::to_string(bar[2]);
+    EXPECT_NEAR(image.rgb_data[0], expectedByte(bar[0], gamma), 1)
+        << "red for " << where;
+    EXPECT_NEAR(image.rgb_data[1], expectedByte(bar[1], gamma), 1)
+        << "green for " << where;
+    EXPECT_NEAR(image.rgb_data[2], expectedByte(bar[2], gamma), 1)
+        << "blue for " << where;
+  }
+}
+
+}  // namespace
+
+TEST(ColourCarrierConversionTest, ModulatedUv_RoundTripsToTheSourceRgb) {
+  // If the modulation weights were not divided out, R' would come back ~23%
+  // high and B' ~13% low, which is what made the preview look more saturated
+  // than the export.
+  expectBarsRoundTrip(kPalLevels, orc::ColorimetricMetadata::default_pal(), 2.8,
+                      "PAL");
+}
+
+TEST(ColourCarrierConversionTest, SetupPedestal_DoesNotCostSaturation) {
+  // Standard NTSC and PAL-M carry a 7.5 IRE setup pedestal, so one unit of
+  // chroma spans 92.5 IRE.  Normalising U/V over blanking-to-white instead of
+  // black-to-white under-recovers it by that 7.5%.
+  expectBarsRoundTrip(kNtscLevels, orc::ColorimetricMetadata::default_ntsc(),
+                      2.2, "NTSC");
+  expectBarsRoundTrip(kNtscLevels, orc::ColorimetricMetadata::default_pal_m(),
+                      2.2, "PAL-M");
+}
+
+TEST(ColourCarrierConversionTest, NtscJ_WithoutSetup_RoundTripsToo) {
+  // NTSC-J has no pedestal: tbc_source reports picture black at the blanking
+  // level, so the excursion is the full 100 IRE.  Deriving the chroma scale
+  // from black rather than assuming a pedestal is what makes both conventions
+  // come out right.
+  expectBarsRoundTrip(kNtscJLevels, orc::ColorimetricMetadata::default_ntsc(),
+                      2.2, "NTSC-J");
+}
+
+TEST(ColourCarrierConversionTest, SetupAndNtscJ_RenderTheSameColour) {
+  // The same source colour, carried once with a pedestal and once without,
+  // must render identically — the pedestal is a level offset, not a colour
+  // change.
+  for (const auto& bar : kBars) {
+    const auto ntsc = orc::render_preview_from_colour_carrier(
+        makePixel(bar[0], bar[1], bar[2], kNtscLevels,
+                  orc::ColorimetricMetadata::default_ntsc()));
+    const auto ntsc_j = orc::render_preview_from_colour_carrier(
+        makePixel(bar[0], bar[1], bar[2], kNtscJLevels,
+                  orc::ColorimetricMetadata::default_ntsc()));
+    ASSERT_TRUE(ntsc.is_valid());
+    ASSERT_TRUE(ntsc_j.is_valid());
+
+    for (size_t channel = 0; channel < 3; ++channel) {
+      EXPECT_NEAR(ntsc.rgb_data[channel], ntsc_j.rgb_data[channel], 1)
+          << "channel " << channel << " for bar " << bar[0] << "," << bar[1]
+          << "," << bar[2];
+    }
+  }
+}
+
+TEST(ColourCarrierConversionTest, SaturatedRed_DoesNotOverdriveTheRedChannel) {
+  // 75% red renders below full scale; the un-weighted matrix clipped it.
+  const auto image =
+      orc::render_preview_from_colour_carrier(makePalPixel(0.75, 0.0, 0.0));
+  ASSERT_TRUE(image.is_valid());
+
+  EXPECT_LT(image.rgb_data[0], 255);
+  EXPECT_EQ(image.rgb_data[1], 0);
+  EXPECT_EQ(image.rgb_data[2], 0);
 }
 
 // =============================================================================

--- a/orc-tests/core/unit/preview_types/preview_types_test.cpp
+++ b/orc-tests/core/unit/preview_types/preview_types_test.cpp
@@ -168,6 +168,23 @@ TEST(ColorimetricMetadataTest, DefaultPal_HasExpectedTransferCharacteristics) {
             orc::ColorimetricTransferCharacteristics::Gamma28);
 }
 
+TEST(ColorimetricMetadataTest, DefaultPalM_UsesSystemMColorimetry) {
+  // PAL-M is PAL chroma encoding on the 525-line System M raster, and BT.470
+  // assigns colorimetry by system: System M's 2.2 gamma and SMPTE C primaries,
+  // not the 2.8 gamma of the 625-line PAL systems.
+  auto meta = orc::ColorimetricMetadata::default_pal_m();
+  EXPECT_EQ(meta.matrix_coefficients,
+            orc::ColorimetricMatrixCoefficients::BT601_525);
+  EXPECT_EQ(meta.primaries, orc::ColorimetricPrimaries::SMPTE_C);
+  EXPECT_EQ(meta.transfer_characteristics,
+            orc::ColorimetricTransferCharacteristics::Gamma22);
+}
+
+TEST(ColorimetricMetadataTest, DefaultPalM_IsNotTheDefaultPalColorimetry) {
+  EXPECT_NE(orc::ColorimetricMetadata::default_pal_m(),
+            orc::ColorimetricMetadata::default_pal());
+}
+
 // =============================================================================
 // ColorimetricMetadata — equality and round-trip
 // =============================================================================

--- a/orc-tests/core/unit/stages/video_sink/vectorscope_analysis_test.cpp
+++ b/orc-tests/core/unit/stages/video_sink/vectorscope_analysis_test.cpp
@@ -26,10 +26,12 @@ TEST(VectorscopeAnalysisTest,
   source_parameters.first_active_frame_line = 1;
   source_parameters.last_active_frame_line = 6;
   source_parameters.active_area_cropping_applied = false;  // absolute indexing
-  // Set CVBS levels so normalization works correctly.  Active-area test values
+  // Set CVBS levels so normalization works correctly.  U/V are normalised over
+  // the picture excursion black→white, here 600.  Active-area test values
   // (y*100+x ≈ 102-505) stay well below the clamp threshold; the outside-area
-  // sentinel (10000) saturates to ±32767 after division by level_range (600).
+  // sentinel (10000) saturates to ±32767 after that division.
   source_parameters.blanking_level = 200;
+  source_parameters.black_level = 200;
   source_parameters.white_level = 800;
 
   ComponentFrame frame;
@@ -102,7 +104,8 @@ TEST(VectorscopeAnalysisTest,
   sp.last_active_frame_line = 5;           // active height = 3
   sp.active_area_cropping_applied = true;  // relative (0-based) indexing
   sp.blanking_level = 200;
-  sp.white_level = 800;  // level_range = 600
+  sp.black_level = 200;
+  sp.white_level = 800;  // level_range (black→white) = 600
 
   ComponentFrame frame;
   frame.init(sp, false);
@@ -148,6 +151,80 @@ TEST(VectorscopeAnalysisTest,
     EXPECT_LT(std::abs(sample.v), 32767.0)
         << "sentinel value found — reader used wrong (absolute) coordinates";
   }
+}
+
+namespace {
+
+// A 1x2-active-pixel NTSC frame carrying one U/V value, at the given levels.
+orc::SourceParameters ntscLevels(int32_t blanking, int32_t black,
+                                 int32_t white) {
+  orc::SourceParameters sp;
+  sp.system = orc::VideoSystem::NTSC;
+  sp.frame_width_nominal = 4;
+  sp.active_video_start = 1;
+  sp.active_video_end = 3;
+  sp.first_active_frame_line = 1;
+  sp.last_active_frame_line = 3;
+  sp.active_area_cropping_applied = false;
+  sp.blanking_level = blanking;
+  sp.black_level = black;
+  sp.white_level = white;
+  return sp;
+}
+
+}  // namespace
+
+TEST(VectorscopeAnalysisTest,
+     ExtractFromComponentFrame_NormalisesOverThePictureExcursion) {
+  // Standard NTSC: picture black sits 7.5 IRE above blanking, so one unit of
+  // chroma spans white - black = 518, not white - blanking = 560.  Normalising
+  // over the longer range would report the sample 7.5% short.
+  const orc::SourceParameters sp = ntscLevels(240, 282, 800);
+
+  ComponentFrame frame;
+  frame.init(sp, false);
+  for (int32_t y = 0; y < frame.getHeight(); ++y) {
+    double* u_line = frame.u(y);
+    double* v_line = frame.v(y);
+    for (int32_t x = 0; x < frame.getWidth(); ++x) {
+      u_line[x] = 100.0;
+      v_line[x] = -50.0;
+    }
+  }
+
+  const auto data =
+      orc::extract_vectorscope_from_component_frame(frame, sp, 0, 1);
+  ASSERT_FALSE(data.samples.empty());
+
+  const double excursion = 800.0 - 282.0;
+  EXPECT_NEAR(data.samples[0].u, (100.0 / excursion) * 32767.0, 1.0);
+  EXPECT_NEAR(data.samples[0].v, (-50.0 / excursion) * 32767.0, 1.0);
+}
+
+TEST(VectorscopeAnalysisTest,
+     ExtractFromComponentFrame_NtscJHasNoPedestalToRemove) {
+  // NTSC-J stores picture black at the blanking level, so its excursion is the
+  // full 560 and the same expression covers it without a special case.
+  const orc::SourceParameters sp = ntscLevels(240, 240, 800);
+
+  ComponentFrame frame;
+  frame.init(sp, false);
+  for (int32_t y = 0; y < frame.getHeight(); ++y) {
+    double* u_line = frame.u(y);
+    double* v_line = frame.v(y);
+    for (int32_t x = 0; x < frame.getWidth(); ++x) {
+      u_line[x] = 100.0;
+      v_line[x] = -50.0;
+    }
+  }
+
+  const auto data =
+      orc::extract_vectorscope_from_component_frame(frame, sp, 0, 1);
+  ASSERT_FALSE(data.samples.empty());
+
+  const double excursion = 800.0 - 240.0;
+  EXPECT_NEAR(data.samples[0].u, (100.0 / excursion) * 32767.0, 1.0);
+  EXPECT_NEAR(data.samples[0].v, (-50.0 / excursion) * 32767.0, 1.0);
 }
 
 TEST(VectorscopeAnalysisTest, ExtractFromColourFrameCarrier_CanUseFullFrame) {

--- a/orc-tests/gui/unit/vectorscope_geometry_test.cpp
+++ b/orc-tests/gui/unit/vectorscope_geometry_test.cpp
@@ -44,21 +44,44 @@ TEST(VectorscopeGeometryTest, PlotGeometry_MatchesVectorscopeRasterMapping) {
   EXPECT_DOUBLE_EQ(bottom_right.y(), 1008.0);
 }
 
-TEST(VectorscopeGeometryTest, Ntsc_TargetsMagnitudeIs_925_Of_Pal) {
-  // SMPTE 170M-2004 §10 / Annex A.2: the NTSC encoding equation applies 0.925
-  // to all chroma: N = 0.925Y + 7.5 + 0.925(Q)sin(…) + 0.925(I)cos(…).
-  // A comb decoder that does not compensate this factor outputs chroma at
-  // 0.925× the GBR-input amplitude, so NTSC targets must lie at 0.925× the
-  // PAL (no-scale) positions for every colour bar.
+TEST(VectorscopeGeometryTest, DecodedTargets_AreTheSameForEverySystem) {
+  // A decoded-component acquisition normalises U/V over the picture excursion
+  // (black → white), which the setup pedestal shortens, so the 0.925 of the
+  // SMPTE 170M-2004 §10 encoding equation is already divided out of the
+  // samples.  One set of targets therefore serves every system — including
+  // NTSC-J, which has no pedestal and so no 0.925 to account for.
   constexpr double kIreRange = 50000.0;
-  constexpr double kSetupFraction = 42.0 / 560.0;  // = 1 − 0.925
 
   for (int rgb = 1; rgb <= 6;
        ++rgb) {  // all six standard primaries/secondaries
-    const orc::UVSample pal = orc::gui::vectorscopeTargetUv(
-        rgb, 0.75, kIreRange, orc::VideoSystem::PAL);
-    const orc::UVSample ntsc = orc::gui::vectorscopeTargetUv(
-        rgb, 0.75, kIreRange, orc::VideoSystem::NTSC);
+    const orc::UVSample target =
+        orc::gui::vectorscopeTargetUv(rgb, 0.75, kIreRange);
+
+    for (const orc::VideoSystem system :
+         {orc::VideoSystem::PAL, orc::VideoSystem::PAL_M,
+          orc::VideoSystem::NTSC}) {
+      const orc::UVSample display =
+          orc::gui::vectorscopeDisplayTargetUv(rgb, 0.75, kIreRange, system);
+      EXPECT_NEAR(display.u, target.u, 1e-9) << "rgb=" << rgb;
+      EXPECT_NEAR(display.v, target.v, 1e-9) << "rgb=" << rgb;
+    }
+  }
+}
+
+TEST(VectorscopeGeometryTest, MeasurementTargets_CarryTheSmpteChromaScale) {
+  // A composite acquisition measures the signal against blanking, so there the
+  // encoding equation's 0.925 is visible and the NTSC / PAL-M targets must sit
+  // 0.925× inside the PAL ones.
+  constexpr double kIreRange = 50000.0;
+  constexpr double kSetupFraction = 42.0 / 560.0;  // = 1 − 0.925
+
+  for (int rgb = 1; rgb <= 6; ++rgb) {
+    const orc::UVSample pal = orc::gui::measurementTargetUv(
+        rgb, 0.75, kIreRange, orc::VideoSystem::PAL,
+        orc::VectorscopeLinePhase::VPositive);
+    const orc::UVSample ntsc = orc::gui::measurementTargetUv(
+        rgb, 0.75, kIreRange, orc::VideoSystem::NTSC,
+        orc::VectorscopeLinePhase::VPositive);
 
     EXPECT_NEAR(ntsc.u, pal.u * (1.0 - kSetupFraction), 1e-9) << "rgb=" << rgb;
     EXPECT_NEAR(ntsc.v, pal.v * (1.0 - kSetupFraction), 1e-9) << "rgb=" << rgb;
@@ -73,7 +96,7 @@ TEST(VectorscopeGeometryTest, Ntsc_DisplayTargetsEqualRawTargets) {
   constexpr double kIreRange = 50000.0;
 
   const orc::UVSample raw_target =
-      orc::gui::vectorscopeTargetUv(4, 0.75, kIreRange, orc::VideoSystem::NTSC);
+      orc::gui::vectorscopeTargetUv(4, 0.75, kIreRange);
   const orc::UVSample display_target = orc::gui::vectorscopeDisplayTargetUv(
       4, 0.75, kIreRange, orc::VideoSystem::NTSC);
 
@@ -85,7 +108,7 @@ TEST(VectorscopeGeometryTest, Pal_DisplayTargetsRemainUnchanged) {
   constexpr double kIreRange = 50000.0;
 
   const orc::UVSample raw_target =
-      orc::gui::vectorscopeTargetUv(4, 0.75, kIreRange, orc::VideoSystem::PAL);
+      orc::gui::vectorscopeTargetUv(4, 0.75, kIreRange);
   const orc::UVSample display_target = orc::gui::vectorscopeDisplayTargetUv(
       4, 0.75, kIreRange, orc::VideoSystem::PAL);
 
@@ -98,9 +121,9 @@ TEST(VectorscopeGeometryTest,
   constexpr double kIreRange = 65535.0;
 
   const orc::UVSample full_target =
-      orc::gui::vectorscopeTargetUv(6, 1.0, kIreRange, orc::VideoSystem::PAL);
+      orc::gui::vectorscopeTargetUv(6, 1.0, kIreRange);
   const orc::UVSample partial_target =
-      orc::gui::vectorscopeTargetUv(6, 0.75, kIreRange, orc::VideoSystem::PAL);
+      orc::gui::vectorscopeTargetUv(6, 0.75, kIreRange);
 
   const double full_magnitude = std::hypot(full_target.u, full_target.v);
   const double partial_magnitude =
@@ -201,17 +224,10 @@ TEST(VectorscopeGeometryTest, MeasurementTargets_MirrorAboutTheUAxis) {
           rgb, 0.75, kIreRange, system, orc::VectorscopeLinePhase::VPositive);
       const orc::UVSample negative = orc::gui::measurementTargetUv(
           rgb, 0.75, kIreRange, system, orc::VectorscopeLinePhase::VNegative);
-      const orc::UVSample reference =
-          orc::gui::vectorscopeTargetUv(rgb, 0.75, kIreRange, system);
-
-      // The +V phase is the ordinary target set.
-      EXPECT_DOUBLE_EQ(positive.u, reference.u);
-      EXPECT_DOUBLE_EQ(positive.v, reference.v);
-
       // A −V line inverts V only, which is exactly what an undelayed composite
       // display shows.
-      EXPECT_DOUBLE_EQ(negative.u, reference.u);
-      EXPECT_DOUBLE_EQ(negative.v, -reference.v);
+      EXPECT_DOUBLE_EQ(negative.u, positive.u);
+      EXPECT_DOUBLE_EQ(negative.v, -positive.v);
     }
   }
 }

--- a/orc/gui/preview/vectorscope_geometry.h
+++ b/orc/gui/preview/vectorscope_geometry.h
@@ -129,36 +129,27 @@ inline orc::UVSample calibrateVectorscopeDisplayUv(
 // GBR encoder inputs have no setup (SMPTE 170M-2004 §4.3 / ITU-R BT.470-6):
 // "off" components are at 0 (blanking) and "on" components are at `percent`.
 //
-// NTSC / PAL_M encoding (SMPTE 170M-2004 §10 / Annex A.2):
-//   N = 0.925(Y) + 7.5 + 0.925(Q)sin(…+33°) + 0.925(I)cos(…+33°)
-//   The 0.925 factor is applied to all chroma in the encoding equation.
-//   A comb decoder that does not compensate this factor outputs chroma at
-//   0.925× the GBR-input amplitude.  Targets must therefore sit at 0.925×
-//   the PAL (no-scale) positions so that a correctly decoded NTSC signal
-//   lands on the crosshairs.
+// These are the targets for a decoded-component acquisition, whose samples
+// extract_vectorscope_from_component_frame() normalises over the picture
+// excursion (black → white).  That is the excursion the encoding equation
+// scales chroma by, so a correctly decoded bar lands here whatever the system
+// and whatever its setup: the 0.925 of SMPTE 170M-2004 §10 is 92.5/100 IRE,
+// already accounted for by dividing decoded chroma by a 92.5 IRE excursion
+// rather than a 100 IRE one.  It is a composite acquisition, measured against
+// blanking, that still needs the factor applied — see measurementTargetUv().
 inline orc::UVSample vectorscopeTargetUv(int rgb, double percent,
-                                         double ire_range,
-                                         orc::VideoSystem system) {
+                                         double ire_range) {
   const double red = ((rgb >> 2) & 1) ? percent : 0.0;
   const double green = ((rgb >> 1) & 1) ? percent : 0.0;
   const double blue = (rgb & 1) ? percent : 0.0;
-  const orc::UVSample uv = normalizedRgbToUv(red, green, blue, ire_range);
-
-  // SMPTE 170M-2004 §10 / Annex A.2: NTSC and PAL_M apply 0.925 to chroma.
-  const bool has_smpte_chroma_scale =
-      (system == orc::VideoSystem::NTSC || system == orc::VideoSystem::PAL_M);
-  constexpr double kSmpteChromaScale = 0.925;
-  if (has_smpte_chroma_scale) {
-    return {uv.u * kSmpteChromaScale, uv.v * kSmpteChromaScale};
-  }
-  return uv;
+  return normalizedRgbToUv(red, green, blue, ire_range);
 }
 
 inline orc::UVSample vectorscopeDisplayTargetUv(int rgb, double percent,
                                                 double ire_range,
                                                 orc::VideoSystem system) {
   return calibrateVectorscopeDisplayUv(
-      vectorscopeTargetUv(rgb, percent, ire_range, system), system);
+      vectorscopeTargetUv(rgb, percent, ire_range), system);
 }
 
 // ============================================================================
@@ -208,12 +199,28 @@ inline bool hasSwitchedVAxis(orc::VideoSystem system) {
 // Colour-bar target for one V-switch line phase.  A −V line inverts the V
 // component only, so its targets are the +V targets mirrored about the U axis
 // — which is exactly what an undelayed composite display shows.
+//
+// A composite acquisition plots the signal itself, normalised over the active
+// video range (blanking → white) so that burst reads in IRE, so here the
+// encoding equation's chroma scale is visible and the targets carry it.
+// SMPTE 170M-2004 §10 / Annex A.2:
+//   N = 0.925(Y) + 7.5 + 0.925(Q)sin(…+33°) + 0.925(I)cos(…+33°)
+// The factor is the ratio of the 92.5 IRE picture excursion to the 100 IRE
+// range the samples are measured against.  It is taken from the system rather
+// than from the signal's own levels because VectorscopeData carries no
+// picture-black anchor, so an NTSC-J acquisition — which has no pedestal and
+// therefore no 0.925 — still lands 8% inside these targets.
 inline orc::UVSample measurementTargetUv(int rgb, double percent,
                                          double ire_range,
                                          orc::VideoSystem system,
                                          orc::VectorscopeLinePhase phase) {
-  const orc::UVSample target =
-      vectorscopeTargetUv(rgb, percent, ire_range, system);
+  orc::UVSample target = vectorscopeTargetUv(rgb, percent, ire_range);
+
+  constexpr double kSmpteChromaScale = 0.925;
+  if (system == orc::VideoSystem::NTSC || system == orc::VideoSystem::PAL_M) {
+    target = {target.u * kSmpteChromaScale, target.v * kSmpteChromaScale};
+  }
+
   if (phase == orc::VectorscopeLinePhase::VNegative) {
     return {target.u, -target.v};
   }

--- a/orc/plugins/stages/sinks/common/decoders/outputwriter.cpp
+++ b/orc/plugins/stages/sinks/common/decoders/outputwriter.cpp
@@ -296,8 +296,18 @@ void OutputWriter::convertLine(int32_t lineNumber,
   const double yOffset = static_cast<double>(videoParameters.black_level);
   const double yRange = static_cast<double>(videoParameters.white_level -
                                             videoParameters.black_level);
-  const double uvRange = static_cast<double>(videoParameters.white_level -
-                                             videoParameters.blanking_level);
+  // U/V share the luma excursion.  The setup pedestal does not offset chroma,
+  // but it does shorten the picture excursion that defines the volts per unit
+  // of colour difference, so the subcarrier amplitude shrinks with it: on a
+  // 7.5 IRE setup system one unit of Y'/U/V spans 92.5 IRE, not 100.  Measured
+  // against the EIA-189-A 75% bars, whose chroma peak-to-peak amplitudes
+  // (62 / 88 / 82 IRE for yellow / cyan / green) only come out right on the
+  // black-to-white excursion.  Deriving the range from black rather than
+  // blanking also covers the systems without a pedestal — PAL, and NTSC-J,
+  // whose picture black tbc_source reports at the blanking level — where the
+  // two ranges coincide.  FFmpegOutputBackend::convertAndEncode() scales
+  // chroma the same way, so the two export paths agree.
+  const double uvRange = yRange;
 
   switch (config.pixelFormat) {
     case RGB48: {

--- a/orc/plugins/stages/sinks/common/decoders/vectorscope_extract.cpp
+++ b/orc/plugins/stages/sinks/common/decoders/vectorscope_extract.cpp
@@ -95,11 +95,21 @@ VectorscopeData extract_vectorscope_from_component_frame(
 
   // Normalise CVBS-domain U/V to the ±32767 scale expected by UVSample.
   // ComponentFrame U/V planes carry values in the CVBS decoder domain;
-  // dividing by the active-video voltage range (blanking→white) maps them
-  // to approximately ±1, consistent with render_preview_from_colour_carrier.
+  // dividing by the picture excursion (black→white) maps them to
+  // approximately ±1, consistent with render_preview_from_colour_carrier.
+  //
+  // Black, not blanking: the setup pedestal shortens the excursion that the
+  // encoding equation scales chroma by, so a 7.5 IRE setup system carries one
+  // unit of U/V in 92.5 IRE.  Dividing by that recovers the same normalised
+  // colour difference from every system — the 0.925 of SMPTE 170M-2004 §10
+  // included, and correctly absent on the systems without a pedestal (PAL,
+  // and NTSC-J, whose picture black tbc_source reports at blanking).  The
+  // decoded-component graticule targets assume this normalisation; a
+  // composite acquisition measures against blanking instead and carries the
+  // factor in its targets (see measurementTargetUv()).
   const double level_range =
       std::max(1.0, static_cast<double>(video_parameters.white_level -
-                                        video_parameters.blanking_level));
+                                        video_parameters.black_level));
 
   // Row 0 of a cropped frame is first_active_frame_line of the uncropped one.
   // UVSample::line_number is an interlaced frame-line index whichever way the

--- a/orc/plugins/stages/sinks/common/video_sink_stage.cpp
+++ b/orc/plugins/stages/sinks/common/video_sink_stage.cpp
@@ -2599,9 +2599,21 @@ std::optional<ColourFrameCarrier> VideoSinkStage::get_colour_preview_carrier(
                        videoParams.system == VideoSystem::PAL_M)
                           ? VideoDataType::ColourPAL
                           : VideoDataType::ColourNTSC;
-  carrier.colorimetry = (carrier.data_type == VideoDataType::ColourPAL)
-                            ? ColorimetricMetadata::default_pal()
-                            : ColorimetricMetadata::default_ntsc();
+  // Colorimetry follows the line standard, not the chroma encoding: PAL-M is
+  // a 525-line System M signal, so it takes System M's 2.2 gamma and SMPTE C
+  // primaries rather than the 625-line PAL defaults it would inherit from
+  // data_type.  This matches how the export path tags PAL-M (SMPTE 170M).
+  switch (videoParams.system) {
+    case VideoSystem::PAL:
+      carrier.colorimetry = ColorimetricMetadata::default_pal();
+      break;
+    case VideoSystem::PAL_M:
+      carrier.colorimetry = ColorimetricMetadata::default_pal_m();
+      break;
+    default:
+      carrier.colorimetry = ColorimetricMetadata::default_ntsc();
+      break;
+  }
   carrier.system = videoParams.system;
   carrier.frame_index = index;
   carrier.width = static_cast<uint32_t>(width);

--- a/orc/sdk/abi_history.yaml
+++ b/orc/sdk/abi_history.yaml
@@ -398,6 +398,19 @@ history:
       already expects, and existing captures read back unchanged. Consumers
       must extract the t-value with `efm_tvalue()` rather than range-checking
       the raw byte.
+
+
+      Also ABI-neutral while abi 16 is current:
+      `orc/stage/preview/orc_preview_types.h` gained the
+      `ColorimetricMetadata::default_pal_m()` factory, and the comment on
+      `orc/stage/preview/orc_preview_carriers.h`'s `cvbs_blanking`/`cvbs_black`/
+      `cvbs_white` was corrected. PAL-M is PAL chroma encoding on the 525-line
+      System M raster and BT.470 assigns colorimetry by system, so it takes
+      System M's 2.2 gamma and SMPTE C primaries rather than the 625-line PAL
+      defaults it was inheriting; the carrier comment still described U/V as
+      normalised over blanking-to-white, which the setup pedestal makes wrong
+      for NTSC and PAL-M. A static member function and comments only — no
+      member changes type, size or position, and there is no vtable to move.
     summary: >-
       The vectorscope contract grows a second acquisition mode. `UVSample`
       carried a field index and nothing else, which is all a grading scope

--- a/orc/sdk/include/orc/stage/preview/orc_preview_carriers.h
+++ b/orc/sdk/include/orc/stage/preview/orc_preview_carriers.h
@@ -52,9 +52,10 @@ struct ColourFrameCarrier {
   // CVBS_U10_4FSC anchor points used to normalize Y/U/V before matrix
   // conversion. Set by chroma_sink from SourceParameters. Values are in the
   // 10-bit CVBS domain (e.g. PAL: 256/256/844, NTSC: 240/282/800).
-  // cvbs_black is the picture-black floor (= blanking for PAL, +7.5 IRE for
-  // NTSC/PAL_M). Y is normalized relative to cvbs_black; U/V use the full
-  // active range (cvbs_white - cvbs_blanking) so chroma scale is unaffected.
+  // cvbs_black is the picture-black floor: blanking for PAL and for NTSC-J,
+  // +7.5 IRE for standard NTSC/PAL_M. Y and U/V are both normalized over the
+  // picture excursion cvbs_white - cvbs_black, which the setup pedestal
+  // shortens; cvbs_blanking anchors instrument readouts, not the matrix.
   double cvbs_blanking{0.0};
   double cvbs_black{0.0};
   double cvbs_white{1023.0};

--- a/orc/sdk/include/orc/stage/preview/orc_preview_types.h
+++ b/orc/sdk/include/orc/stage/preview/orc_preview_types.h
@@ -144,10 +144,29 @@ struct ColorimetricMetadata {
   }
 
   /**
+   * @brief Historically-correct default colorimetry for analog PAL-M
+   *        recordings.
+   *
+   * PAL-M carries PAL chroma encoding on the 525-line System M raster, and
+   * BT.470 assigns colorimetry by system rather than by colour encoding: it is
+   * System M throughout, so the 2.2 gamma transfer and SMPTE C primaries
+   * apply, not the 2.8 gamma of the 625-line systems.  The matrix is the same
+   * BT.601 one either way.
+   */
+  static ColorimetricMetadata default_pal_m() {
+    return {
+        ColorimetricMatrixCoefficients::BT601_525,
+        ColorimetricPrimaries::SMPTE_C,
+        ColorimetricTransferCharacteristics::Gamma22,
+    };
+  }
+
+  /**
    * @brief Historically-correct default colorimetry for analog PAL recordings.
    *
    * Based on EBU/BT.470 PAL primaries, BT.601-625 matrix, and 2.8 gamma
-   * transfer as specified in BT.470 for 625-line systems.
+   * transfer as specified in BT.470 for 625-line systems.  PAL-M is a System M
+   * signal despite its PAL chroma encoding — use default_pal_m() for it.
    */
   static ColorimetricMetadata default_pal() {
     return {

--- a/orc/sdk/include/orc/support/colour_preview_conversion.h
+++ b/orc/sdk/include/orc/support/colour_preview_conversion.h
@@ -20,8 +20,13 @@ namespace orc {
 /**
  * @brief Convert a colour-domain carrier to display-target RGB888 preview.
  *
- * Conversion target is BT.709 primaries with sRGB transfer characteristics.
- * The source colorimetry is taken from carrier.colorimetry.
+ * The carrier's U/V are the composite-modulated colour-difference signals, so
+ * the modulation weights are removed before the matrix given by
+ * carrier.colorimetry is applied.  The result is then linearised through the
+ * carrier's transfer characteristic and re-encoded to sRGB.  No gamut mapping
+ * is performed: the source primaries (BT.470 System B/G or SMPTE 170M) are
+ * taken as-is, which for SD primaries is a small error next to the transfer
+ * difference.
  */
 PreviewImage render_preview_from_colour_carrier(
     const ColourFrameCarrier& carrier);

--- a/orc/sdk/src/colour_preview_conversion.cpp
+++ b/orc/sdk/src/colour_preview_conversion.cpp
@@ -23,6 +23,20 @@ struct MatrixCoefficients {
   double kb;
 };
 
+// Composite modulation factors: the decoders hand this conversion the U/V
+// that ride on the subcarrier, which are the colour-difference signals scaled
+// down so the composite signal stays within its excursion limits
+//
+//   U = kU (B' - Y')    kU = sqrt(209556997 / 96146491) / 3
+//   V = kV (R' - Y')    kV = sqrt(221990474 / 288439473)
+//
+// [ITU-R BT.470-6 s1.1.2 / EBU Tech. 3280-E s2.1, Poynton eq 28.1 p336].
+// They must be divided out before the Y'CbCr matrix is applied, exactly as
+// OutputWriter does on the export path; applying the matrix to the weighted
+// signals over-drives R' by 1/(kV (2 - 2 kr)) ~ 23% and under-drives B'.
+inline constexpr double kCompositeU = 0.49211104112248356308804691718185;
+inline constexpr double kCompositeV = 0.87728321993817866838972487283129;
+
 MatrixCoefficients coefficients_for(ColorimetricMatrixCoefficients matrix) {
   switch (matrix) {
     case ColorimetricMatrixCoefficients::BT601_625:
@@ -182,10 +196,20 @@ PreviewImage render_preview_from_colour_carrier(
   // CVBS_U10_4FSC normative levels from carrier (set by chroma_sink).
   // Y is normalized from picture-black (not blanking) so that sub-black content
   // (below the setup pedestal on NTSC/PAL_M) clamps to zero rather than
-  // rendering as a dark visible level. U/V use the full active-video range
-  // (blanking→white) so chroma amplitude is unaffected by the pedestal.
+  // rendering as a dark visible level.
+  //
+  // U/V are normalized over the same black-to-white excursion, not over
+  // blanking-to-white.  The setup pedestal does not offset chroma, but it does
+  // shorten the picture excursion that defines the volts per unit of
+  // colour difference, so the subcarrier amplitude shrinks with it: on a
+  // 7.5 IRE setup system one unit of Y'/U/V spans 92.5 IRE, not 100.  Dividing
+  // by blanking-to-white under-recovers NTSC and PAL-M chroma by 7.5%.
+  // Cross-checked against the EIA-189-A 75% bars, whose chroma peak-to-peak
+  // amplitudes (62 / 88 / 82 IRE for yellow / cyan / green) only come out
+  // right on the black-to-white excursion.  PAL has no pedestal, so the two
+  // ranges coincide there.  This matches the FFmpeg export path.
   const double y_range = carrier.cvbs_white - carrier.cvbs_black;
-  const double uv_range = carrier.cvbs_white - carrier.cvbs_blanking;
+  const double uv_range = y_range;
 
   // Transfer decode and sRGB encode are resolved once per frame into a single
   // interpolated table; the pixel loop then costs no transcendentals at all.
@@ -196,13 +220,18 @@ PreviewImage render_preview_from_colour_carrier(
       static_cast<size_t>(carrier.width) * static_cast<size_t>(carrier.height);
   for (size_t i = 0; i < samples; ++i) {
     double y = (carrier.y_plane[i] - carrier.cvbs_black) / y_range;
-    double u = carrier.u_plane[i] / uv_range;
-    double v = carrier.v_plane[i] / uv_range;
 
-    double r_nl = y + (2.0 - 2.0 * matrix.kr) * v;
-    double b_nl = y + (2.0 - 2.0 * matrix.kb) * u;
-    double g_nl = y - ((2.0 * matrix.kb * (1.0 - matrix.kb)) / kg) * u -
-                  ((2.0 * matrix.kr * (1.0 - matrix.kr)) / kg) * v;
+    // Un-weight the modulated U/V back into colour-difference signals, then
+    // reconstruct R'G'B' from Y' and the two differences:
+    //   R' = Y' + (R' - Y')
+    //   B' = Y' + (B' - Y')
+    //   G' = Y' - (kb (B' - Y') + kr (R' - Y')) / kg   [from the Y' equation]
+    const double b_minus_y = (carrier.u_plane[i] / uv_range) / kCompositeU;
+    const double r_minus_y = (carrier.v_plane[i] / uv_range) / kCompositeV;
+
+    double r_nl = y + r_minus_y;
+    double b_nl = y + b_minus_y;
+    double g_nl = y - ((matrix.kb * b_minus_y) + (matrix.kr * r_minus_y)) / kg;
 
     r_nl = std::clamp(r_nl, 0.0, 1.0);
     g_nl = std::clamp(g_nl, 0.0, 1.0);


### PR DESCRIPTION
## How this surfaced

A PAL Test Card F clip exported through Video Sink with the **FFV1 for VP415e** preset looked noticeably less saturated in VLC than the same frame in the Field/Frame Preview. The MKV turned out to be correct — correctly matrixed, and correctly tagged BT.470BG / gamma28 / limited range. The preview was the one that was wrong, and chasing it down turned up four related defects in how decoded chroma is scaled and tagged.

None of these are in the export path used by Video Sink's FFmpeg backend, which was right all along and is what the other three paths have now been brought into line with.

## Issue 1 — the preview applied the Y'CbCr matrix to composite-weighted U/V

The chroma decoders write the *modulated* colour-difference signals into `ComponentFrame`:

```
U = kU (B' - Y')    kU = 0.492111
V = kV (R' - Y')    kV = 0.877283
```

(PAL demodulates straight to U/V; the NTSC comb decoder rotates I/Q into the same space in `Comb::FrameBuffer::transformIQ`.)

`render_preview_from_colour_carrier()` applied the digital Y'CbCr inverse matrix — 1.402 / 1.772 — to those weighted values without dividing the modulation factors out first. `OutputWriter` and `FFmpegOutputBackend` both divide them out; the preview did not.

Net effect: **red over-driven by 1.402 / 1.139883 = +23 %**, **blue under-driven by 1.772 / 2.032062 = −13 %**, and hue error on every mixed patch. Saturated reds clipped.

75 % colour bars, before and after (PAL, ignoring the transfer difference):

| patch | preview before | preview after | correct |
|---|---|---|---|
| red | 215, 0, 0 | 178, 0, 0 | ✓ |
| blue | 0, 0, 153 | 0, 0, 178 | ✓ |
| magenta | 209, 0, 162 | 178, 0, 178 | ✓ |
| yellow | 184, 170, 3 | 178, 178, 0 | ✓ |

## Issue 2 — chroma normalised over the wrong excursion (NTSC and PAL-M)

Three places divided U/V by `white - blanking` (100 IRE) rather than `white - black` (92.5 IRE on a setup system):

- `render_preview_from_colour_carrier()`
- `OutputWriter::convertLine()` — the raw RGB48 and YUV444P16 export formats
- `extract_vectorscope_from_component_frame()`

The reasoning recorded in the code was that the setup pedestal shouldn't affect chroma. The pedestal does not *offset* chroma, but it does shorten the picture excursion that defines the volts per unit of colour difference, so the subcarrier amplitude shrinks with it. One unit of Y'/U/V spans 92.5 IRE on a 7.5 IRE setup system, not 100.

Checked against the EIA-189-A 75 % bars — chroma peak-to-peak in IRE:

| bar | ÷ 92.5 (white−black) | ÷ 100 (as written) | published |
|---|---|---|---|
| yellow | 62.1 | 67.1 | 62 |
| cyan | 87.7 | 94.8 | 88 |
| green / magenta | 81.9 | 88.6 | 82 |
| red | 87.7 | 94.8 | 88 |

So NTSC and PAL-M were **7.5 % under-saturated** in the preview, in raw exports, and on the vectorscope. PAL was unaffected (`kPalBlack == kPalBlanking`), which is why it went unnoticed.

Deriving the divisor from `black` rather than assuming a pedestal also handles **NTSC-J** for free: `derive_tbc_domain_levels()` reports NTSC-J picture black *at* the blanking level, so the same expression yields the full 100 IRE excursion there, with no system branch.

`FFmpegOutputBackend::convertAndEncode()` already used `white - black`, so raw and FFmpeg exports of the same NTSC source previously disagreed with each other by 7.5 %. They now agree.

## Issue 3 — PAL-M carried 625-line PAL colorimetry

`get_colour_preview_carrier()` chose colorimetry from `data_type`, which folds PAL-M in with PAL, so PAL-M frames were rendered through `default_pal()`: EBU primaries and **gamma 2.8**.

PAL-M is PAL chroma encoding on the 525-line System M raster, and BT.470 assigns colorimetry by system, not by colour encoding — System M is gamma 2.2 with SMPTE C primaries. The FFmpeg export already tagged PAL-M as SMPTE 170M, so the preview and the file disagreed.

PAL-M previews were therefore too dark and too contrasty: 75 % white rendered 178 instead of 193, mid grey 106 instead of 128.

## Issue 4 — vectorscope: the SMPTE 0.925 was keyed off the system enum

The vectorscope had a self-consistent convention of its own: samples normalised over blanking→white, and NTSC / PAL-M colour-bar targets pulled in by 0.925 to compensate, per the SMPTE 170M-2004 §10 encoding equation.

Two problems with that:

1. It was applied for `VideoSystem::NTSC` unconditionally, but **NTSC-J has no pedestal and therefore no 0.925** — an NTSC-J source's bars landed 8 % inside the targets.
2. It meant `UVSample` units meant something different from the same U/V everywhere else in the codebase.

The two acquisition modes turn out to have genuinely different natural references, and they were sharing one target function:

- **Decoded component** plots decoded U/V, and belongs on the picture excursion like the render and export paths.
- **Composite carrier** plots the signal itself and must stay referenced to blanking — its burst constants (PAL 150/700, NTSC 20 IRE / 100 IRE) and its IRE readouts are all defined against that range, and there the encoding equation's 0.925 is genuinely visible.

## What changed

**`orc/sdk/src/colour_preview_conversion.cpp`**
- Divide out `kU` / `kV` to recover `(B'-Y')` / `(R'-Y')` before reconstructing R'G'B' (issue 1).
- Normalise U/V over `cvbs_white - cvbs_black` (issue 2).
- Green is now derived directly from the two colour differences, which is the same result with one fewer coefficient to keep in step.

**`orc/sdk/include/orc/stage/preview/orc_preview_types.h`**
- New `ColorimetricMetadata::default_pal_m()`: BT.601-525 matrix, SMPTE C primaries, gamma 2.2 (issue 3).

**`orc/plugins/stages/sinks/common/video_sink_stage.cpp`**
- Carrier colorimetry now keys off `videoParams.system`, giving PAL-M its own case (issue 3).

**`orc/plugins/stages/sinks/common/decoders/outputwriter.cpp`**
- `uvRange` is now `yRange`, so raw RGB48 / YUV444P16 exports match the FFmpeg backend (issue 2). PAL and NTSC-J output is bit-identical to before; standard-NTSC raw exports gain the 8.1 % of chroma they were losing.

**`orc/plugins/stages/sinks/common/decoders/vectorscope_extract.cpp`**
- Normalise over `white_level - black_level` (issues 2 and 4).

**`orc/gui/preview/vectorscope_geometry.h`**
- `vectorscopeTargetUv()` drops the 0.925 and its now-unused `system` parameter — one decoded-component target set serves every system, NTSC-J included.
- The 0.925 moves into `measurementTargetUv()`, where the composite acquisition's blanking reference makes it real. Composite graticule behaviour is unchanged.

**`orc/sdk/include/orc/support/colour_preview_conversion.h`, `orc_preview_carriers.h`**
- Doc comments corrected. The header claimed a BT.709 primaries conversion the code has never performed (only the transfer is converted), and the carrier's level comment still described the old U/V normalisation.

No ABI bump: no struct layout changes, and the only new symbol is a static factory on an existing type.

## What deliberately did not change

- **The preview's gamma-to-sRGB re-encode.** `render_preview_from_colour_carrier()` decodes the source transfer to linear and re-encodes to sRGB; players such as VLC pass the non-linear values straight to the display. That accounts for a flat ~7 % brightness difference between the preview and any player (178 vs 191 at 75 % white on PAL). It is a deliberate design choice, not a bug, so it is left alone — the preview and the file now agree on hue and saturation but not on tone curve.
- **The composite vectorscope's blanking reference.** Rebasing it would mean rescaling every burst constant and IRE readout for no display benefit.
- **NTSC-J composite graticules** still take their 0.925 from the system enum, so they keep the 8 % error described in issue 4. Fixing that needs a picture-black anchor in `VectorscopeData`, which crosses the plugin boundary inside `ColourFrameCarrier` — i.e. an ABI version bump. The limitation is documented in `measurementTargetUv()`.

## Testing

New coverage:

- 75 % bar round-trips through the preview conversion for PAL, NTSC (with setup), NTSC-J and PAL-M, asserting each channel returns the R'G'B' that went in.
- The same colour carried with and without a pedestal renders identically.
- 75 % red no longer clips the red channel.
- `default_pal_m()` returns System M colorimetry and differs from `default_pal()`.
- Vectorscope extraction normalises over the picture excursion, pinned separately for standard NTSC and NTSC-J.
- Decoded-component targets are identical across systems; composite targets still carry the 0.925.

Reworked: the geometry test that pinned NTSC decoded targets at 0.925 of PAL now asserts the opposite invariant for the decoded path and keeps the old assertion for the composite path.

Full suite green — 3752/3752, clang-format check included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
